### PR TITLE
fix日志表字段缺失

### DIFF
--- a/src-tauri/migrations/001_init.sql
+++ b/src-tauri/migrations/001_init.sql
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS api_keys (
 -- 请求日志表
 CREATE TABLE IF NOT EXISTS request_logs (
     id                TEXT PRIMARY KEY,
+    seq               INTEGER NOT NULL DEFAULT 0,   
     api_key_id        TEXT,
     api_key_name      TEXT,
     channel_id        TEXT,


### PR DESCRIPTION
初始化sql脚本的日志表缺少`seq`字段,增加该字段已确保日志模块功能正常