### PR TITLE
fix: 完善 Claude Code Anthropic Messages 协议兼容

### DIFF
--- a/src-tauri/src/protocol/anthropic.rs
+++ b/src-tauri/src/protocol/anthropic.rs
@@ -1,322 +1,331 @@
-use serde_json::Value;
-use std::collections::HashMap;
+//! OpenAI Chat Completions SSE -> Anthropic Messages SSE codec.
+//!
+//! This module never handles native Anthropic streams. They are byte-for-byte
+//! proxied by the handler, because parsing and re-emitting them loses forward
+//! compatibility with Claude Code.
 
-/// Convert an OpenAI SSE chunk (Chat Completions stream) to Anthropic Messages SSE events.
-///
-/// Anthropic stream events for text:
-/// - event: message_start
-/// - event: content_block_start (index=0, type="text")
-/// - event: content_block_delta (index=0, type="text_delta")
-/// - event: content_block_stop (index=0)
-///
-/// Anthropic stream events for tool_use:
-/// - event: content_block_start (index=N, type="tool_use", id, name)
-/// - event: content_block_delta (index=N, type="input_json_delta", partial_json)
-/// - event: content_block_stop (index=N)
-///
-/// Final events:
-/// - event: message_delta (stop_reason, usage)
-/// - event: message_stop
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+#[derive(Default)]
+pub struct AnthropicStreamState {
+    pending: Vec<u8>,
+    started: bool,
+    ended: bool,
+    finish_reason: Option<String>,
+    input_tokens: u64,
+    output_tokens: u64,
+    next_content_index: usize,
+    open_text: Option<usize>,
+    tools: BTreeMap<usize, ToolState>,
+}
+
+#[derive(Default)]
+struct ToolState {
+    content_index: Option<usize>,
+    id: String,
+    name: String,
+    arguments: String,
+    stopped: bool,
+}
+
+fn event(name: &str, value: Value) -> String {
+    format!("event: {name}\ndata: {value}\n\n")
+}
+
+impl AnthropicStreamState {
+    pub fn usage(&self) -> (i64, i64) { (self.input_tokens as i64, self.output_tokens as i64) }
+    /// Feed arbitrary network bytes.  A TCP chunk may split a UTF-8 codepoint,
+    /// an SSE field, or the CRLF event delimiter, so bytes are retained until a
+    /// complete event is available.
+    pub fn feed(
+        &mut self,
+        bytes: &[u8],
+        model: &str,
+        message_id: &str,
+    ) -> Result<Vec<String>, String> {
+        self.pending.extend_from_slice(bytes);
+        let mut events = Vec::new();
+        while let Some(end) = sse_record_end(&self.pending) {
+            let record: Vec<u8> = self.pending.drain(..end).collect();
+            let payload = parse_sse_data(&record)?;
+            if payload.is_empty() || payload == "[DONE]" {
+                continue;
+            }
+            let json: Value = serde_json::from_str(&payload)
+                .map_err(|error| format!("OpenAI upstream emitted invalid SSE JSON: {error}"))?;
+            self.consume_json(json, model, message_id, &mut events)?;
+        }
+        Ok(events)
+    }
+
+    /// Flush an EOF-terminated event and emit the exactly-once final sequence.
+    pub fn finish(&mut self, model: &str, message_id: &str) -> Result<Vec<String>, String> {
+        let mut events = Vec::new();
+        if !self.pending.is_empty() {
+            let record = std::mem::take(&mut self.pending);
+            let payload = parse_sse_data(&record)?;
+            if !payload.is_empty() && payload != "[DONE]" {
+                let json: Value = serde_json::from_str(&payload).map_err(|error| {
+                    format!("OpenAI upstream emitted invalid SSE JSON: {error}")
+                })?;
+                self.consume_json(json, model, message_id, &mut events)?;
+            }
+        }
+        self.emit_final(&mut events)?;
+        Ok(events)
+    }
+
+    fn consume_json(
+        &mut self,
+        json: Value,
+        model: &str,
+        message_id: &str,
+        events: &mut Vec<String>,
+    ) -> Result<(), String> {
+        self.update_usage(&json);
+        if !self.started {
+            self.started = true;
+            events.push(event("message_start", serde_json::json!({
+                "type": "message_start",
+                "message": {"id": message_id, "type": "message", "role": "assistant", "model": model, "content": [], "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": self.input_tokens, "output_tokens": 0}}
+            })));
+        }
+        for choice in json
+            .get("choices")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let delta = choice.get("delta").unwrap_or(&Value::Null);
+            if delta
+                .get("reasoning_content")
+                .and_then(Value::as_str)
+                .filter(|text| !text.is_empty())
+                .is_some()
+                || delta.get("thinking").is_some()
+            {
+                return Err("OpenAI upstream returned thinking content, which cannot be converted to Anthropic Messages safely".to_string());
+            }
+            if let Some(text) = delta
+                .get("content")
+                .and_then(Value::as_str)
+                .filter(|text| !text.is_empty())
+            {
+                let index = self.ensure_text(events);
+                events.push(event("content_block_delta", serde_json::json!({"type":"content_block_delta", "index":index, "delta":{"type":"text_delta", "text":text}})));
+            }
+            if let Some(calls) = delta.get("tool_calls").and_then(Value::as_array) {
+                for call in calls { self.consume_tool_call(call)?; }
+            }
+            if let Some(reason) = choice
+                .get("finish_reason")
+                .and_then(Value::as_str)
+                .filter(|reason| !reason.is_empty() && *reason != "null")
+            {
+                self.finish_reason = Some(reason.to_string());
+            }
+            if delta.get("refusal").and_then(Value::as_str).is_some() {
+                self.finish_reason = Some("content_filter".to_string());
+            }
+        }
+        Ok(())
+    }
+
+    fn update_usage(&mut self, json: &Value) {
+        if let Some(usage) = json.get("usage") {
+            self.input_tokens = usage
+                .get("prompt_tokens")
+                .and_then(Value::as_u64)
+                .unwrap_or(self.input_tokens);
+            self.output_tokens = usage
+                .get("completion_tokens")
+                .and_then(Value::as_u64)
+                .unwrap_or(self.output_tokens);
+        }
+    }
+
+    fn ensure_text(&mut self, events: &mut Vec<String>) -> usize {
+        if let Some(index) = self.open_text {
+            return index;
+        }
+        let index = self.next_content_index;
+        self.next_content_index += 1;
+        self.open_text = Some(index);
+        events.push(event("content_block_start", serde_json::json!({"type":"content_block_start", "index":index, "content_block":{"type":"text", "text":""}})));
+        index
+    }
+
+    fn consume_tool_call(&mut self, call: &Value) -> Result<(), String> {
+        let source_index = call.get("index").and_then(Value::as_u64).unwrap_or(0) as usize;
+        let id = call.get("id").and_then(Value::as_str);
+        let name = call
+            .get("function")
+            .and_then(|f| f.get("name"))
+            .and_then(Value::as_str);
+        let arguments = call
+            .get("function")
+            .and_then(|f| f.get("arguments"))
+            .and_then(Value::as_str);
+        let tool = self.tools.entry(source_index).or_default();
+        if let Some(id) = id { tool.id = id.to_string(); }
+        if let Some(name) = name { tool.name = name.to_string(); }
+        if let Some(arguments) = arguments { tool.arguments.push_str(arguments); }
+        Ok(())
+    }
+
+    fn emit_final(&mut self, events: &mut Vec<String>) -> Result<(), String> {
+        if self.ended || !self.started {
+            return Ok(());
+        }
+        if let Some(index) = self.open_text.take() {
+            events.push(event(
+                "content_block_stop",
+                serde_json::json!({"type":"content_block_stop", "index":index}),
+            ));
+        }
+        // OpenAI deltas for parallel calls may interleave. Anthropic content
+        // blocks may not: serialize each complete tool block only after every
+        // text block has stopped.
+        for tool in self.tools.values_mut() {
+            if tool.id.is_empty() || tool.name.is_empty() { return Err("OpenAI stream ended with an incomplete tool call".to_string()); }
+            let input: Value = serde_json::from_str(&tool.arguments).map_err(|error| format!("OpenAI stream ended with invalid tool arguments: {error}"))?;
+            if !input.is_object() { return Err("OpenAI stream tool arguments must decode to a JSON object".to_string()); }
+            let index = self.next_content_index;
+            self.next_content_index += 1;
+            tool.content_index = Some(index);
+            events.push(event("content_block_start", serde_json::json!({"type":"content_block_start", "index":index, "content_block":{"type":"tool_use", "id":tool.id, "name":tool.name, "input":{}}})));
+            events.push(event("content_block_delta", serde_json::json!({"type":"content_block_delta", "index":index, "delta":{"type":"input_json_delta", "partial_json":tool.arguments}})));
+            tool.stopped = true;
+            events.push(event("content_block_stop", serde_json::json!({"type":"content_block_stop", "index":index})));
+        }
+        let stop_reason = match self.finish_reason.as_deref() {
+            Some("length") => "max_tokens",
+            Some("tool_calls") | Some("function_call") => "tool_use",
+            Some("content_filter") => "refusal",
+            None if !self.tools.is_empty() => "tool_use",
+            _ => "end_turn",
+        };
+        events.push(event("message_delta", serde_json::json!({"type":"message_delta", "delta":{"stop_reason":stop_reason, "stop_sequence":null}, "usage":{"input_tokens":self.input_tokens, "output_tokens":self.output_tokens}})));
+        events.push(event(
+            "message_stop",
+            serde_json::json!({"type":"message_stop"}),
+        ));
+        self.ended = true;
+        Ok(())
+    }
+}
+
+fn sse_record_end(input: &[u8]) -> Option<usize> {
+    let crlf = input
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .map(|index| index + 4);
+    let lf = input
+        .windows(2)
+        .position(|window| window == b"\n\n")
+        .map(|index| index + 2);
+    match (crlf, lf) {
+        (Some(crlf), Some(lf)) => Some(crlf.min(lf)),
+        (Some(end), None) | (None, Some(end)) => Some(end),
+        (None, None) => None,
+    }
+}
+
+fn parse_sse_data(record: &[u8]) -> Result<String, String> {
+    let text = std::str::from_utf8(record)
+        .map_err(|_| "OpenAI upstream SSE was not valid UTF-8".to_string())?;
+    let mut lines = Vec::new();
+    for line in text.lines() {
+        let line = line.trim_end_matches('\r');
+        if let Some(data) = line.strip_prefix("data:") {
+            lines.push(data.strip_prefix(' ').unwrap_or(data));
+        }
+    }
+    Ok(lines.join("\n"))
+}
+
+// Kept for the older OpenAI-only handlers while they remain available. The
+// Anthropic Messages endpoint uses `feed`/`finish` directly above.
+#[allow(dead_code)]
 pub fn convert_openai_sse_to_anthropic(
-    chunk_text: &str,
+    chunk: &str,
     model: &str,
     message_id: &str,
     state: &mut AnthropicStreamState,
 ) -> Vec<String> {
-    let mut events = Vec::new();
-
-    // Emit message_start on first chunk
-    if !state.started {
-        let msg_start = serde_json::json!({
-            "type": "message_start",
-            "message": {
-                "id": message_id,
-                "type": "message",
-                "role": "assistant",
-                "model": model,
-                "content": [],
-                "stop_reason": null,
-                "usage": {
-                    "input_tokens": state.input_tokens,
-                    "output_tokens": 0
-                }
-            }
-        });
-        events.push(format!("event: message_start\ndata: {}\n\n", msg_start));
-        state.started = true;
-    }
-
-    for line in chunk_text.lines() {
-        let trimmed = line.trim();
-        if !trimmed.starts_with("data:") {
-            continue;
-        }
-        let data_str = trimmed.trim_start_matches("data:").trim();
-        if data_str == "[DONE]" || data_str.is_empty() {
-            continue;
-        }
-
-        let json: Value = match serde_json::from_str(data_str) {
-            Ok(j) => j,
-            Err(_) => continue,
-        };
-
-        if let Some(choices) = json.get("choices").and_then(|c| c.as_array()) {
-            for choice in choices {
-                if let Some(delta) = choice.get("delta") {
-                    // --- Text content delta ---
-                    if let Some(content) = delta.get("content").and_then(|c| c.as_str()) {
-                        if !content.is_empty() {
-                            // Ensure text block is open at index 0
-                            if !state.text_block_open {
-                                // Close any open tool_use blocks before opening text? No — text comes first.
-                                let block_start = serde_json::json!({
-                                    "type": "content_block_start",
-                                    "index": 0,
-                                    "content_block": {"type": "text", "text": ""}
-                                });
-                                events.push(format!("event: content_block_start\ndata: {}\n\n", block_start));
-                                state.text_block_open = true;
-                                state.current_index = 0;
-                            }
-
-                            let block_delta = serde_json::json!({
-                                "type": "content_block_delta",
-                                "index": 0,
-                                "delta": {
-                                    "type": "text_delta",
-                                    "text": content
-                                }
-                            });
-                            events.push(format!("event: content_block_delta\ndata: {}\n\n", block_delta));
-                            state.output_tokens += 1; // approximate
-                        }
-                    }
-
-                    // --- Tool calls delta ---
-                    if let Some(tool_calls) = delta.get("tool_calls").and_then(|t| t.as_array()) {
-                        for tc in tool_calls {
-                            let tc_index = tc.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as usize;
-
-                            // Get or create tool call state
-                            let tool_state = state.tool_calls.entry(tc_index).or_insert_with(|| ToolCallState {
-                                block_index: 0,
-                                id: String::new(),
-                                name: String::new(),
-                                arguments: String::new(),
-                                block_started: false,
-                                block_stopped: false,
-                            });
-
-                            // If this is the first delta for this tool call, capture id and name
-                            if !tool_state.block_started {
-                                // Close text block if open
-                                if state.text_block_open && !state.text_block_stopped {
-                                    let block_stop = serde_json::json!({
-                                        "type": "content_block_stop",
-                                        "index": 0
-                                    });
-                                    events.push(format!("event: content_block_stop\ndata: {}\n\n", block_stop));
-                                    state.text_block_stopped = true;
-                                }
-
-                                // Assign next content block index
-                                state.next_block_index += 1;
-                                tool_state.block_index = state.next_block_index;
-
-                                // Extract id and function name
-                                tool_state.id = tc.get("id").and_then(|i| i.as_str()).unwrap_or("").to_string();
-                                let func = tc.get("function");
-                                tool_state.name = func
-                                    .and_then(|f| f.get("name"))
-                                    .and_then(|n| n.as_str())
-                                    .unwrap_or("")
-                                    .to_string();
-
-                                // Emit content_block_start for tool_use
-                                let block_start = serde_json::json!({
-                                    "type": "content_block_start",
-                                    "index": tool_state.block_index,
-                                    "content_block": {
-                                        "type": "tool_use",
-                                        "id": tool_state.id,
-                                        "name": tool_state.name,
-                                        "input": {}
-                                    }
-                                });
-                                events.push(format!("event: content_block_start\ndata: {}\n\n", block_start));
-                                tool_state.block_started = true;
-                            }
-
-                            // Accumulate arguments delta
-                            if let Some(args_delta) = tc.get("function").and_then(|f| f.get("arguments")).and_then(|a| a.as_str()) {
-                                tool_state.arguments.push_str(args_delta);
-
-                                // Emit input_json_delta
-                                let block_delta = serde_json::json!({
-                                    "type": "content_block_delta",
-                                    "index": tool_state.block_index,
-                                    "delta": {
-                                        "type": "input_json_delta",
-                                        "partial_json": args_delta
-                                    }
-                                });
-                                events.push(format!("event: content_block_delta\ndata: {}\n\n", block_delta));
-                            }
-                        }
-                    }
-
-                    // --- Reasoning content (thinking) ---
-                    // Some OpenAI-compatible providers return delta.reasoning_content
-                    if let Some(reasoning) = delta.get("reasoning_content").and_then(|r| r.as_str()) {
-                        if !reasoning.is_empty() {
-                            // Map to thinking block in Anthropic format
-                            if !state.thinking_block_open {
-                                let block_start = serde_json::json!({
-                                    "type": "content_block_start",
-                                    "index": state.next_block_index + 1,
-                                    "content_block": {
-                                        "type": "thinking",
-                                        "thinking": ""
-                                    }
-                                });
-                                events.push(format!("event: content_block_start\ndata: {}\n\n", block_start));
-                                state.thinking_block_open = true;
-                                state.thinking_block_index = state.next_block_index + 1;
-                            }
-
-                            let block_delta = serde_json::json!({
-                                "type": "content_block_delta",
-                                "index": state.thinking_block_index,
-                                "delta": {
-                                    "type": "thinking_delta",
-                                    "thinking": reasoning
-                                }
-                            });
-                            events.push(format!("event: content_block_delta\ndata: {}\n\n", block_delta));
-                        }
-                    }
-                }
-
-                // Check for finish_reason
-                if let Some(finish) = choice.get("finish_reason").and_then(|f| f.as_str()) {
-                    if !finish.is_empty() && finish != "null" {
-                        // Close text block if still open
-                        if state.text_block_open && !state.text_block_stopped {
-                            let block_stop = serde_json::json!({
-                                "type": "content_block_stop",
-                                "index": 0
-                            });
-                            events.push(format!("event: content_block_stop\ndata: {}\n\n", block_stop));
-                            state.text_block_stopped = true;
-                        }
-
-                        // Close all tool_use blocks
-                        for (_, ts) in &state.tool_calls {
-                            if ts.block_started && !ts.block_stopped {
-                                let block_stop = serde_json::json!({
-                                    "type": "content_block_stop",
-                                    "index": ts.block_index
-                                });
-                                events.push(format!("event: content_block_stop\ndata: {}\n\n", block_stop));
-                            }
-                        }
-
-                        // Close thinking block if open
-                        if state.thinking_block_open {
-                            let block_stop = serde_json::json!({
-                                "type": "content_block_stop",
-                                "index": state.thinking_block_index
-                            });
-                            events.push(format!("event: content_block_stop\ndata: {}\n\n", block_stop));
-                        }
-
-                        let stop_reason = match finish {
-                            "stop" => "end_turn",
-                            "length" => "max_tokens",
-                            "tool_calls" => "tool_use",
-                            _ => "end_turn",
-                        };
-
-                        // Extract usage if present
-                        let prompt_tokens = json.get("usage").and_then(|u| u.get("prompt_tokens")).and_then(|t| t.as_u64()).unwrap_or(0);
-                        let completion_tokens = json.get("usage").and_then(|u| u.get("completion_tokens")).and_then(|t| t.as_u64()).unwrap_or(0);
-
-                        let msg_delta = serde_json::json!({
-                            "type": "message_delta",
-                            "delta": {
-                                "stop_reason": stop_reason,
-                                "stop_sequence": null
-                            },
-                            "usage": {
-                                "input_tokens": prompt_tokens,
-                                "output_tokens": completion_tokens
-                            }
-                        });
-                        events.push(format!("event: message_delta\ndata: {}\n\n", msg_delta));
-
-                        let msg_stop = serde_json::json!({"type": "message_stop"});
-                        events.push(format!("event: message_stop\ndata: {}\n\n", msg_stop));
-                    }
-                }
-            }
-        }
-    }
-
-    events
+    state
+        .feed(chunk.as_bytes(), model, message_id)
+        .unwrap_or_default()
 }
 
-/// State for a single tool call being streamed.
-#[derive(Clone)]
-struct ToolCallState {
-    block_index: usize,
-    id: String,
-    name: String,
-    arguments: String,
-    block_started: bool,
-    block_stopped: bool,
-}
-
-/// State for Anthropic stream conversion.
-#[derive(Default)]
-pub struct AnthropicStreamState {
-    pub started: bool,
-    pub input_tokens: u64,
-    pub output_tokens: u64,
-    // Text block tracking
-    text_block_open: bool,
-    text_block_stopped: bool,
-    // Tool call tracking: OpenAI tool_call index → state
-    tool_calls: HashMap<usize, ToolCallState>,
-    // Next content block index (0 = text, 1+ = tool_use)
-    next_block_index: usize,
-    current_index: usize,
-    // Thinking block tracking
-    thinking_block_open: bool,
-    thinking_block_index: usize,
-}
-
-/// Parse usage from OpenAI SSE chunk for Anthropic logging.
+#[allow(dead_code)]
 pub fn parse_usage_from_sse_chunk(text: &str) -> Option<(i64, i64, i64)> {
-    for line in text.lines() {
-        let trimmed = line.trim();
-        if !trimmed.starts_with("data:") {
-            continue;
-        }
-        let data_str = trimmed.trim_start_matches("data:").trim();
-        if data_str == "[DONE]" || data_str.is_empty() {
-            continue;
-        }
-        if let Ok(json) = serde_json::from_str::<Value>(data_str) {
+    for record in text.split("\n\n") {
+        let data = parse_sse_data(record.as_bytes()).ok()?;
+        if let Ok(json) = serde_json::from_str::<Value>(&data) {
             if let Some(usage) = json.get("usage") {
-                let prompt = usage.get("prompt_tokens").and_then(|v| v.as_i64()).unwrap_or(0);
-                let completion = usage.get("completion_tokens").and_then(|v| v.as_i64()).unwrap_or(0);
-                let total = usage.get("total_tokens").and_then(|v| v.as_i64()).unwrap_or(0);
-                if total > 0 || prompt > 0 || completion > 0 {
-                    return Some((prompt, completion, total));
+                let input = usage
+                    .get("prompt_tokens")
+                    .and_then(Value::as_i64)
+                    .unwrap_or(0);
+                let output = usage
+                    .get("completion_tokens")
+                    .and_then(Value::as_i64)
+                    .unwrap_or(0);
+                let total = usage
+                    .get("total_tokens")
+                    .and_then(Value::as_i64)
+                    .unwrap_or(input + output);
+                if input > 0 || output > 0 || total > 0 {
+                    return Some((input, output, total));
                 }
             }
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handles_crlf_utf8_splits_parallel_tools_and_late_usage() {
+        let mut state = AnthropicStreamState::default();
+        let parts = [
+            b"data: {\"choices\":[{\"delta\":{\"content\":\"h".as_slice(),
+            "\u{00e9}".as_bytes(),
+            b"\"}}]}\r\n\r\ndata: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":1,\"id\":\"b\",\"function\":{\"name\":\"two\",\"arguments\":\"{\\\"b\\\":2}\"}},{\"index\":0,\"id\":\"a\",\"function\":{\"name\":\"one\",\"arguments\":\"{\\\"a\\\":1}\"}}]}}]}\r\n\r\n".as_slice(),
+            b"data: {\"choices\":[{\"finish_reason\":\"tool_calls\"}]}\n\ndata: {\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":3}}\n\ndata: [DONE]\n\n".as_slice(),
+        ];
+        let mut output = Vec::new();
+        for part in parts {
+            output.extend(state.feed(part, "model", "msg_1").unwrap());
+        }
+        output.extend(state.finish("model", "msg_1").unwrap());
+        let output = output.join("");
+        assert!(output.contains("hé"));
+        assert!(output.contains("\"id\":\"a\""));
+        assert!(output.contains("\"id\":\"b\""));
+        assert!(output.contains("\"input_tokens\":7"));
+        assert!(output.contains("\"stop_sequence\":null"));
+        let text_stop = output.find("content_block_stop").unwrap();
+        let first_tool = output.find("\"type\":\"tool_use\"").unwrap();
+        assert!(text_stop < first_tool, "text must stop before a tool block starts");
+        assert!(output.find("\"id\":\"a\"").unwrap() < output.find("\"id\":\"b\"").unwrap());
+        assert_eq!(output.matches("event: message_stop").count(), 1);
+    }
+
+    #[test]
+    fn infers_tool_use_and_maps_refusal_when_chat_omits_finish_reason() {
+        let mut state = AnthropicStreamState::default();
+        let tool = b"data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"run\",\"arguments\":\"{}\"}}]}}]}\n\n";
+        state.feed(tool, "model", "msg_1").unwrap();
+        assert!(state.finish("model", "msg_1").unwrap().join("").contains("\"stop_reason\":\"tool_use\""));
+
+        let mut refusal = AnthropicStreamState::default();
+        refusal.feed(b"data: {\"choices\":[{\"delta\":{\"refusal\":\"no\"}}]}\n\n", "model", "msg_2").unwrap();
+        assert!(refusal.finish("model", "msg_2").unwrap().join("").contains("\"stop_reason\":\"refusal\""));
+    }
 }

--- a/src-tauri/src/protocol/mod.rs
+++ b/src-tauri/src/protocol/mod.rs
@@ -1,5 +1,5 @@
-pub mod responses;
 pub mod anthropic;
+pub mod responses;
 
 use serde_json::Value;
 
@@ -84,10 +84,21 @@ pub fn openai_to_responses(openai_resp: &Value, model: &str) -> Value {
     let mut output = Vec::new();
 
     // Add function_call outputs for tool_calls
-    if let Some(tool_calls) = message.and_then(|m| m.get("tool_calls")).and_then(|t| t.as_array()) {
+    if let Some(tool_calls) = message
+        .and_then(|m| m.get("tool_calls"))
+        .and_then(|t| t.as_array())
+    {
         for tc in tool_calls {
-            let name = tc.get("function").and_then(|f| f.get("name")).and_then(|n| n.as_str()).unwrap_or("");
-            let arguments = tc.get("function").and_then(|f| f.get("arguments")).and_then(|a| a.as_str()).unwrap_or("");
+            let name = tc
+                .get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(|n| n.as_str())
+                .unwrap_or("");
+            let arguments = tc
+                .get("function")
+                .and_then(|f| f.get("arguments"))
+                .and_then(|a| a.as_str())
+                .unwrap_or("");
             let call_id = tc.get("id").and_then(|i| i.as_str()).unwrap_or("");
             output.push(serde_json::json!({
                 "id": format!("fc_{}", uuid::Uuid::new_v4().simple()),
@@ -132,8 +143,12 @@ pub fn openai_to_responses(openai_resp: &Value, model: &str) -> Value {
 
 /// Convert Responses API request to OpenAI Chat Completions format.
 pub fn responses_to_openai(body: &Value) -> Value {
-    let model = body.get("model").and_then(|m| m.as_str()).unwrap_or("").to_string();
-    
+    let model = body
+        .get("model")
+        .and_then(|m| m.as_str())
+        .unwrap_or("")
+        .to_string();
+
     // Convert input array to messages array
     let messages = if let Some(input) = body.get("input") {
         convert_responses_input_to_messages(input)
@@ -142,9 +157,15 @@ pub fn responses_to_openai(body: &Value) -> Value {
     };
 
     // max_output_tokens -> max_tokens
-    let max_tokens = body.get("max_output_tokens").and_then(|m| m.as_u64()).unwrap_or(4096);
+    let max_tokens = body
+        .get("max_output_tokens")
+        .and_then(|m| m.as_u64())
+        .unwrap_or(4096);
 
-    let stream = body.get("stream").and_then(|s| s.as_bool()).unwrap_or(false);
+    let stream = body
+        .get("stream")
+        .and_then(|s| s.as_bool())
+        .unwrap_or(false);
 
     let mut openai_body = serde_json::json!({
         "model": model,
@@ -166,36 +187,39 @@ pub fn responses_to_openai(body: &Value) -> Value {
     // Chat Completions uses nested format: { type: "function", function: { name, parameters, description } }
     if let Some(tools) = body.get("tools") {
         if let Some(arr) = tools.as_array() {
-            let openai_tools: Vec<Value> = arr.iter().filter_map(|t| {
-                let tool_type = t.get("type").and_then(|ty| ty.as_str()).unwrap_or("");
-                match tool_type {
-                    // Function tools: convert flat → nested
-                    "function" => {
-                        // Already in Chat Completions format (has "function" field) — pass through
-                        if t.get("function").is_some() {
-                            return Some(t.clone());
+            let openai_tools: Vec<Value> = arr
+                .iter()
+                .filter_map(|t| {
+                    let tool_type = t.get("type").and_then(|ty| ty.as_str()).unwrap_or("");
+                    match tool_type {
+                        // Function tools: convert flat → nested
+                        "function" => {
+                            // Already in Chat Completions format (has "function" field) — pass through
+                            if t.get("function").is_some() {
+                                return Some(t.clone());
+                            }
+                            // Responses API flat format → convert to Chat Completions nested format
+                            let func = serde_json::json!({
+                                "name": t.get("name").cloned().unwrap_or(Value::Null),
+                                "parameters": t.get("parameters").cloned().unwrap_or(Value::Null),
+                            });
+                            let mut func_obj = func;
+                            if let Some(desc) = t.get("description") {
+                                func_obj["description"] = desc.clone();
+                            }
+                            if let Some(strict) = t.get("strict") {
+                                func_obj["strict"] = strict.clone();
+                            }
+                            Some(serde_json::json!({
+                                "type": "function",
+                                "function": func_obj
+                            }))
                         }
-                        // Responses API flat format → convert to Chat Completions nested format
-                        let func = serde_json::json!({
-                            "name": t.get("name").cloned().unwrap_or(Value::Null),
-                            "parameters": t.get("parameters").cloned().unwrap_or(Value::Null),
-                        });
-                        let mut func_obj = func;
-                        if let Some(desc) = t.get("description") {
-                            func_obj["description"] = desc.clone();
-                        }
-                        if let Some(strict) = t.get("strict") {
-                            func_obj["strict"] = strict.clone();
-                        }
-                        Some(serde_json::json!({
-                            "type": "function",
-                            "function": func_obj
-                        }))
+                        // Built-in tools (web_search, file_search, computer_use, etc.) — skip
+                        _ => None,
                     }
-                    // Built-in tools (web_search, file_search, computer_use, etc.) — skip
-                    _ => None
-                }
-            }).collect();
+                })
+                .collect();
             if !openai_tools.is_empty() {
                 openai_body["tools"] = Value::Array(openai_tools);
             }
@@ -210,11 +234,17 @@ pub fn responses_to_openai(body: &Value) -> Value {
     // Pass through instructions as a system message if present
     if let Some(instructions) = body.get("instructions").and_then(|i| i.as_str()) {
         if !instructions.is_empty() {
-            if let Some(msgs) = openai_body.get_mut("messages").and_then(|m| m.as_array_mut()) {
-                msgs.insert(0, serde_json::json!({
-                    "role": "system",
-                    "content": instructions
-                }));
+            if let Some(msgs) = openai_body
+                .get_mut("messages")
+                .and_then(|m| m.as_array_mut())
+            {
+                msgs.insert(
+                    0,
+                    serde_json::json!({
+                        "role": "system",
+                        "content": instructions
+                    }),
+                );
             }
         }
     }
@@ -292,25 +322,36 @@ fn convert_responses_input_to_messages(input: &Value) -> Value {
 
                 // message: standard chat message
                 "message" | _ if item.get("role").is_some() => {
-                    let role = item.get("role").and_then(|r| r.as_str()).unwrap_or("user").to_string();
+                    let role = item
+                        .get("role")
+                        .and_then(|r| r.as_str())
+                        .unwrap_or("user")
+                        .to_string();
                     // Map Roles that some providers don't recognize
                     // 'developer' is an OpenAI alias for 'system' (used by Codex/Responses API)
                     let role = match role.as_str() {
                         "developer" => "system".to_string(),
                         other => other.to_string(),
                     };
-                    let content = if let Some(content_arr) = item.get("content").and_then(|c| c.as_array()) {
-                        // Extract text from content blocks
-                        let texts: Vec<String> = content_arr.iter().filter_map(|block| {
-                            // input_text, output_text, text
-                            block.get("text").and_then(|t| t.as_str()).map(|s| s.to_string())
-                        }).collect();
-                        Value::String(texts.join(""))
-                    } else if let Some(text) = item.get("content").and_then(|c| c.as_str()) {
-                        Value::String(text.to_string())
-                    } else {
-                        Value::String(String::new())
-                    };
+                    let content =
+                        if let Some(content_arr) = item.get("content").and_then(|c| c.as_array()) {
+                            // Extract text from content blocks
+                            let texts: Vec<String> = content_arr
+                                .iter()
+                                .filter_map(|block| {
+                                    // input_text, output_text, text
+                                    block
+                                        .get("text")
+                                        .and_then(|t| t.as_str())
+                                        .map(|s| s.to_string())
+                                })
+                                .collect();
+                            Value::String(texts.join(""))
+                        } else if let Some(text) = item.get("content").and_then(|c| c.as_str()) {
+                            Value::String(text.to_string())
+                        } else {
+                            Value::String(String::new())
+                        };
                     msgs.push(serde_json::json!({
                         "role": role,
                         "content": content,
@@ -348,8 +389,12 @@ fn convert_responses_input_to_messages(input: &Value) -> Value {
     Value::Array(messages)
 }
 
-/// Convert OpenAI Chat Completions response to Anthropic Messages format.
-pub fn openai_to_anthropic(openai_resp: &Value, model: &str) -> Value {
+/// Convert an OpenAI Chat Completions response to Anthropic Messages format.
+///
+/// This deliberately fails instead of inventing tool input when an upstream
+/// returns malformed function arguments. Claude Code uses those arguments to
+/// execute local tools, so replacing bad JSON with `{}` is unsafe.
+pub fn openai_to_anthropic(openai_resp: &Value, model: &str) -> Result<Value, String> {
     let choice = openai_resp
         .get("choices")
         .and_then(|c| c.as_array())
@@ -357,20 +402,39 @@ pub fn openai_to_anthropic(openai_resp: &Value, model: &str) -> Value {
 
     let message = choice.and_then(|ch| ch.get("message"));
 
-    let content_text = message
-        .and_then(|msg| msg.get("content"))
-        .and_then(|c| c.as_str())
-        .unwrap_or("");
+    let message = message
+        .ok_or_else(|| "OpenAI response does not contain a completion message".to_string())?;
+    if message.get("reasoning_content").is_some() || message.get("thinking").is_some() {
+        return Err("OpenAI upstream returned thinking content, which cannot be represented safely by this Anthropic compatibility endpoint".to_string());
+    }
+    let content_text = match message.get("content") {
+        None | Some(Value::Null) => "",
+        Some(Value::String(value)) => value,
+        Some(_) => {
+            return Err("OpenAI response has unsupported non-text message content".to_string())
+        }
+    };
 
     let finish_reason = choice
         .and_then(|ch| ch.get("finish_reason"))
         .and_then(|f| f.as_str())
-        .unwrap_or("stop");
+        .unwrap_or("");
 
+    // Chat Completions normally sets `tool_calls`, but some compatible
+    // upstreams omit it.  The tool-call payload is less ambiguous than a
+    // missing finish reason, so do not report a completed tool turn as an
+    // ordinary end_turn.
+    let has_tool_calls = message
+        .get("tool_calls")
+        .and_then(Value::as_array)
+        .is_some_and(|calls| !calls.is_empty());
     let stop_reason = match finish_reason {
         "stop" => "end_turn",
         "length" => "max_tokens",
         "tool_calls" => "tool_use",
+        "content_filter" => "refusal",
+        _ if message.get("refusal").is_some() => "refusal",
+        _ if has_tool_calls => "tool_use",
         _ => "end_turn",
     };
 
@@ -397,13 +461,34 @@ pub fn openai_to_anthropic(openai_resp: &Value, model: &str) -> Value {
     }
 
     // Add tool_use blocks for tool_calls
-    if let Some(tool_calls) = message.and_then(|m| m.get("tool_calls")).and_then(|t| t.as_array()) {
+    if let Some(tool_calls) = message.get("tool_calls").and_then(|t| t.as_array()) {
         for tc in tool_calls {
-            let id = tc.get("id").and_then(|i| i.as_str()).unwrap_or("");
+            let id = tc
+                .get("id")
+                .and_then(|i| i.as_str())
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| "OpenAI response tool call is missing its id".to_string())?;
             let func = tc.get("function");
-            let name = func.and_then(|f| f.get("name").and_then(|n| n.as_str())).unwrap_or("");
-            let arguments_str = func.and_then(|f| f.get("arguments").and_then(|a| a.as_str())).unwrap_or("{}");
-            let input: Value = serde_json::from_str(&arguments_str).unwrap_or(serde_json::json!({}));
+            let name = func
+                .and_then(|f| f.get("name").and_then(|n| n.as_str()))
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| {
+                    "OpenAI response tool call is missing its function name".to_string()
+                })?;
+            let arguments_str = func
+                .and_then(|f| f.get("arguments").and_then(|a| a.as_str()))
+                .ok_or_else(|| {
+                    "OpenAI response tool call is missing function arguments".to_string()
+                })?;
+            let input: Value = serde_json::from_str(arguments_str).map_err(|error| {
+                format!(
+                    "OpenAI response contained invalid tool arguments: {}",
+                    error
+                )
+            })?;
+            if !input.is_object() {
+                return Err("OpenAI response tool arguments must decode to a JSON object".to_string());
+            }
 
             content_blocks.push(serde_json::json!({
                 "type": "tool_use",
@@ -422,44 +507,80 @@ pub fn openai_to_anthropic(openai_resp: &Value, model: &str) -> Value {
         }));
     }
 
-    serde_json::json!({
+    Ok(serde_json::json!({
         "id": openai_resp.get("id").cloned().unwrap_or(Value::String(format!("msg_{}", uuid::Uuid::new_v4().simple()))),
         "type": "message",
         "role": "assistant",
         "model": model,
         "content": content_blocks,
         "stop_reason": stop_reason,
+        "stop_sequence": null,
         "usage": {
             "input_tokens": input_tokens,
             "output_tokens": output_tokens
         }
-    })
+    }))
 }
 
-/// Convert Anthropic Messages request to OpenAI Chat Completions format.
-pub fn anthropic_to_openai(body: &Value) -> Value {
-    let model = body.get("model").and_then(|m| m.as_str()).unwrap_or("").to_string();
-    let messages = body.get("messages").cloned().unwrap_or(Value::Array(vec![]));
-    let max_tokens = body.get("max_tokens").and_then(|m| m.as_u64()).unwrap_or(4096);
-    let stream = body.get("stream").and_then(|s| s.as_bool()).unwrap_or(false);
+/// Convert an Anthropic Messages request to OpenAI Chat Completions.
+///
+/// This converter intentionally accepts only the intersection which can be
+/// represented by Chat Completions. Native Anthropic channels must bypass it.
+pub fn anthropic_to_openai(body: &Value) -> Result<Value, String> {
+    if body.get("thinking").is_some()
+        || body.get("output_config").is_some()
+        || body.get("container").is_some()
+        || body.get("context_management").is_some()
+        || body.get("context_management_config").is_some()
+    {
+        return Err(
+            "thinking, containers, output_config, and context management require a native Anthropic Messages channel"
+                .to_string(),
+        );
+    }
+    let model = body
+        .get("model")
+        .and_then(|m| m.as_str())
+        .unwrap_or("")
+        .to_string();
+    let messages = body
+        .get("messages")
+        .cloned()
+        .unwrap_or(Value::Array(vec![]));
+    let max_tokens = body
+        .get("max_tokens")
+        .and_then(|m| m.as_u64())
+        .unwrap_or(4096);
+    let stream = body
+        .get("stream")
+        .and_then(|s| s.as_bool())
+        .unwrap_or(false);
 
     // Extract system message and prepend it
-    let system = body.get("system").and_then(|s| {
+    let system = body.get("system").map(|s| {
         if let Some(str_val) = s.as_str() {
-            Some(str_val.to_string())
+            Ok(str_val.to_string())
         } else if let Some(arr) = s.as_array() {
-            // Anthropic system can be an array of content blocks
-            let texts: Vec<String> = arr.iter().filter_map(|block| {
-                block.get("text").and_then(|t| t.as_str()).map(|s| s.to_string())
-            }).collect();
-            Some(texts.join(""))
+            let mut texts = Vec::new();
+            for block in arr {
+                // Prompt caching changes Anthropic billing/cache behavior but
+                // not the text content of a Chat Completions request.  It is
+                // safe to drop this annotation on the OpenAI bridge; native
+                // channels still receive the original body unchanged.
+                match block.get("type").and_then(|t| t.as_str()) {
+                    Some("text") => texts.push(block.get("text").and_then(|t| t.as_str()).unwrap_or("").to_string()),
+                    Some("cache_control") | Some("thinking") => return Err("system cache/thinking blocks require a native Anthropic Messages channel".to_string()),
+                    _ => return Err("unsupported non-text system content requires a native Anthropic Messages channel".to_string()),
+                }
+            }
+            Ok(texts.join(""))
         } else {
-            None
+            Err("system must be text or an array of text blocks".to_string())
         }
-    });
+    }).transpose()?;
 
     // Convert Anthropic message content (array format) to OpenAI string format
-    let openai_messages = convert_anthropic_messages_to_openai(&messages, system);
+    let openai_messages = convert_anthropic_messages_to_openai(&messages, system)?;
 
     let mut openai_body = serde_json::json!({
         "model": model,
@@ -482,37 +603,58 @@ pub fn anthropic_to_openai(body: &Value) -> Value {
     if let Some(stop_seq) = body.get("stop_sequences") {
         openai_body["stop"] = stop_seq.clone();
     }
-    // Note: thinking field is not forwarded to OpenAI API since most providers don't support it.
-    // It's safely ignored rather than causing an error.
-
+    if stream {
+        let mut options = body.get("stream_options").cloned().unwrap_or_else(|| serde_json::json!({}));
+        if !options.is_object() { return Err("stream_options must be an object".to_string()); }
+        options["include_usage"] = Value::Bool(true);
+        openai_body["stream_options"] = options;
+    }
     // Convert Anthropic tools to OpenAI tools format
     // Anthropic: {"name": "xxx", "description": "xxx", "input_schema": {...}}
     // OpenAI: {"type": "function", "function": {"name": "xxx", "description": "xxx", "parameters": {...}}}
     // Also handles Anthropic built-in tools (web_search, computer_use, etc.) which are skipped.
     if let Some(tools) = body.get("tools").and_then(|t| t.as_array()) {
-        let openai_tools: Vec<Value> = tools.iter().filter_map(|tool| {
+        let mut openai_tools = Vec::new();
+        for tool in tools {
+            // `cache_control` on a custom tool is likewise an Anthropic
+            // caching annotation and has no Chat Completions equivalent.
             // Get the tool type — Anthropic custom tools use "custom" or have no type field
-            let tool_type = tool.get("type").and_then(|t| t.as_str()).unwrap_or("custom");
+            let tool_type = tool
+                .get("type")
+                .and_then(|t| t.as_str())
+                .unwrap_or("custom");
             match tool_type {
                 // Standard function tools (type "custom" or no type)
                 "custom" | "" => {
-                    let name = tool.get("name").and_then(|n| n.as_str()).unwrap_or("");
-                    if name.is_empty() { return None; }
-                    let description = tool.get("description").and_then(|d| d.as_str()).unwrap_or("");
-                    let parameters = tool.get("input_schema").cloned().unwrap_or(serde_json::json!({}));
-                    Some(serde_json::json!({
+                    let name = tool
+                        .get("name")
+                        .and_then(|n| n.as_str())
+                        .filter(|s| !s.is_empty())
+                        .ok_or_else(|| "Anthropic tool is missing its name".to_string())?;
+                    let description = tool
+                        .get("description")
+                        .and_then(|d| d.as_str())
+                        .unwrap_or("");
+                    let parameters = tool.get("input_schema").cloned().ok_or_else(|| {
+                        format!("Anthropic tool '{}' is missing input_schema", name)
+                    })?;
+                    openai_tools.push(serde_json::json!({
                         "type": "function",
                         "function": {
                             "name": name,
                             "description": description,
                             "parameters": parameters
                         }
-                    }))
+                    }));
                 }
-                // Built-in tools (web_search_*, computer_*, bash_*, text_editor_*, etc.) — skip
-                _ => None
+                _ => {
+                    return Err(
+                        "Anthropic built-in tools require a native Anthropic Messages channel"
+                            .to_string(),
+                    )
+                }
             }
-        }).collect();
+        }
         if !openai_tools.is_empty() {
             openai_body["tools"] = Value::Array(openai_tools);
         }
@@ -527,13 +669,14 @@ pub fn anthropic_to_openai(body: &Value) -> Value {
                 "auto" => Value::String("auto".to_string()),
                 "any" => Value::String("required".to_string()),
                 "tool" => {
-                    let name = tc.get("name").and_then(|n| n.as_str()).unwrap_or("");
+                    let name = tc.get("name").and_then(|n| n.as_str()).filter(|s| !s.is_empty())
+                        .ok_or_else(|| "Anthropic tool_choice type 'tool' is missing a name".to_string())?;
                     serde_json::json!({
                         "type": "function",
                         "function": {"name": name}
                     })
                 }
-                _ => Value::String("auto".to_string()),
+                _ => return Err("unsupported Anthropic tool_choice requires a native Anthropic Messages channel".to_string()),
             };
             openai_body["tool_choice"] = openai_tc;
         } else if let Some(s) = tc.as_str() {
@@ -541,13 +684,63 @@ pub fn anthropic_to_openai(body: &Value) -> Value {
         }
     }
 
-    openai_body
+    if body
+        .get("tool_choice")
+        .and_then(|choice| choice.get("disable_parallel_tool_use"))
+        .and_then(|v| v.as_bool())
+        == Some(true)
+    {
+        openai_body["parallel_tool_calls"] = Value::Bool(false);
+    }
+
+    Ok(openai_body)
+}
+
+/// Estimate structured Anthropic request size for the optional count_tokens endpoint.
+pub fn estimate_anthropic_input_tokens(body: &Value) -> u64 {
+    fn estimate(value: &Value) -> u64 {
+        match value {
+            Value::String(text) => ((text.chars().count() as u64) + 3) / 4,
+            Value::Array(values) => values.iter().map(estimate).sum(),
+            Value::Object(object) => object
+                .iter()
+                // Image source data is base64, not prompt text. Counting it would
+                // overestimate by orders of magnitude on OpenAI-only channels.
+                .filter(|(key, _)| !matches!(key.as_str(), "model" | "stream" | "data"))
+                .map(|(_, value)| estimate(value))
+                .sum(),
+            _ => 0,
+        }
+    }
+    estimate(body).max(1)
+}
+
+fn tool_result_to_openai_content(block: &Value) -> Result<String, String> {
+    match block.get("content") {
+        None | Some(Value::Null) => Ok(String::new()),
+        Some(Value::String(text)) => Ok(text.clone()),
+        Some(Value::Array(items)) => {
+            let mut text = String::new();
+            for item in items {
+                match item.get("type").and_then(|v| v.as_str()) {
+                    Some("text") => text.push_str(item.get("text").and_then(|v| v.as_str()).unwrap_or("")),
+                    Some("image") => return Err("tool_result images require a native Anthropic Messages channel".to_string()),
+                    _ => return Err("unsupported tool_result content requires a native Anthropic Messages channel".to_string()),
+                }
+            }
+            Ok(text)
+        }
+        _ => Err("tool_result content must be text or text blocks".to_string()),
+    }
 }
 
 /// Convert Anthropic messages array to OpenAI messages array.
 /// Anthropic content can be string or array of content blocks.
 /// Handles: text, tool_use (assistant), tool_result (user)
-fn convert_anthropic_messages_to_openai(messages: &Value, system: Option<String>) -> Value {
+fn convert_anthropic_messages_to_openai(
+    messages: &Value,
+    system: Option<String>,
+) -> Result<Value, String> {
     let mut msgs = Vec::new();
 
     // Prepend system message if present
@@ -557,97 +750,88 @@ fn convert_anthropic_messages_to_openai(messages: &Value, system: Option<String>
 
     if let Some(arr) = messages.as_array() {
         for msg in arr {
-            let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("user").to_string();
+            let role = msg
+                .get("role")
+                .and_then(|r| r.as_str())
+                .ok_or_else(|| "Anthropic message is missing role".to_string())?
+                .to_string();
+            if role != "user" && role != "assistant" {
+                return Err("only user and assistant Anthropic messages can be sent to OpenAI Chat Completions".to_string());
+            }
 
             if let Some(content_arr) = msg.get("content").and_then(|c| c.as_array()) {
-                // Complex content: may contain text, tool_use, or tool_result blocks
-                let mut text_parts: Vec<String> = Vec::new();
+                let mut parts: Vec<Value> = Vec::new();
                 let mut tool_calls: Vec<Value> = Vec::new();
-                let mut tool_results: Vec<Value> = Vec::new();
-
+                let flush_user_parts = |parts: &mut Vec<Value>, msgs: &mut Vec<Value>| {
+                    if !parts.is_empty() {
+                        msgs.push(
+                            serde_json::json!({"role": "user", "content": std::mem::take(parts)}),
+                        );
+                    }
+                };
                 for block in content_arr {
+                    // Cache controls are annotations on otherwise supported
+                    // blocks.  Strip them instead of rejecting an entire
+                    // OpenAI-only Claude Code request.
                     match block.get("type").and_then(|t| t.as_str()).unwrap_or("") {
-                        "text" => {
-                            if let Some(t) = block.get("text").and_then(|t| t.as_str()) {
-                                text_parts.push(t.to_string());
-                            }
+                        "text" => parts.push(serde_json::json!({"type": "text", "text": block.get("text").and_then(|t| t.as_str()).unwrap_or("")})),
+                        "image" => {
+                            if role != "user" { return Err("OpenAI Chat Completions cannot safely encode assistant image blocks".to_string()); }
+                            let source = block.get("source").ok_or_else(|| "Anthropic image block is missing source".to_string())?;
+                            let url = match source.get("type").and_then(|v| v.as_str()) {
+                                Some("url") => source.get("url").and_then(|v| v.as_str()).ok_or_else(|| "Anthropic image URL source is missing url".to_string())?.to_string(),
+                                Some("base64") => format!("data:{};base64,{}", source.get("media_type").and_then(|v| v.as_str()).ok_or_else(|| "Anthropic base64 image is missing media_type".to_string())?, source.get("data").and_then(|v| v.as_str()).ok_or_else(|| "Anthropic base64 image is missing data".to_string())?),
+                                _ => return Err("unsupported Anthropic image source requires a native channel".to_string()),
+                            };
+                            parts.push(serde_json::json!({"type": "image_url", "image_url": {"url": url}}));
                         }
                         "tool_use" => {
-                            // Anthropic tool_use → OpenAI assistant tool_calls
-                            let id = block.get("id").and_then(|i| i.as_str()).unwrap_or("");
-                            let name = block.get("name").and_then(|n| n.as_str()).unwrap_or("");
-                            let input = block.get("input").cloned().unwrap_or(serde_json::json!({}));
-                            let arguments = serde_json::to_string(&input).unwrap_or_default();
-                            tool_calls.push(serde_json::json!({
-                                "id": id,
-                                "type": "function",
-                                "function": {
-                                    "name": name,
-                                    "arguments": arguments
-                                }
-                            }));
-                        }
-                        "thinking" => {
-                            // Anthropic thinking block — extract text, prepend to message content
-                            // OpenAI doesn't have a native thinking block, so we include it as text
-                            if let Some(t) = block.get("thinking").and_then(|t| t.as_str()) {
-                                text_parts.push(t.to_string());
-                            }
-                        }
-                        "image" => {
-                            // Anthropic image block — skip for now (would need URL conversion)
-                            // Future: convert to OpenAI image_url format
+                            if role != "assistant" { return Err("tool_use blocks must be in an assistant message".to_string()); }
+                            let id = block.get("id").and_then(|i| i.as_str()).filter(|s| !s.is_empty()).ok_or_else(|| "tool_use is missing id".to_string())?;
+                            let name = block.get("name").and_then(|n| n.as_str()).filter(|s| !s.is_empty()).ok_or_else(|| "tool_use is missing name".to_string())?;
+                            let input = block.get("input").cloned().unwrap_or_else(|| serde_json::json!({}));
+                            tool_calls.push(serde_json::json!({"id": id, "type": "function", "function": {"name": name, "arguments": serde_json::to_string(&input).map_err(|e| e.to_string())?}}));
                         }
                         "tool_result" => {
-                            // Anthropic tool_result → OpenAI tool message
-                            let tool_use_id = block.get("tool_use_id").and_then(|t| t.as_str()).unwrap_or("");
-                            let result_content = if let Some(rc) = block.get("content").and_then(|c| c.as_array()) {
-                                // Extract text from result content blocks
-                                let texts: Vec<String> = rc.iter().filter_map(|b| {
-                                    b.get("text").and_then(|t| t.as_str()).map(|s| s.to_string())
-                                }).collect();
-                                texts.join("")
-                            } else if let Some(s) = block.get("content").and_then(|c| c.as_str()) {
-                                s.to_string()
-                            } else {
-                                String::new()
-                            };
-                            tool_results.push(serde_json::json!({
-                                "role": "tool",
-                                "tool_call_id": tool_use_id,
-                                "content": result_content
-                            }));
+                            if role != "user" { return Err("tool_result blocks must be in a user message".to_string()); }
+                            flush_user_parts(&mut parts, &mut msgs);
+                            let tool_use_id = block.get("tool_use_id").and_then(|t| t.as_str()).filter(|s| !s.is_empty()).ok_or_else(|| "tool_result is missing tool_use_id".to_string())?;
+                            let result_content = tool_result_to_openai_content(block)?;
+                            let is_error = block.get("is_error").and_then(|v| v.as_bool()).unwrap_or(false);
+                            msgs.push(serde_json::json!({"role": "tool", "tool_call_id": tool_use_id, "content": if is_error { format!("Tool execution error:\n{}", result_content) } else { result_content }}));
                         }
-                        _ => {}
+                        "thinking" | "redacted_thinking" => return Err("Anthropic thinking blocks require a native Anthropic Messages channel".to_string()),
+                        "cache_control" => return Err("Anthropic cache controls require a native Anthropic Messages channel".to_string()),
+                        _ => return Err("unsupported Anthropic content block requires a native Anthropic Messages channel".to_string()),
                     }
                 }
-
-                if !tool_calls.is_empty() {
-                    // Assistant message with tool_calls
-                    let content = if text_parts.is_empty() { Value::Null } else { Value::String(text_parts.join("")) };
-                    msgs.push(serde_json::json!({
-                        "role": role,
-                        "content": content,
-                        "tool_calls": tool_calls
-                    }));
-                } else if !tool_results.is_empty() {
-                    // Tool result messages (may be multiple)
-                    // If there's also text, add it as a preceding user message
-                    if !text_parts.is_empty() {
-                        msgs.push(serde_json::json!({
-                            "role": role,
-                            "content": text_parts.join("")
-                        }));
+                if role == "assistant" {
+                    let content = if parts.is_empty() {
+                        Value::Null
+                    } else if parts
+                        .iter()
+                        .all(|part| part.get("type").and_then(|v| v.as_str()) == Some("text"))
+                    {
+                        Value::String(
+                            parts
+                                .iter()
+                                .filter_map(|part| part.get("text").and_then(|v| v.as_str()))
+                                .collect::<String>(),
+                        )
+                    } else {
+                        Value::Array(parts)
+                    };
+                    if tool_calls.is_empty() && content.is_null() {
+                        return Err("assistant message is empty".to_string());
                     }
-                    for tr in tool_results {
-                        msgs.push(tr);
+                    let mut assistant =
+                        serde_json::json!({"role": "assistant", "content": content});
+                    if !tool_calls.is_empty() {
+                        assistant["tool_calls"] = Value::Array(tool_calls);
                     }
+                    msgs.push(assistant);
                 } else {
-                    // Plain text message
-                    msgs.push(serde_json::json!({
-                        "role": role,
-                        "content": text_parts.join("")
-                    }));
+                    flush_user_parts(&mut parts, &mut msgs);
                 }
             } else if let Some(s) = msg.get("content").and_then(|c| c.as_str()) {
                 msgs.push(serde_json::json!({
@@ -661,7 +845,89 @@ fn convert_anthropic_messages_to_openai(messages: &Value, system: Option<String>
                 }));
             }
         }
+    } else {
+        return Err("Anthropic messages must be an array".to_string());
     }
 
-    Value::Array(msgs)
+    Ok(Value::Array(msgs))
+}
+
+#[cfg(test)]
+mod anthropic_tests {
+    use super::*;
+
+    #[test]
+    fn counts_structured_anthropic_input() {
+        let body = serde_json::json!({
+            "model": "test-model",
+            "system": [{"type": "text", "text": "system prompt"}],
+            "tools": [{"name": "read", "input_schema": {"type": "object"}}],
+            "messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}]
+        });
+        assert!(estimate_anthropic_input_tokens(&body) > 1);
+    }
+
+    #[test]
+    fn maps_tools_parallel_control_and_mixed_tool_results() {
+        let request = serde_json::json!({
+            "model": "claude-compatible",
+            "max_tokens": 32,
+            "system": [{"type":"text", "text":"be concise"}],
+            "tools": [{"name":"weather", "description":"weather", "input_schema":{"type":"object"}}],
+            "tool_choice": {"type":"any", "disable_parallel_tool_use":true},
+            "messages": [
+                {"role":"assistant", "content":[{"type":"text","text":"checking"},{"type":"tool_use","id":"call_1","name":"weather","input":{"city":"Paris"}}]},
+                {"role":"user", "content":[{"type":"tool_result","tool_use_id":"call_1","content":"sunny"},{"type":"text","text":"thanks"}]}
+            ]
+        });
+        let converted = anthropic_to_openai(&request).unwrap();
+        assert_eq!(converted["parallel_tool_calls"], false);
+        assert_eq!(converted["tool_choice"], "required");
+        assert_eq!(
+            converted["tools"][0]["function"]["parameters"]["type"],
+            "object"
+        );
+        assert_eq!(
+            converted["messages"][1]["tool_calls"][0]["function"]["arguments"],
+            "{\"city\":\"Paris\"}"
+        );
+        assert_eq!(converted["messages"][2]["role"], "tool");
+        assert_eq!(converted["messages"][3]["content"][0]["text"], "thanks");
+    }
+
+    #[test]
+    fn rejects_invalid_openai_tool_arguments_without_inventing_input() {
+        let response = serde_json::json!({"choices":[{"finish_reason":"tool_calls", "message":{"role":"assistant", "content":null, "tool_calls":[{"id":"call_1", "function":{"name":"run", "arguments":"{bad"}}]}}]});
+        assert!(openai_to_anthropic(&response, "model").is_err());
+    }
+
+    #[test]
+    fn rejects_non_object_openai_tool_arguments_and_strips_cache_controls() {
+        let response = serde_json::json!({"choices":[{"message":{"role":"assistant", "tool_calls":[{"id":"call_1", "function":{"name":"run", "arguments":"[]"}}]}}]});
+        assert!(openai_to_anthropic(&response, "model").is_err());
+
+        let cache_in_system = serde_json::json!({"model":"model", "system":[{"type":"text", "text":"cached", "cache_control":{"type":"ephemeral"}}], "messages":[]});
+        assert_eq!(anthropic_to_openai(&cache_in_system).unwrap()["messages"][0]["content"], "cached");
+        let cache_in_message = serde_json::json!({"model":"model", "messages":[{"role":"user", "content":[{"type":"text", "text":"cached", "cache_control":{"type":"ephemeral"}}]}]});
+        assert_eq!(anthropic_to_openai(&cache_in_message).unwrap()["messages"][0]["content"][0]["text"], "cached");
+    }
+
+    #[test]
+    fn preserves_anthropic_response_shape_for_refusals_and_implicit_tools() {
+        let refusal = serde_json::json!({"choices":[{"finish_reason":"content_filter", "message":{"role":"assistant", "content":null, "refusal":"no"}}]});
+        let converted = openai_to_anthropic(&refusal, "model").unwrap();
+        assert_eq!(converted["stop_reason"], "refusal");
+        assert!(converted.get("stop_sequence").is_some());
+
+        let implicit_tool = serde_json::json!({"choices":[{"finish_reason":null, "message":{"role":"assistant", "content":null, "tool_calls":[{"id":"call_1", "function":{"name":"run", "arguments":"{}"}}]}}]});
+        assert_eq!(openai_to_anthropic(&implicit_tool, "model").unwrap()["stop_reason"], "tool_use");
+    }
+
+    #[test]
+    fn streaming_openai_requests_always_request_late_usage() {
+        let request = serde_json::json!({"model":"model", "stream":true, "stream_options":{"include_usage":false, "custom":true}, "messages":[]});
+        let converted = anthropic_to_openai(&request).unwrap();
+        assert_eq!(converted["stream_options"]["include_usage"], true);
+        assert_eq!(converted["stream_options"]["custom"], true);
+    }
 }

--- a/src-tauri/src/protocol/responses.rs
+++ b/src-tauri/src/protocol/responses.rs
@@ -120,8 +120,7 @@ pub fn convert_openai_sse_to_responses(
             for choice in choices {
                 if let Some(delta) = choice.get("delta") {
                     // Reasoning content delta (DeepSeek R1, OpenAI o1/o3, etc.)
-                    if let Some(reasoning) =
-                        delta.get("reasoning_content").and_then(|c| c.as_str())
+                    if let Some(reasoning) = delta.get("reasoning_content").and_then(|c| c.as_str())
                     {
                         if !reasoning.is_empty() {
                             let seq = next_seq(state);
@@ -216,10 +215,14 @@ pub fn convert_openai_sse_to_responses(
                             let tc_index = tc.get("index").and_then(|i| i.as_u64()).unwrap_or(0);
                             let tc_id = tc.get("id").and_then(|i| i.as_str()).unwrap_or("");
                             let func = tc.get("function");
-                            let name =
-                                func.and_then(|f| f.get("name")).and_then(|n| n.as_str()).unwrap_or("");
-                            let arguments =
-                                func.and_then(|f| f.get("arguments")).and_then(|a| a.as_str()).unwrap_or("");
+                            let name = func
+                                .and_then(|f| f.get("name"))
+                                .and_then(|n| n.as_str())
+                                .unwrap_or("");
+                            let arguments = func
+                                .and_then(|f| f.get("arguments"))
+                                .and_then(|a| a.as_str())
+                                .unwrap_or("");
 
                             // Initialize tool call state if this is the first time we see it
                             if !state.tool_calls.contains_key(&tc_index) {
@@ -317,9 +320,7 @@ pub fn convert_openai_sse_to_responses(
                 }
 
                 // Check for finish_reason
-                if let Some(finish) =
-                    choice.get("finish_reason").and_then(|f| f.as_str())
-                {
+                if let Some(finish) = choice.get("finish_reason").and_then(|f| f.as_str()) {
                     if !finish.is_empty() && finish != "null" {
                         // Close text item if it was opened and not yet closed
                         if state.text_item_added && !state.text_item_done {
@@ -385,8 +386,19 @@ pub fn convert_openai_sse_to_responses(
 
                         // Close all tool call items
                         // Collect tool call data first to avoid double mutable borrow of state
-                        let tool_calls_data: Vec<(u64, String, String, String, String, bool, bool, bool)> =
-                            state.tool_calls.iter().map(|(_, tc)| {
+                        let tool_calls_data: Vec<(
+                            u64,
+                            String,
+                            String,
+                            String,
+                            String,
+                            bool,
+                            bool,
+                            bool,
+                        )> = state
+                            .tool_calls
+                            .iter()
+                            .map(|(_, tc)| {
                                 (
                                     tc.output_index as u64,
                                     tc.item_id.clone(),
@@ -397,9 +409,20 @@ pub fn convert_openai_sse_to_responses(
                                     tc.arguments_done_sent,
                                     tc.output_item_done_sent,
                                 )
-                            }).collect();
+                            })
+                            .collect();
 
-                        for (output_index, item_id, call_id, name, accumulated_args, _item_added, arguments_done, output_item_done) in &tool_calls_data {
+                        for (
+                            output_index,
+                            item_id,
+                            call_id,
+                            name,
+                            accumulated_args,
+                            _item_added,
+                            arguments_done,
+                            output_item_done,
+                        ) in &tool_calls_data
+                        {
                             if !arguments_done {
                                 let seq = next_seq(state);
                                 let args_done = serde_json::json!({
@@ -546,7 +569,10 @@ pub fn create_synthetic_completed_events(
             "text": accumulated_content,
             "sequence_number": s
         });
-        events.push(format!("event: response.output_text.done\ndata: {}\n\n", text_done));
+        events.push(format!(
+            "event: response.output_text.done\ndata: {}\n\n",
+            text_done
+        ));
 
         let s = next_seq!();
         let part = serde_json::json!({
@@ -562,7 +588,10 @@ pub fn create_synthetic_completed_events(
             "part": part,
             "sequence_number": s
         });
-        events.push(format!("event: response.content_part.done\ndata: {}\n\n", part_done));
+        events.push(format!(
+            "event: response.content_part.done\ndata: {}\n\n",
+            part_done
+        ));
 
         let s = next_seq!();
         let completed_item = serde_json::json!({
@@ -582,7 +611,10 @@ pub fn create_synthetic_completed_events(
             "item": completed_item,
             "sequence_number": s
         });
-        events.push(format!("event: response.output_item.done\ndata: {}\n\n", item_done));
+        events.push(format!(
+            "event: response.output_item.done\ndata: {}\n\n",
+            item_done
+        ));
     }
 
     // Close any still-open tool call items
@@ -596,7 +628,10 @@ pub fn create_synthetic_completed_events(
                 "arguments": tc_state.accumulated_arguments,
                 "sequence_number": s
             });
-            events.push(format!("event: response.function_call_arguments.done\ndata: {}\n\n", args_done));
+            events.push(format!(
+                "event: response.function_call_arguments.done\ndata: {}\n\n",
+                args_done
+            ));
         }
 
         if !tc_state.output_item_done_sent {
@@ -615,7 +650,10 @@ pub fn create_synthetic_completed_events(
                 "item": fc_completed,
                 "sequence_number": s
             });
-            events.push(format!("event: response.output_item.done\ndata: {}\n\n", item_done));
+            events.push(format!(
+                "event: response.output_item.done\ndata: {}\n\n",
+                item_done
+            ));
         }
     }
 
@@ -680,7 +718,10 @@ pub fn create_synthetic_completed_events(
         },
         "sequence_number": s
     });
-    events.push(format!("event: response.completed\ndata: {}\n\n", completed));
+    events.push(format!(
+        "event: response.completed\ndata: {}\n\n",
+        completed
+    ));
 
     events
 }
@@ -698,9 +739,18 @@ pub fn parse_usage_from_sse_chunk(text: &str) -> Option<(i64, i64, i64)> {
         }
         if let Ok(json) = serde_json::from_str::<Value>(data_str) {
             if let Some(usage) = json.get("usage") {
-                let prompt = usage.get("prompt_tokens").and_then(|v| v.as_i64()).unwrap_or(0);
-                let completion = usage.get("completion_tokens").and_then(|v| v.as_i64()).unwrap_or(0);
-                let total = usage.get("total_tokens").and_then(|v| v.as_i64()).unwrap_or(0);
+                let prompt = usage
+                    .get("prompt_tokens")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+                let completion = usage
+                    .get("completion_tokens")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+                let total = usage
+                    .get("total_tokens")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
                 if total > 0 || prompt > 0 || completion > 0 {
                     return Some((prompt, completion, total));
                 }
@@ -759,9 +809,8 @@ mod tests {
 
         // Chunk 1: text delta
         let chunk1 = r#"data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}"#;
-        let events1 = convert_openai_sse_to_responses(
-            chunk1, "gpt-4", response_id, "Hello", &mut state,
-        );
+        let events1 =
+            convert_openai_sse_to_responses(chunk1, "gpt-4", response_id, "Hello", &mut state);
         let types1 = extract_event_types(&events1);
         assert_eq!(
             types1,
@@ -780,15 +829,24 @@ mod tests {
         // Chunk 2: more text
         let chunk2 = r#"data: {"id":"c1","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}"#;
         let events2 = convert_openai_sse_to_responses(
-            chunk2, "gpt-4", response_id, "Hello world", &mut state,
+            chunk2,
+            "gpt-4",
+            response_id,
+            "Hello world",
+            &mut state,
         );
         let types2 = extract_event_types(&events2);
         assert_eq!(types2, vec!["response.output_text.delta"]);
 
         // Chunk 3: finish
-        let chunk3 = r#"data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#;
+        let chunk3 =
+            r#"data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#;
         let events3 = convert_openai_sse_to_responses(
-            chunk3, "gpt-4", response_id, "Hello world", &mut state,
+            chunk3,
+            "gpt-4",
+            response_id,
+            "Hello world",
+            &mut state,
         );
         let types3 = extract_event_types(&events3);
         assert_eq!(
@@ -813,14 +871,9 @@ mod tests {
 
         // Chunk 1: tool call start (id + name)
         let chunk1 = r#"data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_abc","function":{"name":"get_weather","arguments":""}}]},"finish_reason":null}]}"#;
-        let events1 = convert_openai_sse_to_responses(
-            chunk1, "gpt-4", response_id, "", &mut state,
-        );
+        let events1 = convert_openai_sse_to_responses(chunk1, "gpt-4", response_id, "", &mut state);
         let types1 = extract_event_types(&events1);
-        assert_eq!(
-            types1,
-            vec!["response.output_item.added"]
-        );
+        assert_eq!(types1, vec!["response.output_item.added"]);
 
         // Verify it's a function_call item
         let added_data = extract_event_data(&events1[0]);
@@ -831,9 +884,7 @@ mod tests {
 
         // Chunk 2: arguments delta
         let chunk2 = r#"data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"city\":\"SF\"}"}}]},"finish_reason":null}]}"#;
-        let events2 = convert_openai_sse_to_responses(
-            chunk2, "gpt-4", response_id, "", &mut state,
-        );
+        let events2 = convert_openai_sse_to_responses(chunk2, "gpt-4", response_id, "", &mut state);
         let types2 = extract_event_types(&events2);
         assert_eq!(types2, vec!["response.function_call_arguments.delta"]);
 
@@ -843,10 +894,9 @@ mod tests {
         assert_eq!(args_delta_data["delta"], "{\"city\":\"SF\"}");
 
         // Chunk 3: finish with tool_calls
-        let chunk3 = r#"data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"#;
-        let events3 = convert_openai_sse_to_responses(
-            chunk3, "gpt-4", response_id, "", &mut state,
-        );
+        let chunk3 =
+            r#"data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"#;
+        let events3 = convert_openai_sse_to_responses(chunk3, "gpt-4", response_id, "", &mut state);
         let types3 = extract_event_types(&events3);
         assert_eq!(
             types3,
@@ -870,7 +920,11 @@ mod tests {
         // Chunk 1: text
         let chunk1 = r#"data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Let me check"},"finish_reason":null}]}"#;
         let _ = convert_openai_sse_to_responses(
-            chunk1, "gpt-4", response_id, "Let me check", &mut state,
+            chunk1,
+            "gpt-4",
+            response_id,
+            "Let me check",
+            &mut state,
         );
         assert_eq!(state.text_output_index, 0);
         assert_eq!(state.next_output_index, 1);
@@ -878,7 +932,11 @@ mod tests {
         // Chunk 2: tool call start
         let chunk2 = r#"data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_xyz","function":{"name":"search","arguments":""}}]},"finish_reason":null}]}"#;
         let events2 = convert_openai_sse_to_responses(
-            chunk2, "gpt-4", response_id, "Let me check", &mut state,
+            chunk2,
+            "gpt-4",
+            response_id,
+            "Let me check",
+            &mut state,
         );
         let types2 = extract_event_types(&events2);
         assert_eq!(types2, vec!["response.output_item.added"]);
@@ -891,15 +949,24 @@ mod tests {
         // Chunk 3: arguments
         let chunk3 = r#"data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]},"finish_reason":null}]}"#;
         let events3 = convert_openai_sse_to_responses(
-            chunk3, "gpt-4", response_id, "Let me check", &mut state,
+            chunk3,
+            "gpt-4",
+            response_id,
+            "Let me check",
+            &mut state,
         );
         let types3 = extract_event_types(&events3);
         assert_eq!(types3, vec!["response.function_call_arguments.delta"]);
 
         // Chunk 4: finish
-        let chunk4 = r#"data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"#;
+        let chunk4 =
+            r#"data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"#;
         let events4 = convert_openai_sse_to_responses(
-            chunk4, "gpt-4", response_id, "Let me check", &mut state,
+            chunk4,
+            "gpt-4",
+            response_id,
+            "Let me check",
+            &mut state,
         );
         let types4 = extract_event_types(&events4);
         assert_eq!(
@@ -930,14 +997,10 @@ mod tests {
 
         // Simulate: tool call only, no finish_reason in stream
         let chunk1 = r#"data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"test","arguments":"{\"x\":1}"}}]},"finish_reason":null}]}"#;
-        let _ = convert_openai_sse_to_responses(
-            chunk1, "gpt-4", response_id, "", &mut state,
-        );
+        let _ = convert_openai_sse_to_responses(chunk1, "gpt-4", response_id, "", &mut state);
 
         // Stream ends without finish_reason — call synthetic completed
-        let synth = create_synthetic_completed_events(
-            "gpt-4", response_id, "", &state, 10, 20,
-        );
+        let synth = create_synthetic_completed_events("gpt-4", response_id, "", &state, 10, 20);
         let synth_types = extract_event_types(&synth);
         assert_eq!(
             synth_types,
@@ -950,7 +1013,10 @@ mod tests {
 
         // Verify response.completed has function_call in output
         let completed_data = extract_event_data(&synth[2]);
-        assert_eq!(completed_data["response"]["output"][0]["type"], "function_call");
+        assert_eq!(
+            completed_data["response"]["output"][0]["type"],
+            "function_call"
+        );
         assert_eq!(completed_data["response"]["usage"]["input_tokens"], 10);
         assert_eq!(completed_data["response"]["usage"]["output_tokens"], 20);
     }

--- a/src-tauri/src/security/redact.rs
+++ b/src-tauri/src/security/redact.rs
@@ -11,6 +11,16 @@ pub fn redact_json(value: &serde_json::Value, settings: &SecuritySettings) -> se
     cloned
 }
 
+/// Logs are a different trust boundary from upstream forwarding.  Never make
+/// persistence of a caller's prompt conditional on the user-selected
+/// forwarding-redaction mode: scan findings can identify a secret even while
+/// audit mode intentionally forwards the original request.
+pub fn redact_json_for_logging(value: &serde_json::Value) -> serde_json::Value {
+    let mut cloned = value.clone();
+    redact_value_in_place(&mut cloned);
+    cloned
+}
+
 fn redact_value_in_place(value: &mut serde_json::Value) {
     match value {
         serde_json::Value::String(s) => {
@@ -27,7 +37,7 @@ fn redact_value_in_place(value: &mut serde_json::Value) {
                 let lower_key = k.to_ascii_lowercase();
                 if is_secret_field(&lower_key) {
                     if let Some(s) = v.as_str() {
-                        if s.len() > 4 {
+                        if !s.is_empty() {
                             *v = serde_json::Value::String(mask_string(s));
                         }
                     }

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -1,17 +1,17 @@
-use axum::{
-    body::Body,
-    extract::State,
-    http::{HeaderMap, StatusCode, header},
-    response::{Json, IntoResponse, Response},
-};
-use futures_util::StreamExt;
 use super::router::SharedState;
-use crate::core::proxy;
-use crate::db::repository::Repository;
 use crate::adaptor::{get_adaptor, ProxyRequest};
 use crate::core::dispatcher::Dispatcher;
-use crate::security;
+use crate::core::proxy;
+use crate::db::repository::Repository;
 use crate::protocol;
+use crate::security;
+use axum::{
+    body::Body,
+    extract::{OriginalUri, State},
+    http::{header, HeaderMap, StatusCode},
+    response::{IntoResponse, Json, Response},
+};
+use futures_util::StreamExt;
 
 pub async fn handle_chat_completions(
     State(shared): State<SharedState>,
@@ -24,9 +24,15 @@ pub async fn handle_chat_completions(
         Err(e) => return (StatusCode::BAD_REQUEST, format!("Invalid JSON: {}", e)).into_response(),
     };
 
-    let is_stream = json.get("stream").and_then(|s| s.as_bool()).unwrap_or(false);
+    let is_stream = json
+        .get("stream")
+        .and_then(|s| s.as_bool())
+        .unwrap_or(false);
 
-    let auth_header = headers.get("authorization").and_then(|h| h.to_str().ok()).unwrap_or("");
+    let auth_header = headers
+        .get("authorization")
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("");
     let api_key = auth_header.strip_prefix("Bearer ").unwrap_or("").trim();
 
     if api_key.is_empty() {
@@ -44,21 +50,47 @@ pub async fn handle_chat_completions(
     }
 
     // Extract Wali-Trace-Id from request headers
-    let trace_id = headers.get("Wali-Trace-Id").and_then(|h| h.to_str().ok()).map(|s| s.to_string());
+    let trace_id = headers
+        .get("Wali-Trace-Id")
+        .and_then(|h| h.to_str().ok())
+        .map(|s| s.to_string());
 
     // Store full request body for logging (no truncation — let frontend handle display)
     let request_body_str = serde_json::to_string(&json).unwrap_or_default();
 
     if is_stream {
-        handle_stream(shared, json, key_record.id, key_record.name, request_body_str, trace_id).await
+        handle_stream(
+            shared,
+            json,
+            key_record.id,
+            key_record.name,
+            request_body_str,
+            trace_id,
+        )
+        .await
     } else {
-        match proxy::handle_request(&repo, &shared.app, &key_record.id, &key_record.name, json, false, Some(request_body_str), trace_id).await {
+        match proxy::handle_request(
+            &repo,
+            &shared.app,
+            &key_record.id,
+            &key_record.name,
+            json,
+            false,
+            Some(request_body_str),
+            trace_id,
+        )
+        .await
+        {
             Ok(result) => (StatusCode::OK, Json(result.body)).into_response(),
             Err((code, msg)) => {
                 let err_body = serde_json::json!({
                     "error": { "message": msg, "type": "upstream_error", "code": code }
                 });
-                (StatusCode::from_u16(code).unwrap_or(StatusCode::BAD_GATEWAY), Json(err_body)).into_response()
+                (
+                    StatusCode::from_u16(code).unwrap_or(StatusCode::BAD_GATEWAY),
+                    Json(err_body),
+                )
+                    .into_response()
             }
         }
     }
@@ -78,9 +110,18 @@ fn parse_usage_from_chunk(text: &str) -> Option<(i64, i64, i64)> {
         }
         if let Ok(json) = serde_json::from_str::<serde_json::Value>(data_str) {
             if let Some(usage) = json.get("usage") {
-                let prompt = usage.get("prompt_tokens").and_then(|v| v.as_i64()).unwrap_or(0);
-                let completion = usage.get("completion_tokens").and_then(|v| v.as_i64()).unwrap_or(0);
-                let total = usage.get("total_tokens").and_then(|v| v.as_i64()).unwrap_or(0);
+                let prompt = usage
+                    .get("prompt_tokens")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+                let completion = usage
+                    .get("completion_tokens")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+                let total = usage
+                    .get("total_tokens")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
                 if total > 0 || prompt > 0 || completion > 0 {
                     return Some((prompt, completion, total));
                 }
@@ -98,16 +139,23 @@ async fn handle_stream(
     request_body: String,
     trace_id: Option<String>,
 ) -> Response {
-    let model = json.get("model").and_then(|m| m.as_str()).unwrap_or("").to_string();
+    let model = json
+        .get("model")
+        .and_then(|m| m.as_str())
+        .unwrap_or("")
+        .to_string();
     let security_settings = security::get_security_settings(&shared.app);
     let security_result = security::scan_request(&json, &security_settings);
 
     // Real redaction: if redact mode is active, sanitize the request body before forwarding
-    let (forward_json, was_redacted) = if matches!(security_result.action, security::SecurityAction::Redact) || security_settings.redact_secrets {
-        security::redact_request_body(&json, &security_settings)
-    } else {
-        (json.clone(), false)
-    };
+    let (forward_json, was_redacted) =
+        if matches!(security_result.action, security::SecurityAction::Redact)
+            || security_settings.redact_secrets
+        {
+            security::redact_request_body(&json, &security_settings)
+        } else {
+            (json.clone(), false)
+        };
     let mut security_result = security_result;
     if was_redacted {
         security_result.sanitized = true;
@@ -146,14 +194,27 @@ async fn handle_stream(
             trace_id: trace_id.clone(),
         };
         let log_id = log.id.clone();
-        if let Err(e) = repo.create_log(&log).await { eprintln!("[WARN] create_log failed: {}", e); }
-        if let Err(e) = repo.create_security_findings(&log_id, &security_result.findings, security_result.action.as_str()).await { eprintln!("[WARN] create_security_findings failed: {}", e); }
+        if let Err(e) = repo.create_log(&log).await {
+            eprintln!("[WARN] create_log failed: {}", e);
+        }
+        if let Err(e) = repo
+            .create_security_findings(
+                &log_id,
+                &security_result.findings,
+                security_result.action.as_str(),
+            )
+            .await
+        {
+            eprintln!("[WARN] create_security_findings failed: {}", e);
+        }
         let err_body = serde_json::json!({"error": {"message": security_result.summary, "type": "security_blocked", "code": "security.blocked"}});
         return (StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS, Json(err_body)).into_response();
     }
     let channels = match repo.get_enabled_channels().await {
         Ok(c) => c,
-        Err(_) => return (StatusCode::SERVICE_UNAVAILABLE, "No channels available").into_response(),
+        Err(_) => {
+            return (StatusCode::SERVICE_UNAVAILABLE, "No channels available").into_response()
+        }
     };
 
     let selected_channels = Dispatcher::select_channels(&channels, &model);
@@ -445,8 +506,19 @@ async fn handle_stream(
                     trace_id: trace_id.clone(),
                 };
                 let log_id = log.id.clone();
-                if let Err(e) = repo.create_log(&log).await { eprintln!("[WARN] create_log failed: {}", e); }
-                if let Err(e) = repo.create_security_findings(&log_id, &security_result.findings, security_result.action.as_str()).await { eprintln!("[WARN] create_security_findings failed: {}", e); }
+                if let Err(e) = repo.create_log(&log).await {
+                    eprintln!("[WARN] create_log failed: {}", e);
+                }
+                if let Err(e) = repo
+                    .create_security_findings(
+                        &log_id,
+                        &security_result.findings,
+                        security_result.action.as_str(),
+                    )
+                    .await
+                {
+                    eprintln!("[WARN] create_security_findings failed: {}", e);
+                }
                 last_error = Some(format!("{}: {}", channel.name, error_message));
             }
         }
@@ -471,7 +543,758 @@ async fn handle_stream(
 // For Claude-type channels: forward natively (Anthropic format).
 // For other channels: convert Anthropic → OpenAI → upstream → OpenAI → Anthropic.
 
+fn anthropic_error(status: StatusCode, kind: &str, message: impl Into<String>) -> Response {
+    (
+        status,
+        Json(serde_json::json!({"type":"error", "error":{"type":kind, "message":message.into()}})),
+    )
+        .into_response()
+}
+
+fn mapped_anthropic_body(
+    body: &serde_json::Value,
+    mapping: &serde_json::Value,
+) -> serde_json::Value {
+    let mut body = body.clone();
+    if let Some(model) = body.get("model").and_then(|value| value.as_str()) {
+        if let Some(mapped) = mapping.get(model).and_then(|value| value.as_str()) {
+            body["model"] = serde_json::Value::String(mapped.to_string());
+        }
+    }
+    body
+}
+
+fn is_native_anthropic_channel(channel_type: &str) -> bool {
+    channel_type == "claude"
+}
+
+fn is_unsafe_proxy_header(name: &str) -> bool {
+    // RFC 9110 hop-by-hop fields and credentials belonging to the *client*
+    // must never cross the gateway boundary.  Everything else is deliberately
+    // forwarded so future Anthropic end-to-end headers keep working.
+    matches!(name,
+        "authorization" | "proxy-authorization" | "x-api-key" | "cookie" | "set-cookie"
+            | "host" | "connection" | "keep-alive" | "proxy-authenticate" | "te"
+            | "trailer" | "transfer-encoding" | "upgrade" | "content-length" | "content-type"
+            | "expect" | "wali-trace-id"
+    )
+}
+
+fn forwarded_anthropic_headers(
+    headers: &HeaderMap,
+) -> Vec<(axum::http::HeaderName, axum::http::HeaderValue)> {
+    headers
+        .iter()
+        .filter_map(|(name, value)| {
+            (!is_unsafe_proxy_header(name.as_str())).then(|| (name.clone(), value.clone()))
+        })
+        .collect()
+}
+
+fn valuable_anthropic_response_headers(
+    headers: &reqwest::header::HeaderMap,
+) -> Vec<(axum::http::HeaderName, axum::http::HeaderValue)> {
+    headers
+        .iter()
+        .filter_map(|(name, value)| {
+            (!is_unsafe_proxy_header(name.as_str())).then(|| (name.clone(), value.clone()))
+        })
+        .collect()
+}
+
+async fn native_anthropic_request(
+    config: &crate::adaptor::ChannelConfig,
+    headers: &HeaderMap,
+    body: &serde_json::Value,
+    count_tokens: bool,
+    query: Option<&str>,
+) -> Result<reqwest::Response, reqwest::Error> {
+    let path = if count_tokens {
+        "messages/count_tokens"
+    } else {
+        "messages"
+    };
+    let url = native_anthropic_url(config, path, query);
+    let mut request = reqwest::Client::new()
+        .post(url)
+        .header("x-api-key", &config.api_key)
+        .header("content-type", "application/json");
+    for (name, value) in forwarded_anthropic_headers(headers) {
+        request = request.header(name, value);
+    }
+    request
+        .json(&mapped_anthropic_body(body, &config.model_mapping))
+        .send()
+        .await
+}
+
+fn native_anthropic_url(config: &crate::adaptor::ChannelConfig, path: &str, query: Option<&str>) -> String {
+    let mut url = format!("{}/{}", config.base_url.trim_end_matches('/'), path);
+    if let Some(query) = query.filter(|query| !query.is_empty()) {
+        url.push('?');
+        url.push_str(query);
+    }
+    url
+}
+
+async fn openai_messages_request(
+    config: &crate::adaptor::ChannelConfig,
+    body: &serde_json::Value,
+) -> Result<reqwest::Response, reqwest::Error> {
+    let url = format!("{}/chat/completions", config.base_url.trim_end_matches('/'));
+    reqwest::Client::new()
+        .post(url)
+        .bearer_auth(&config.api_key)
+        .header("content-type", "application/json")
+        .json(&crate::adaptor::openai::apply_model_mapping(
+            body,
+            &config.model_mapping,
+        ))
+        .send()
+        .await
+}
+
+#[derive(Clone)]
+struct StreamLogContext {
+    repo: std::sync::Arc<Repository>,
+    key: crate::db::models::ApiKey,
+    channel: crate::db::models::Channel,
+    model: String,
+    request: serde_json::Value,
+    security: security::SecurityScanResult,
+    is_stream: bool,
+}
+
+const MAX_NATIVE_SSE_RECORD_BYTES: usize = 64 * 1024;
+
+/// Incrementally extracts the cumulative usage fields from a native Anthropic
+/// SSE stream.  It deliberately retains at most one bounded record rather
+/// than every byte forwarded to the client.
+#[derive(Default)]
+struct NativeSseUsageParser {
+    pending: Vec<u8>,
+    input: Option<i64>,
+    output: Option<i64>,
+    stopped: bool,
+    malformed_or_oversized: bool,
+}
+
+impl NativeSseUsageParser {
+    fn feed(&mut self, bytes: &[u8]) {
+        if self.malformed_or_oversized { return; }
+        self.pending.extend_from_slice(bytes);
+        while let Some(end) = sse_record_end(&self.pending) {
+            let record: Vec<u8> = self.pending.drain(..end).collect();
+            self.consume_record(&record);
+        }
+        if self.pending.len() > MAX_NATIVE_SSE_RECORD_BYTES {
+            self.pending.clear();
+            self.malformed_or_oversized = true;
+        }
+    }
+
+    fn consume_record(&mut self, record: &[u8]) {
+        let Ok(text) = std::str::from_utf8(record) else { return; };
+        let data = text.lines()
+            .filter_map(|line| line.trim_end_matches('\r').strip_prefix("data:").map(|value| value.trim_start()))
+            .collect::<Vec<_>>().join("\n");
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&data) else { return; };
+        match value.get("type").and_then(|value| value.as_str()) {
+            Some("message_start") => self.input = value.pointer("/message/usage").map(anthropic_input_usage),
+            Some("message_delta") => self.output = value.pointer("/usage/output_tokens").and_then(|value| value.as_i64()),
+            Some("message_stop") => self.stopped = true,
+            _ => {}
+        }
+    }
+
+    fn finish(self) -> Option<(i64, i64)> {
+        (!self.malformed_or_oversized && self.stopped)
+            .then(|| (self.input.unwrap_or(0), self.output.unwrap_or(0)))
+    }
+}
+
+fn sse_record_end(input: &[u8]) -> Option<usize> {
+    let crlf = input.windows(4).position(|window| window == b"\r\n\r\n").map(|index| index + 4);
+    let lf = input.windows(2).position(|window| window == b"\n\n").map(|index| index + 2);
+    match (crlf, lf) {
+        (Some(crlf), Some(lf)) => Some(crlf.min(lf)),
+        (Some(end), None) | (None, Some(end)) => Some(end),
+        (None, None) => None,
+    }
+}
+
+fn native_usage(bytes: &[u8], is_sse: bool) -> Option<(i64, i64)> {
+    let text = std::str::from_utf8(bytes).ok()?;
+    if !is_sse {
+        let value: serde_json::Value = serde_json::from_str(text).ok()?;
+        let usage = value.get("usage")?;
+        return Some((anthropic_input_usage(usage), usage.get("output_tokens").and_then(|v| v.as_i64()).unwrap_or(0)));
+    }
+    let mut parser = NativeSseUsageParser::default();
+    parser.feed(text.as_bytes());
+    parser.finish()
+}
+
+fn anthropic_input_usage(usage: &serde_json::Value) -> i64 {
+    usage.get("input_tokens").and_then(|value| value.as_i64()).unwrap_or(0)
+        + usage.get("cache_creation_input_tokens").and_then(|value| value.as_i64()).unwrap_or(0)
+        + usage.get("cache_read_input_tokens").and_then(|value| value.as_i64()).unwrap_or(0)
+}
+
+fn native_response(response: reqwest::Response, accounting: Option<StreamLogContext>) -> Response {
+    let status =
+        StatusCode::from_u16(response.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+    let headers = valuable_anthropic_response_headers(response.headers());
+    let content_type = response.headers().get(header::CONTENT_TYPE).cloned();
+    let is_sse = content_type.as_ref().and_then(|value| value.to_str().ok()).is_some_and(|value| value.starts_with("text/event-stream"));
+    let upstream = response.bytes_stream();
+    let stream = async_stream::stream! {
+        tokio::pin!(upstream);
+        let mut usage_parser = NativeSseUsageParser::default();
+        // A non-streaming Messages response is a small JSON object in normal
+        // operation.  Keep a hard cap for accounting so a malicious upstream
+        // can never turn the proxy into an unbounded collector.
+        let mut non_sse_observed = Vec::new();
+        let mut completed = true;
+        while let Some(item) = upstream.next().await {
+            match item {
+                Ok(bytes) => {
+                    if is_sse {
+                        usage_parser.feed(&bytes);
+                    } else if non_sse_observed.len().saturating_add(bytes.len()) <= MAX_NATIVE_SSE_RECORD_BYTES {
+                        non_sse_observed.extend_from_slice(&bytes);
+                    }
+                    yield Ok::<_, std::io::Error>(bytes);
+                }
+                Err(error) => { completed = false; yield Err::<bytes::Bytes, _>(std::io::Error::other(error)); break; }
+            }
+        }
+        if let Some(context) = accounting {
+            if completed {
+                let usage = if is_sse { usage_parser.finish() } else { native_usage(&non_sse_observed, false) };
+                if let Some(usage) = usage {
+                    record_anthropic_success(context.repo, &context.key, &context.channel, &context.model, &context.request, &context.security, context.is_stream, Some(usage)).await;
+                }
+            }
+        }
+    };
+    let mut builder = Response::builder().status(status);
+    if let Some(content_type) = content_type {
+        builder = builder.header(header::CONTENT_TYPE, content_type);
+    }
+    for (name, value) in headers {
+        builder = builder.header(name, value);
+    }
+    builder.body(Body::from_stream(stream)).unwrap_or_else(|_| {
+        anthropic_error(
+            StatusCode::BAD_GATEWAY,
+            "api_error",
+            "Unable to proxy native Anthropic response",
+        )
+    })
+}
+
+struct StoredNativeError {
+    status: StatusCode,
+    content_type: Option<axum::http::HeaderValue>,
+    headers: Vec<(axum::http::HeaderName, axum::http::HeaderValue)>,
+    body: bytes::Bytes,
+}
+
+async fn store_native_error(response: reqwest::Response) -> StoredNativeError {
+    let status = StatusCode::from_u16(response.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+    let content_type = response.headers().get(header::CONTENT_TYPE).cloned();
+    let headers = valuable_anthropic_response_headers(response.headers());
+    let body = response.bytes().await.unwrap_or_default();
+    StoredNativeError { status, content_type, headers, body }
+}
+
+fn stored_native_response(error: StoredNativeError) -> Response {
+    let mut builder = Response::builder().status(error.status);
+    if let Some(content_type) = error.content_type { builder = builder.header(header::CONTENT_TYPE, content_type); }
+    for (name, value) in error.headers { builder = builder.header(name, value); }
+    builder.body(Body::from(error.body)).unwrap_or_else(|_| anthropic_error(StatusCode::BAD_GATEWAY, "api_error", "Unable to proxy native Anthropic response"))
+}
+
+fn retryable_upstream_status(status: StatusCode) -> bool {
+    matches!(status.as_u16(), 408 | 409 | 429 | 529) || status.is_server_error()
+}
+
+fn openai_error_response(status: StatusCode, message: &str, headers: &reqwest::header::HeaderMap) -> Response {
+    // Upstream credentials belong to the gateway. Do not report an upstream
+    // 401/403 as though the Claude Code caller supplied a bad local key.
+    let (downstream_status, kind) = match status.as_u16() {
+        429 => (StatusCode::TOO_MANY_REQUESTS, "rate_limit_error"),
+        400 | 404 | 408 | 409 | 422 => (status, "invalid_request_error"),
+        _ => (StatusCode::BAD_GATEWAY, "api_error"),
+    };
+    let mut response = anthropic_error(downstream_status, kind, message);
+    if let Some(retry_after) = headers.get("retry-after") {
+        response.headers_mut().insert(header::RETRY_AFTER, retry_after.clone());
+    }
+    response
+}
+
+fn sanitized_anthropic_log_body(request: &serde_json::Value) -> (Option<String>, bool) {
+    let redacted = security::redact::redact_json_for_logging(request);
+    let sanitized = redacted != *request;
+    (serde_json::to_string(&redacted).ok(), sanitized)
+}
+
+async fn record_anthropic_outcome(
+    repo: std::sync::Arc<Repository>,
+    key: &crate::db::models::ApiKey,
+    channel: Option<&crate::db::models::Channel>,
+    model: &str,
+    request: &serde_json::Value,
+    security_result: &security::SecurityScanResult,
+    is_stream: bool,
+    status_code: i64,
+    error_message: Option<String>,
+    usage: Option<(i64, i64)>,
+) {
+    let (prompt_tokens, completion_tokens) = usage.unwrap_or((0, 0));
+    let total_tokens = prompt_tokens + completion_tokens;
+    let (request_body, log_sanitized) = sanitized_anthropic_log_body(request);
+    let log = crate::db::models::RequestLog {
+        id: crate::utils::id::new_id(), seq: None, api_key_id: Some(key.id.clone()), api_key_name: Some(key.name.clone()),
+        channel_id: channel.map(|channel| channel.id.clone()), channel_name: channel.map(|channel| channel.name.clone()), model: model.to_string(), upstream_model: None,
+        mode: "anthropic".to_string(), status_code, prompt_tokens, completion_tokens, total_tokens, duration_ms: 0,
+        error_message, is_stream: i64::from(is_stream), is_retry: 0, created_at: crate::utils::time::now_iso(),
+        request_body, response_choices: None, risk_level: security_result.risk_level.as_str().to_string(), risk_score: security_result.risk_score as i64,
+        risk_summary: Some(security_result.summary.clone()), security_action: security_result.action.as_str().to_string(), sanitized: i64::from(log_sanitized || security_result.sanitized), blocked_reason: security_result.blocked_reason.clone(), trace_id: None,
+    };
+    let log_id = log.id.clone();
+    let _ = repo.create_log(&log).await;
+    let _ = repo.create_security_findings(&log_id, &security_result.findings, security_result.action.as_str()).await;
+    if total_tokens > 0 { let _ = repo.increment_quota(&key.id, total_tokens).await; }
+}
+
+async fn record_anthropic_success(repo: std::sync::Arc<Repository>, key: &crate::db::models::ApiKey, channel: &crate::db::models::Channel, model: &str, request: &serde_json::Value, security_result: &security::SecurityScanResult, is_stream: bool, usage: Option<(i64, i64)>) {
+    record_anthropic_outcome(repo, key, Some(channel), model, request, security_result, is_stream, 200, None, usage).await;
+}
+
+/// Anthropic Messages compatibility endpoint.
+///
+/// Channel selection is performed before any format conversion. Claude channels
+/// receive the original request and native response bytes; every other channel
+/// is the explicit OpenAI Chat Completions compatibility path.
 pub async fn handle_messages(
+    State(shared): State<SharedState>,
+    OriginalUri(uri): OriginalUri,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> Response {
+    let json: serde_json::Value = match serde_json::from_slice(&body) {
+        Ok(value) => value,
+        Err(error) => {
+            return anthropic_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request_error",
+                format!("Invalid JSON: {error}"),
+            )
+        }
+    };
+    let api_key = match protocol::extract_api_key(&headers) {
+        Some(key) => key,
+        None => {
+            return anthropic_error(
+                StatusCode::UNAUTHORIZED,
+                "authentication_error",
+                "Missing API key",
+            )
+        }
+    };
+    let repo = std::sync::Arc::new(Repository::new(shared.state.db.pool.clone()));
+    let key = match repo.get_api_key_by_key(&api_key).await {
+        Ok(key) => key,
+        Err(_) => {
+            return anthropic_error(
+                StatusCode::UNAUTHORIZED,
+                "authentication_error",
+                "Invalid API key",
+            )
+        }
+    };
+    if key.quota_limit > 0 && key.quota_used >= key.quota_limit {
+        return anthropic_error(
+            StatusCode::TOO_MANY_REQUESTS,
+            "rate_limit_error",
+            "Quota exceeded",
+        );
+    }
+    let model = match json
+        .get("model")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+    {
+        Some(model) => model.to_string(),
+        None => {
+            return anthropic_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request_error",
+                "model is required",
+            )
+        }
+    };
+    let stream = json
+        .get("stream")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+    let security_settings = security::get_security_settings(&shared.app);
+    let mut security_result = security::scan_request(&json, &security_settings);
+    if matches!(security_result.action, security::SecurityAction::Block) {
+        record_anthropic_outcome(repo.clone(), &key, None, &model, &json, &security_result, stream, 451, security_result.blocked_reason.clone(), None).await;
+        return anthropic_error(StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS, "api_error", security_result.summary);
+    }
+    let (forward_json, was_redacted) = if matches!(security_result.action, security::SecurityAction::Redact) || security_settings.redact_secrets {
+        security::redact_request_body(&json, &security_settings)
+    } else { (json.clone(), false) };
+    security_result.sanitized |= was_redacted;
+    let channels = match repo.get_enabled_channels().await {
+        Ok(channels) => channels,
+        Err(_) => {
+            return anthropic_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "api_error",
+                "No channels available",
+            )
+        }
+    };
+    let mut selected = Dispatcher::select_channels(&channels, &model);
+    // A native channel preserves all current and future Anthropic features, so
+    // prefer it before entering the intentionally smaller Chat codec.
+    selected.sort_by_key(|channel| !is_native_anthropic_channel(&channel.channel_type));
+    if selected.is_empty() {
+        return anthropic_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "api_error",
+            format!("No channel for model: {model}"),
+        );
+    }
+    let (retry_enabled, retry_times) = proxy::get_retry_settings(&shared.app);
+    let max_attempts = if retry_enabled {
+        (retry_times.max(0) as usize + 1).min(selected.len())
+    } else {
+        1
+    };
+    let mut last_error = "unknown upstream error".to_string();
+    let mut last_native_error = None;
+    let mut last_openai_error: Option<(StatusCode, String, reqwest::header::HeaderMap)> = None;
+    let mut upstream_attempts = 0usize;
+
+    for channel in selected {
+        let config = Dispatcher::channel_to_config(&channel);
+        if is_native_anthropic_channel(&channel.channel_type) {
+            if upstream_attempts >= max_attempts { break; }
+            upstream_attempts += 1;
+            match native_anthropic_request(&config, &headers, &forward_json, false, uri.query()).await {
+                Ok(response) if response.status().is_success() => {
+                    return native_response(response, Some(StreamLogContext { repo: repo.clone(), key: key.clone(), channel: channel.clone(), model: model.clone(), request: json.clone(), security: security_result.clone(), is_stream: stream }))
+                },
+                Ok(response) => {
+                    let status = StatusCode::from_u16(response.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+                    if !retryable_upstream_status(status) {
+                        record_anthropic_outcome(repo.clone(), &key, Some(&channel), &model, &json, &security_result, stream, status.as_u16() as i64, Some(format!("Native upstream returned HTTP {status}")), None).await;
+                        return native_response(response, None);
+                    }
+                    last_error = format!("{}: HTTP {}", channel.name, status);
+                    last_native_error = Some(store_native_error(response).await);
+                }
+                Err(error) => {
+                    last_error = format!("{}: {error}", channel.name);
+                    record_anthropic_outcome(repo.clone(), &key, Some(&channel), &model, &json, &security_result, stream, 502, Some(last_error.clone()), None).await;
+                },
+            }
+            continue;
+        }
+
+        let openai_body = match protocol::anthropic_to_openai(&forward_json) {
+            Ok(value) => value,
+            Err(message) => {
+                last_error = format!("{}: incompatible with OpenAI Chat Completions: {message}", channel.name);
+                continue;
+            }
+        };
+        if upstream_attempts >= max_attempts { break; }
+        upstream_attempts += 1;
+        match openai_messages_request(&config, &openai_body).await {
+            Ok(response) if response.status().is_success() && stream => {
+                return openai_sse_response(response, &model, StreamLogContext { repo: repo.clone(), key: key.clone(), channel: channel.clone(), model: model.clone(), request: json.clone(), security: security_result.clone(), is_stream: true })
+            }
+            Ok(response) if response.status().is_success() => {
+                let body: serde_json::Value = match response.json().await {
+                    Ok(value) => value,
+                    Err(error) => {
+                        last_error = format!("{}: {error}", channel.name);
+                        // A successful HTTP response that cannot be decoded is
+                        // not an upstream attempt for failover purposes.
+                        upstream_attempts = upstream_attempts.saturating_sub(1);
+                        continue;
+                    }
+                };
+                return match protocol::openai_to_anthropic(&body, &model) {
+                    Ok(value) => {
+                        let usage = Some((body.pointer("/usage/prompt_tokens").and_then(|value| value.as_i64()).unwrap_or(0), body.pointer("/usage/completion_tokens").and_then(|value| value.as_i64()).unwrap_or(0)));
+                        record_anthropic_success(repo.clone(), &key, &channel, &model, &json, &security_result, false, usage).await;
+                        (StatusCode::OK, Json(value)).into_response()
+                    },
+                    Err(message) => {
+                        // A 200 transport response is not a usable channel if
+                        // its tool arguments/content cannot satisfy Messages.
+                        last_error = format!("{}: conversion failed: {message}", channel.name);
+                        record_anthropic_outcome(repo.clone(), &key, Some(&channel), &model, &json, &security_result, false, 502, Some(message), None).await;
+                        upstream_attempts = upstream_attempts.saturating_sub(1);
+                        continue;
+                    },
+                };
+            }
+            Ok(response) => {
+                let status = StatusCode::from_u16(response.status().as_u16())
+                    .unwrap_or(StatusCode::BAD_GATEWAY);
+                let response_headers = response.headers().clone();
+                let upstream: serde_json::Value =
+                    response.json().await.unwrap_or(serde_json::Value::Null);
+                let message = upstream
+                    .pointer("/error/message")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("OpenAI Chat Completions upstream rejected the request");
+                last_error = format!("{}: {message}", channel.name);
+                if !retryable_upstream_status(status) {
+                    record_anthropic_outcome(repo.clone(), &key, Some(&channel), &model, &json, &security_result, stream, status.as_u16() as i64, Some(last_error.clone()), None).await;
+                    return openai_error_response(status, message, &response_headers);
+                }
+                last_openai_error = Some((status, message.to_string(), response_headers));
+            }
+            Err(error) => {
+                last_error = format!("{}: {error}", channel.name);
+                record_anthropic_outcome(repo.clone(), &key, Some(&channel), &model, &json, &security_result, stream, 502, Some(last_error.clone()), None).await;
+            },
+        }
+    }
+    if let Some((status, message, headers)) = last_openai_error {
+        return openai_error_response(status, &message, &headers);
+    }
+    if let Some(response) = last_native_error { return stored_native_response(response); }
+    if last_error.contains("incompatible with OpenAI Chat Completions") {
+        record_anthropic_outcome(repo.clone(), &key, None, &model, &json, &security_result, stream, 400, Some(last_error.clone()), None).await;
+        return anthropic_error(StatusCode::BAD_REQUEST, "invalid_request_error", last_error);
+    }
+    record_anthropic_outcome(repo.clone(), &key, None, &model, &json, &security_result, stream, 502, Some(last_error.clone()), None).await;
+    anthropic_error(
+        StatusCode::BAD_GATEWAY,
+        "api_error",
+        format!("All channels failed for model {model}: {last_error}"),
+    )
+}
+
+fn openai_sse_response(response: reqwest::Response, model: &str, accounting: StreamLogContext) -> Response {
+    let model = model.to_string();
+    let message_id = format!("msg_{}", uuid::Uuid::new_v4().simple());
+    let upstream = response.bytes_stream();
+    let stream = async_stream::stream! {
+        tokio::pin!(upstream);
+        let mut state = crate::protocol::anthropic::AnthropicStreamState::default();
+        let mut failed = false;
+        while let Some(chunk) = upstream.next().await {
+            match chunk {
+                Ok(bytes) => match state.feed(&bytes, &model, &message_id) {
+                    Ok(events) => for event in events { yield Ok::<_, std::io::Error>(bytes::Bytes::from(event.into_bytes())); },
+                    Err(message) => {
+                        failed = true;
+                        record_anthropic_outcome(accounting.repo.clone(), &accounting.key, Some(&accounting.channel), &accounting.model, &accounting.request, &accounting.security, true, 502, Some(format!("OpenAI stream conversion failed: {message}")), None).await;
+                        yield Ok::<_, std::io::Error>(bytes::Bytes::from(format!("event: error\ndata: {{\"type\":\"error\",\"error\":{{\"type\":\"api_error\",\"message\":{}}}}}\n\n", serde_json::to_string(&message).unwrap()).into_bytes()));
+                        break;
+                    }
+                },
+                Err(error) => {
+                    failed = true;
+                    let message = format!("OpenAI stream interrupted: {error}");
+                    record_anthropic_outcome(accounting.repo.clone(), &accounting.key, Some(&accounting.channel), &accounting.model, &accounting.request, &accounting.security, true, 502, Some(message.clone()), None).await;
+                    yield Ok::<_, std::io::Error>(bytes::Bytes::from(format!("event: error\ndata: {{\"type\":\"error\",\"error\":{{\"type\":\"api_error\",\"message\":{}}}}}\n\n", serde_json::to_string(&message).unwrap()).into_bytes()));
+                    break;
+                }
+            }
+        }
+        if !failed {
+            match state.finish(&model, &message_id) {
+                Ok(events) => {
+                    for event in events { yield Ok::<_, std::io::Error>(bytes::Bytes::from(event.into_bytes())); }
+                    let usage = state.usage();
+                    record_anthropic_success(accounting.repo, &accounting.key, &accounting.channel, &accounting.model, &accounting.request, &accounting.security, true, Some(usage)).await;
+                },
+                Err(message) => {
+                    record_anthropic_outcome(accounting.repo.clone(), &accounting.key, Some(&accounting.channel), &accounting.model, &accounting.request, &accounting.security, true, 502, Some(format!("OpenAI stream conversion failed: {message}")), None).await;
+                    yield Ok::<_, std::io::Error>(bytes::Bytes::from(format!("event: error\ndata: {{\"type\":\"error\",\"error\":{{\"type\":\"api_error\",\"message\":{}}}}}\n\n", serde_json::to_string(&message).unwrap()).into_bytes()))
+                },
+            }
+        }
+    };
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/event-stream")
+        .header(header::CACHE_CONTROL, "no-cache")
+        .body(Body::from_stream(stream))
+        .unwrap()
+}
+
+#[cfg(test)]
+mod anthropic_handler_tests {
+    use super::*;
+
+    #[test]
+    fn native_forwarding_keeps_anthropic_headers_and_only_maps_model() {
+        let mut headers = HeaderMap::new();
+        headers.insert("anthropic-version", "2023-06-01".parse().unwrap());
+        headers.insert("anthropic-beta", "prompt-caching".parse().unwrap());
+        headers.insert("x-api-key", "local-only-key".parse().unwrap());
+        headers.insert("authorization", "Bearer caller-secret".parse().unwrap());
+        headers.insert("cookie", "session=caller-secret".parse().unwrap());
+        headers.insert("x-anthropic-future-feature", "on".parse().unwrap());
+        let kept = forwarded_anthropic_headers(&headers);
+        assert!(kept.iter().any(|(name, _)| name == "anthropic-version"));
+        assert!(kept.iter().any(|(name, _)| name == "anthropic-beta"));
+        assert!(kept.iter().any(|(name, _)| name == "x-anthropic-future-feature"));
+        assert!(!kept.iter().any(|(name, _)| name == "x-api-key" || name == "authorization" || name == "cookie"));
+        let body = serde_json::json!({"model":"public-model", "system":[{"type":"thinking"}], "messages":[]});
+        let mapped =
+            mapped_anthropic_body(&body, &serde_json::json!({"public-model":"upstream-model"}));
+        assert_eq!(mapped["model"], "upstream-model");
+        assert_eq!(mapped["system"], body["system"]);
+        assert!(is_native_anthropic_channel("claude"));
+    }
+
+    #[tokio::test]
+    async fn maps_openai_rate_limits_without_exposing_channel_auth_as_client_auth() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert("retry-after", "17".parse().unwrap());
+        let rate_limited = openai_error_response(StatusCode::TOO_MANY_REQUESTS, "slow down", &headers);
+        assert_eq!(rate_limited.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(rate_limited.headers()[header::RETRY_AFTER], "17");
+        let rate_body = axum::body::to_bytes(rate_limited.into_body(), usize::MAX).await.unwrap();
+        assert!(std::str::from_utf8(&rate_body).unwrap().contains("rate_limit_error"));
+
+        let auth_failed = openai_error_response(StatusCode::UNAUTHORIZED, "upstream key rejected", &reqwest::header::HeaderMap::new());
+        assert_eq!(auth_failed.status(), StatusCode::BAD_GATEWAY);
+        let auth_body = axum::body::to_bytes(auth_failed.into_body(), usize::MAX).await.unwrap();
+        assert!(std::str::from_utf8(&auth_body).unwrap().contains("api_error"));
+    }
+
+    #[test]
+    fn reads_native_message_and_sse_usage_without_changing_payload() {
+        assert_eq!(native_usage(br#"{"usage":{"input_tokens":12,"output_tokens":4}}"#, false), Some((12, 4)));
+        let sse = b"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":12,\"cache_creation_input_tokens\":2,\"cache_read_input_tokens\":3}}}\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":4}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
+        assert_eq!(native_usage(sse, true), Some((17, 4)));
+        assert_eq!(native_usage(&sse[..sse.len() - 48], true), None);
+
+        let mut incremental = NativeSseUsageParser::default();
+        for piece in sse.chunks(7) { incremental.feed(piece); }
+        assert_eq!(incremental.finish(), Some((17, 4)));
+        let mut oversized = NativeSseUsageParser::default();
+        oversized.feed(&vec![b'x'; MAX_NATIVE_SSE_RECORD_BYTES + 1]);
+        assert!(oversized.finish().is_none());
+    }
+
+    #[test]
+    fn preserves_query_beta_for_both_native_message_paths() {
+        let config = crate::adaptor::ChannelConfig {
+            base_url: "https://upstream.example/v1/".to_string(), api_key: "key".to_string(), models: vec![], model_mapping: serde_json::json!({}), extra: serde_json::json!({}),
+        };
+        assert_eq!(native_anthropic_url(&config, "messages", Some("beta=true")), "https://upstream.example/v1/messages?beta=true");
+        assert_eq!(native_anthropic_url(&config, "messages/count_tokens", Some("beta=true")), "https://upstream.example/v1/messages/count_tokens?beta=true");
+    }
+
+    #[test]
+    fn always_redacts_log_body_even_when_forwarding_redaction_is_off() {
+        let request = serde_json::json!({"messages":[{"role":"user","content":"sk-abcdefghijklmnopqrstuvwx123456"}]});
+        let (body, sanitized) = sanitized_anthropic_log_body(&request);
+        assert!(sanitized);
+        assert!(!body.unwrap().contains("abcdefghijklmnopqrstuvwx"));
+    }
+}
+
+/// Claude Code calls this endpoint while constructing context.  Exact counts
+/// are only available from a native Anthropic channel; returning characters/4
+/// would falsely advertise precision.
+pub async fn handle_messages_count_tokens(
+    State(shared): State<SharedState>,
+    OriginalUri(uri): OriginalUri,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> Response {
+    let json: serde_json::Value = match serde_json::from_slice(&body) {
+        Ok(value) => value,
+        Err(error) => {
+            return anthropic_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request_error",
+                format!("Invalid JSON: {error}"),
+            )
+        }
+    };
+    let api_key = match protocol::extract_api_key(&headers) {
+        Some(key) => key,
+        None => {
+            return anthropic_error(
+                StatusCode::UNAUTHORIZED,
+                "authentication_error",
+                "Missing API key",
+            )
+        }
+    };
+    let repo = std::sync::Arc::new(Repository::new(shared.state.db.pool.clone()));
+    let key = match repo.get_api_key_by_key(&api_key).await {
+        Ok(key) => key,
+        Err(_) => return anthropic_error(StatusCode::UNAUTHORIZED, "authentication_error", "Invalid API key"),
+    };
+    let model = match json.get("model").and_then(|value| value.as_str()) {
+        Some(model) => model,
+        None => {
+            return anthropic_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request_error",
+                "model is required",
+            )
+        }
+    };
+    let security_settings = security::get_security_settings(&shared.app);
+    let security_result = security::scan_request(&json, &security_settings);
+    if matches!(security_result.action, security::SecurityAction::Block) {
+        record_anthropic_outcome(repo.clone(), &key, None, model, &json, &security_result, false, 451, security_result.blocked_reason.clone(), None).await;
+        return anthropic_error(StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS, "api_error", security_result.summary);
+    }
+    let channels = match repo.get_enabled_channels().await {
+        Ok(channels) => channels,
+        Err(_) => {
+            return anthropic_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "api_error",
+                "No channels available",
+            )
+        }
+    };
+    let native_channels: Vec<_> = Dispatcher::select_channels(&channels, model).into_iter().filter(|channel| is_native_anthropic_channel(&channel.channel_type)).collect();
+    let (retry_enabled, retry_times) = proxy::get_retry_settings(&shared.app);
+    let max_attempts = if retry_enabled { (retry_times.max(0) as usize + 1).min(native_channels.len()) } else { native_channels.len().min(1) };
+    let mut last_error = None;
+    for channel in native_channels.into_iter().take(max_attempts) {
+        let config = Dispatcher::channel_to_config(&channel);
+        match native_anthropic_request(&config, &headers, &json, true, uri.query()).await {
+            Ok(response) if response.status().is_success() => return native_response(response, None),
+            Ok(response) => {
+                let status = StatusCode::from_u16(response.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+                if !retryable_upstream_status(status) { return native_response(response, None); }
+                last_error = Some(store_native_error(response).await);
+            }
+            Err(_) => continue,
+        }
+    }
+    if let Some(response) = last_error { return stored_native_response(response); }
+    record_anthropic_outcome(repo, &key, None, model, &json, &security_result, false, 501, Some("Exact Anthropic count_tokens is unavailable without a native Anthropic channel".to_string()), None).await;
+    anthropic_error(StatusCode::NOT_IMPLEMENTED, "api_error", "Exact Anthropic count_tokens requires a native Anthropic Messages channel")
+}
+
+pub async fn handle_messages_legacy(
     State(shared): State<SharedState>,
     headers: HeaderMap,
     body: axum::body::Bytes,
@@ -482,60 +1305,143 @@ pub async fn handle_messages(
         Err(e) => return (StatusCode::BAD_REQUEST, format!("Invalid JSON: {}", e)).into_response(),
     };
 
-    let is_stream = json.get("stream").and_then(|s| s.as_bool()).unwrap_or(false);
+    let is_stream = json
+        .get("stream")
+        .and_then(|s| s.as_bool())
+        .unwrap_or(false);
 
     // Extract API key from x-api-key header or Authorization Bearer
     let api_key = match protocol::extract_api_key(&headers) {
         Some(k) => k,
         None => {
-            return (StatusCode::UNAUTHORIZED, Json(serde_json::json!({
-                "type": "error",
-                "error": {"type": "authentication_error", "message": "Missing API key"}
-            }))).into_response();
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({
+                    "type": "error",
+                    "error": {"type": "authentication_error", "message": "Missing API key"}
+                })),
+            )
+                .into_response();
         }
     };
 
     let repo = std::sync::Arc::new(Repository::new(shared.state.db.pool.clone()));
     let key_record = match repo.get_api_key_by_key(&api_key).await {
         Ok(k) => k,
-        Err(_) => return (StatusCode::UNAUTHORIZED, Json(serde_json::json!({
-            "type": "error",
-            "error": {"type": "authentication_error", "message": "Invalid API key"}
-        }))).into_response(),
+        Err(_) => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({
+                    "type": "error",
+                    "error": {"type": "authentication_error", "message": "Invalid API key"}
+                })),
+            )
+                .into_response()
+        }
     };
 
     if key_record.quota_limit > 0 && key_record.quota_used >= key_record.quota_limit {
-        return (StatusCode::TOO_MANY_REQUESTS, Json(serde_json::json!({
-            "type": "error",
-            "error": {"type": "rate_limit_error", "message": "Quota exceeded"}
-        }))).into_response();
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(serde_json::json!({
+                "type": "error",
+                "error": {"type": "rate_limit_error", "message": "Quota exceeded"}
+            })),
+        )
+            .into_response();
     }
 
-    let trace_id = headers.get("Wali-Trace-Id").and_then(|h| h.to_str().ok()).map(|s| s.to_string());
+    let trace_id = headers
+        .get("Wali-Trace-Id")
+        .and_then(|h| h.to_str().ok())
+        .map(|s| s.to_string());
     let request_body_str = serde_json::to_string(&json).unwrap_or_default();
-    let model = json.get("model").and_then(|m| m.as_str()).unwrap_or("").to_string();
+    let model = json
+        .get("model")
+        .and_then(|m| m.as_str())
+        .unwrap_or("")
+        .to_string();
 
     // Convert Anthropic request to OpenAI format for internal proxy
-    let openai_body = protocol::anthropic_to_openai(&json);
+    let openai_body = match protocol::anthropic_to_openai(&json) {
+        Ok(value) => value,
+        Err(message) => {
+            return anthropic_error(StatusCode::BAD_REQUEST, "invalid_request_error", message)
+        }
+    };
 
     if is_stream {
-        handle_messages_stream(shared, openai_body, model, key_record.id, key_record.name, request_body_str, trace_id).await
+        handle_messages_stream(
+            shared,
+            openai_body,
+            model,
+            key_record.id,
+            key_record.name,
+            request_body_str,
+            trace_id,
+        )
+        .await
     } else {
-        match proxy::handle_request(&repo, &shared.app, &key_record.id, &key_record.name, openai_body, false, Some(request_body_str), trace_id).await {
+        match proxy::handle_request(
+            &repo,
+            &shared.app,
+            &key_record.id,
+            &key_record.name,
+            openai_body,
+            false,
+            Some(request_body_str),
+            trace_id,
+        )
+        .await
+        {
             Ok(result) => {
                 // Convert OpenAI response back to Anthropic format
-                let anthropic_resp = protocol::openai_to_anthropic(&result.body, &result.channel.channel_type);
-                (StatusCode::OK, Json(anthropic_resp)).into_response()
+                match protocol::openai_to_anthropic(&result.body, &model) {
+                    Ok(anthropic_resp) => (StatusCode::OK, Json(anthropic_resp)).into_response(),
+                    Err(message) => anthropic_error(StatusCode::BAD_GATEWAY, "api_error", message),
+                }
             }
             Err((code, msg)) => {
                 let err_body = serde_json::json!({
                     "type": "error",
                     "error": {"type": "api_error", "message": msg}
                 });
-                (StatusCode::from_u16(code).unwrap_or(StatusCode::BAD_GATEWAY), Json(err_body)).into_response()
+                (
+                    StatusCode::from_u16(code).unwrap_or(StatusCode::BAD_GATEWAY),
+                    Json(err_body),
+                )
+                    .into_response()
             }
         }
     }
+}
+
+/// Optional Anthropic endpoint used by Claude Code for context estimation.
+pub async fn handle_messages_count_tokens_legacy(
+    State(shared): State<SharedState>,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> Response {
+    let json: serde_json::Value = match serde_json::from_slice(&body) {
+        Ok(value) => value,
+        Err(error) => return (StatusCode::BAD_REQUEST, Json(serde_json::json!({
+            "type": "error", "error": {"type": "invalid_request_error", "message": format!("Invalid JSON: {}", error)}
+        }))).into_response(),
+    };
+    let api_key = match protocol::extract_api_key(&headers) {
+        Some(key) => key,
+        None => return (StatusCode::UNAUTHORIZED, Json(serde_json::json!({
+            "type": "error", "error": {"type": "authentication_error", "message": "Missing API key"}
+        }))).into_response(),
+    };
+    let repo = Repository::new(shared.state.db.pool.clone());
+    if repo.get_api_key_by_key(&api_key).await.is_err() {
+        return (StatusCode::UNAUTHORIZED, Json(serde_json::json!({
+            "type": "error", "error": {"type": "authentication_error", "message": "Invalid API key"}
+        }))).into_response();
+    }
+    Json(serde_json::json!({"input_tokens": protocol::estimate_anthropic_input_tokens(&json)}))
+        .into_response()
 }
 
 /// Stream handler for Anthropic Messages API.
@@ -552,11 +1458,14 @@ async fn handle_messages_stream(
     let security_settings = security::get_security_settings(&shared.app);
     let security_result = security::scan_request(&openai_body, &security_settings);
 
-    let (forward_json, was_redacted) = if matches!(security_result.action, security::SecurityAction::Redact) || security_settings.redact_secrets {
-        security::redact_request_body(&openai_body, &security_settings)
-    } else {
-        (openai_body.clone(), false)
-    };
+    let (forward_json, was_redacted) =
+        if matches!(security_result.action, security::SecurityAction::Redact)
+            || security_settings.redact_secrets
+        {
+            security::redact_request_body(&openai_body, &security_settings)
+        } else {
+            (openai_body.clone(), false)
+        };
     let mut security_result = security_result;
     if was_redacted {
         security_result.sanitized = true;
@@ -595,17 +1504,32 @@ async fn handle_messages_stream(
             trace_id: trace_id.clone(),
         };
         let log_id = log.id.clone();
-        if let Err(e) = repo.create_log(&log).await { eprintln!("[WARN] create_log failed: {}", e); }
-        if let Err(e) = repo.create_security_findings(&log_id, &security_result.findings, security_result.action.as_str()).await { eprintln!("[WARN] create_security_findings failed: {}", e); }
+        if let Err(e) = repo.create_log(&log).await {
+            eprintln!("[WARN] create_log failed: {}", e);
+        }
+        if let Err(e) = repo
+            .create_security_findings(
+                &log_id,
+                &security_result.findings,
+                security_result.action.as_str(),
+            )
+            .await
+        {
+            eprintln!("[WARN] create_security_findings failed: {}", e);
+        }
         let err_body = serde_json::json!({"type": "error", "error": {"type": "api_error", "message": security_result.summary}});
         return (StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS, Json(err_body)).into_response();
     }
 
     let channels = match repo.get_enabled_channels().await {
         Ok(c) => c,
-        Err(_) => return (StatusCode::SERVICE_UNAVAILABLE, Json(serde_json::json!({
-            "type": "error", "error": {"type": "api_error", "message": "No channels available"}
-        }))).into_response(),
+        Err(_) => return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "type": "error", "error": {"type": "api_error", "message": "No channels available"}
+            })),
+        )
+            .into_response(),
     };
 
     let selected_channels = Dispatcher::select_channels(&channels, &model);
@@ -615,11 +1539,17 @@ async fn handle_messages_stream(
         }))).into_response();
     }
 
-    let request = ProxyRequest { model: model.clone(), body: forward_json.clone(), stream: true };
+    let request = ProxyRequest {
+        model: model.clone(),
+        body: forward_json.clone(),
+        stream: true,
+    };
     let (retry_enabled, retry_times) = proxy::get_retry_settings(&shared.app);
     let max_attempts = if retry_enabled {
         (retry_times.max(0) as usize + 1).min(selected_channels.len())
-    } else { 1 };
+    } else {
+        1
+    };
 
     let mut last_error = None;
 
@@ -630,7 +1560,9 @@ async fn handle_messages_stream(
             let mapping = &config.model_mapping;
             if let Some(mapped) = mapping.get(model.as_str()).and_then(|v| v.as_str()) {
                 mapped.to_string()
-            } else { model.clone() }
+            } else {
+                model.clone()
+            }
         };
 
         match adaptor.forward_stream(&request, &config).await {
@@ -804,8 +1736,19 @@ async fn handle_messages_stream(
                     trace_id: trace_id.clone(),
                 };
                 let log_id = log.id.clone();
-                if let Err(e) = repo.create_log(&log).await { eprintln!("[WARN] create_log failed: {}", e); }
-                if let Err(e) = repo.create_security_findings(&log_id, &security_result.findings, security_result.action.as_str()).await { eprintln!("[WARN] create_security_findings failed: {}", e); }
+                if let Err(e) = repo.create_log(&log).await {
+                    eprintln!("[WARN] create_log failed: {}", e);
+                }
+                if let Err(e) = repo
+                    .create_security_findings(
+                        &log_id,
+                        &security_result.findings,
+                        security_result.action.as_str(),
+                    )
+                    .await
+                {
+                    eprintln!("[WARN] create_security_findings failed: {}", e);
+                }
                 last_error = Some(format!("{}: {}", channel.name, error_message));
             }
         }
@@ -833,40 +1776,86 @@ pub async fn handle_responses(
         Err(e) => return (StatusCode::BAD_REQUEST, format!("Invalid JSON: {}", e)).into_response(),
     };
 
-    let is_stream = json.get("stream").and_then(|s| s.as_bool()).unwrap_or(false);
+    let is_stream = json
+        .get("stream")
+        .and_then(|s| s.as_bool())
+        .unwrap_or(false);
 
     let api_key = match protocol::extract_api_key(&headers) {
         Some(k) => k,
-        None => return (StatusCode::UNAUTHORIZED, Json(serde_json::json!({
-            "error": {"message": "Missing API key", "type": "authentication_error"}
-        }))).into_response(),
+        None => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({
+                    "error": {"message": "Missing API key", "type": "authentication_error"}
+                })),
+            )
+                .into_response()
+        }
     };
 
     let repo = std::sync::Arc::new(Repository::new(shared.state.db.pool.clone()));
     let key_record = match repo.get_api_key_by_key(&api_key).await {
         Ok(k) => k,
-        Err(_) => return (StatusCode::UNAUTHORIZED, Json(serde_json::json!({
-            "error": {"message": "Invalid API key", "type": "authentication_error"}
-        }))).into_response(),
+        Err(_) => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({
+                    "error": {"message": "Invalid API key", "type": "authentication_error"}
+                })),
+            )
+                .into_response()
+        }
     };
 
     if key_record.quota_limit > 0 && key_record.quota_used >= key_record.quota_limit {
-        return (StatusCode::TOO_MANY_REQUESTS, Json(serde_json::json!({
-            "error": {"message": "Quota exceeded", "type": "rate_limit_error"}
-        }))).into_response();
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(serde_json::json!({
+                "error": {"message": "Quota exceeded", "type": "rate_limit_error"}
+            })),
+        )
+            .into_response();
     }
 
-    let trace_id = headers.get("Wali-Trace-Id").and_then(|h| h.to_str().ok()).map(|s| s.to_string());
+    let trace_id = headers
+        .get("Wali-Trace-Id")
+        .and_then(|h| h.to_str().ok())
+        .map(|s| s.to_string());
     let request_body_str = serde_json::to_string(&json).unwrap_or_default();
-    let model = json.get("model").and_then(|m| m.as_str()).unwrap_or("").to_string();
+    let model = json
+        .get("model")
+        .and_then(|m| m.as_str())
+        .unwrap_or("")
+        .to_string();
 
     // Convert Responses API request to OpenAI Chat Completions format
     let openai_body = protocol::responses_to_openai(&json);
 
     if is_stream {
-        handle_responses_stream(shared, openai_body, model, key_record.id, key_record.name, request_body_str, trace_id).await
+        handle_responses_stream(
+            shared,
+            openai_body,
+            model,
+            key_record.id,
+            key_record.name,
+            request_body_str,
+            trace_id,
+        )
+        .await
     } else {
-        match proxy::handle_request(&repo, &shared.app, &key_record.id, &key_record.name, openai_body, false, Some(request_body_str), trace_id).await {
+        match proxy::handle_request(
+            &repo,
+            &shared.app,
+            &key_record.id,
+            &key_record.name,
+            openai_body,
+            false,
+            Some(request_body_str),
+            trace_id,
+        )
+        .await
+        {
             Ok(result) => {
                 // Convert OpenAI response to Responses API format
                 let responses_resp = protocol::openai_to_responses(&result.body, &model);
@@ -876,7 +1865,11 @@ pub async fn handle_responses(
                 let err_body = serde_json::json!({
                     "error": {"message": msg, "type": "upstream_error", "code": code}
                 });
-                (StatusCode::from_u16(code).unwrap_or(StatusCode::BAD_GATEWAY), Json(err_body)).into_response()
+                (
+                    StatusCode::from_u16(code).unwrap_or(StatusCode::BAD_GATEWAY),
+                    Json(err_body),
+                )
+                    .into_response()
             }
         }
     }
@@ -896,11 +1889,14 @@ async fn handle_responses_stream(
     let security_settings = security::get_security_settings(&shared.app);
     let security_result = security::scan_request(&openai_body, &security_settings);
 
-    let (forward_json, was_redacted) = if matches!(security_result.action, security::SecurityAction::Redact) || security_settings.redact_secrets {
-        security::redact_request_body(&openai_body, &security_settings)
-    } else {
-        (openai_body.clone(), false)
-    };
+    let (forward_json, was_redacted) =
+        if matches!(security_result.action, security::SecurityAction::Redact)
+            || security_settings.redact_secrets
+        {
+            security::redact_request_body(&openai_body, &security_settings)
+        } else {
+            (openai_body.clone(), false)
+        };
     let mut security_result = security_result;
     if was_redacted {
         security_result.sanitized = true;
@@ -939,15 +1935,28 @@ async fn handle_responses_stream(
             trace_id: trace_id.clone(),
         };
         let log_id = log.id.clone();
-        if let Err(e) = repo.create_log(&log).await { eprintln!("[WARN] create_log failed: {}", e); }
-        if let Err(e) = repo.create_security_findings(&log_id, &security_result.findings, security_result.action.as_str()).await { eprintln!("[WARN] create_security_findings failed: {}", e); }
+        if let Err(e) = repo.create_log(&log).await {
+            eprintln!("[WARN] create_log failed: {}", e);
+        }
+        if let Err(e) = repo
+            .create_security_findings(
+                &log_id,
+                &security_result.findings,
+                security_result.action.as_str(),
+            )
+            .await
+        {
+            eprintln!("[WARN] create_security_findings failed: {}", e);
+        }
         let err_body = serde_json::json!({"error": {"message": security_result.summary, "type": "security_blocked"}});
         return (StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS, Json(err_body)).into_response();
     }
 
     let channels = match repo.get_enabled_channels().await {
         Ok(c) => c,
-        Err(_) => return (StatusCode::SERVICE_UNAVAILABLE, "No channels available").into_response(),
+        Err(_) => {
+            return (StatusCode::SERVICE_UNAVAILABLE, "No channels available").into_response()
+        }
     };
 
     let selected_channels = Dispatcher::select_channels(&channels, &model);
@@ -955,11 +1964,17 @@ async fn handle_responses_stream(
         return (StatusCode::SERVICE_UNAVAILABLE, "No channel for model").into_response();
     }
 
-    let request = ProxyRequest { model: model.clone(), body: forward_json.clone(), stream: true };
+    let request = ProxyRequest {
+        model: model.clone(),
+        body: forward_json.clone(),
+        stream: true,
+    };
     let (retry_enabled, retry_times) = proxy::get_retry_settings(&shared.app);
     let max_attempts = if retry_enabled {
         (retry_times.max(0) as usize + 1).min(selected_channels.len())
-    } else { 1 };
+    } else {
+        1
+    };
 
     let mut last_error = None;
 
@@ -970,7 +1985,9 @@ async fn handle_responses_stream(
             let mapping = &config.model_mapping;
             if let Some(mapped) = mapping.get(model.as_str()).and_then(|v| v.as_str()) {
                 mapped.to_string()
-            } else { model.clone() }
+            } else {
+                model.clone()
+            }
         };
 
         match adaptor.forward_stream(&request, &config).await {
@@ -1179,8 +2196,19 @@ async fn handle_responses_stream(
                     trace_id: trace_id.clone(),
                 };
                 let log_id = log.id.clone();
-                if let Err(e) = repo.create_log(&log).await { eprintln!("[WARN] create_log failed: {}", e); }
-                if let Err(e) = repo.create_security_findings(&log_id, &security_result.findings, security_result.action.as_str()).await { eprintln!("[WARN] create_security_findings failed: {}", e); }
+                if let Err(e) = repo.create_log(&log).await {
+                    eprintln!("[WARN] create_log failed: {}", e);
+                }
+                if let Err(e) = repo
+                    .create_security_findings(
+                        &log_id,
+                        &security_result.findings,
+                        security_result.action.as_str(),
+                    )
+                    .await
+                {
+                    eprintln!("[WARN] create_security_findings failed: {}", e);
+                }
                 last_error = Some(format!("{}: {}", channel.name, error_message));
             }
         }
@@ -1212,27 +2240,50 @@ pub async fn handle_embeddings(
 
     let api_key = match protocol::extract_api_key(&headers) {
         Some(k) => k,
-        None => return (StatusCode::UNAUTHORIZED, Json(serde_json::json!({
-            "error": {"message": "Missing API key", "type": "authentication_error"}
-        }))).into_response(),
+        None => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({
+                    "error": {"message": "Missing API key", "type": "authentication_error"}
+                })),
+            )
+                .into_response()
+        }
     };
 
     let repo = std::sync::Arc::new(Repository::new(shared.state.db.pool.clone()));
     let key_record = match repo.get_api_key_by_key(&api_key).await {
         Ok(k) => k,
-        Err(_) => return (StatusCode::UNAUTHORIZED, Json(serde_json::json!({
-            "error": {"message": "Invalid API key", "type": "authentication_error"}
-        }))).into_response(),
+        Err(_) => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({
+                    "error": {"message": "Invalid API key", "type": "authentication_error"}
+                })),
+            )
+                .into_response()
+        }
     };
 
     if key_record.quota_limit > 0 && key_record.quota_used >= key_record.quota_limit {
-        return (StatusCode::TOO_MANY_REQUESTS, Json(serde_json::json!({
-            "error": {"message": "Quota exceeded", "type": "rate_limit_error"}
-        }))).into_response();
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(serde_json::json!({
+                "error": {"message": "Quota exceeded", "type": "rate_limit_error"}
+            })),
+        )
+            .into_response();
     }
 
-    let model = json.get("model").and_then(|m| m.as_str()).unwrap_or("").to_string();
-    let trace_id = headers.get("Wali-Trace-Id").and_then(|h| h.to_str().ok()).map(|s| s.to_string());
+    let model = json
+        .get("model")
+        .and_then(|m| m.as_str())
+        .unwrap_or("")
+        .to_string();
+    let trace_id = headers
+        .get("Wali-Trace-Id")
+        .and_then(|h| h.to_str().ok())
+        .map(|s| s.to_string());
     let request_body_str = serde_json::to_string(&json).unwrap_or_default();
 
     // Security scan
@@ -1270,17 +2321,34 @@ pub async fn handle_embeddings(
             trace_id: trace_id.clone(),
         };
         let log_id = log.id.clone();
-        if let Err(e) = repo.create_log(&log).await { eprintln!("[WARN] create_log failed: {}", e); }
-        if let Err(e) = repo.create_security_findings(&log_id, &security_result.findings, security_result.action.as_str()).await { eprintln!("[WARN] create_security_findings failed: {}", e); }
-        return (StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS, Json(serde_json::json!({
-            "error": {"message": security_result.summary, "type": "security_blocked"}
-        }))).into_response();
+        if let Err(e) = repo.create_log(&log).await {
+            eprintln!("[WARN] create_log failed: {}", e);
+        }
+        if let Err(e) = repo
+            .create_security_findings(
+                &log_id,
+                &security_result.findings,
+                security_result.action.as_str(),
+            )
+            .await
+        {
+            eprintln!("[WARN] create_security_findings failed: {}", e);
+        }
+        return (
+            StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS,
+            Json(serde_json::json!({
+                "error": {"message": security_result.summary, "type": "security_blocked"}
+            })),
+        )
+            .into_response();
     }
 
     // Select channels
     let channels = match repo.get_enabled_channels().await {
         Ok(c) => c,
-        Err(_) => return (StatusCode::SERVICE_UNAVAILABLE, "No channels available").into_response(),
+        Err(_) => {
+            return (StatusCode::SERVICE_UNAVAILABLE, "No channels available").into_response()
+        }
     };
 
     let selected_channels = Dispatcher::select_channels(&channels, &model);
@@ -1291,7 +2359,9 @@ pub async fn handle_embeddings(
     let (retry_enabled, retry_times) = proxy::get_retry_settings(&shared.app);
     let max_attempts = if retry_enabled {
         (retry_times.max(0) as usize + 1).min(selected_channels.len())
-    } else { 1 };
+    } else {
+        1
+    };
 
     let mut last_error = None;
     let start = std::time::Instant::now();
@@ -1303,7 +2373,9 @@ pub async fn handle_embeddings(
             let mapping = &config.model_mapping;
             if let Some(mapped) = mapping.get(model.as_str()).and_then(|v| v.as_str()) {
                 mapped.to_string()
-            } else { model.clone() }
+            } else {
+                model.clone()
+            }
         };
 
         // Build upstream embedding request — send directly to /embeddings
@@ -1328,10 +2400,19 @@ pub async fn handle_embeddings(
         match result {
             Ok(resp) => {
                 let status = resp.status();
-                let resp_body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+                let resp_body: serde_json::Value =
+                    resp.json().await.unwrap_or(serde_json::Value::Null);
 
                 if !status.is_success() {
-                    let error_message = format!("HTTP {}: {}", status, serde_json::to_string(&resp_body).unwrap_or_default().chars().take(300).collect::<String>());
+                    let error_message = format!(
+                        "HTTP {}: {}",
+                        status,
+                        serde_json::to_string(&resp_body)
+                            .unwrap_or_default()
+                            .chars()
+                            .take(300)
+                            .collect::<String>()
+                    );
                     let log = crate::db::models::RequestLog {
                         id: crate::utils::id::new_id(),
                         seq: None,
@@ -1362,15 +2443,34 @@ pub async fn handle_embeddings(
                         trace_id: trace_id.clone(),
                     };
                     let log_id = log.id.clone();
-                    if let Err(e) = repo.create_log(&log).await { eprintln!("[WARN] create_log failed: {}", e); }
-                    if let Err(e) = repo.create_security_findings(&log_id, &security_result.findings, security_result.action.as_str()).await { eprintln!("[WARN] create_security_findings failed: {}", e); }
+                    if let Err(e) = repo.create_log(&log).await {
+                        eprintln!("[WARN] create_log failed: {}", e);
+                    }
+                    if let Err(e) = repo
+                        .create_security_findings(
+                            &log_id,
+                            &security_result.findings,
+                            security_result.action.as_str(),
+                        )
+                        .await
+                    {
+                        eprintln!("[WARN] create_security_findings failed: {}", e);
+                    }
                     last_error = Some(error_message);
                     continue;
                 }
 
                 // Extract usage from response
-                let usage_total = resp_body.get("usage").and_then(|u| u.get("total_tokens")).and_then(|t| t.as_u64()).unwrap_or(0) as i64;
-                let usage_prompt = resp_body.get("usage").and_then(|u| u.get("prompt_tokens")).and_then(|t| t.as_u64()).unwrap_or(0) as i64;
+                let usage_total = resp_body
+                    .get("usage")
+                    .and_then(|u| u.get("total_tokens"))
+                    .and_then(|t| t.as_u64())
+                    .unwrap_or(0) as i64;
+                let usage_prompt = resp_body
+                    .get("usage")
+                    .and_then(|u| u.get("prompt_tokens"))
+                    .and_then(|t| t.as_u64())
+                    .unwrap_or(0) as i64;
 
                 let log = crate::db::models::RequestLog {
                     id: crate::utils::id::new_id(),
@@ -1402,10 +2502,23 @@ pub async fn handle_embeddings(
                     trace_id: trace_id.clone(),
                 };
                 let log_id = log.id.clone();
-                if let Err(e) = repo.create_log(&log).await { eprintln!("[WARN] create_log failed: {}", e); }
-                if let Err(e) = repo.create_security_findings(&log_id, &security_result.findings, security_result.action.as_str()).await { eprintln!("[WARN] create_security_findings failed: {}", e); }
+                if let Err(e) = repo.create_log(&log).await {
+                    eprintln!("[WARN] create_log failed: {}", e);
+                }
+                if let Err(e) = repo
+                    .create_security_findings(
+                        &log_id,
+                        &security_result.findings,
+                        security_result.action.as_str(),
+                    )
+                    .await
+                {
+                    eprintln!("[WARN] create_security_findings failed: {}", e);
+                }
                 if usage_total > 0 {
-                    if let Err(e) = repo.increment_quota(&key_record.id, usage_total).await { eprintln!("[WARN] increment_quota failed: {}", e); }
+                    if let Err(e) = repo.increment_quota(&key_record.id, usage_total).await {
+                        eprintln!("[WARN] increment_quota failed: {}", e);
+                    }
                 }
 
                 return (StatusCode::OK, Json(resp_body)).into_response();
@@ -1442,8 +2555,19 @@ pub async fn handle_embeddings(
                     trace_id: trace_id.clone(),
                 };
                 let log_id = log.id.clone();
-                if let Err(e) = repo.create_log(&log).await { eprintln!("[WARN] create_log failed: {}", e); }
-                if let Err(e) = repo.create_security_findings(&log_id, &security_result.findings, security_result.action.as_str()).await { eprintln!("[WARN] create_security_findings failed: {}", e); }
+                if let Err(e) = repo.create_log(&log).await {
+                    eprintln!("[WARN] create_log failed: {}", e);
+                }
+                if let Err(e) = repo
+                    .create_security_findings(
+                        &log_id,
+                        &security_result.findings,
+                        security_result.action.as_str(),
+                    )
+                    .await
+                {
+                    eprintln!("[WARN] create_security_findings failed: {}", e);
+                }
                 last_error = Some(error_message);
             }
         }
@@ -1476,8 +2600,8 @@ pub async fn handle_list_models(State(shared): State<SharedState>) -> Response {
                     }
                 }
                 // Also expose mapped model names (mapping keys)
-                let mapping: serde_json::Value =
-                    serde_json::from_str(&ch.model_mapping).unwrap_or(serde_json::Value::Object(Default::default()));
+                let mapping: serde_json::Value = serde_json::from_str(&ch.model_mapping)
+                    .unwrap_or(serde_json::Value::Object(Default::default()));
                 if let Some(obj) = mapping.as_object() {
                     for key in obj.keys() {
                         if seen.insert(key.clone()) {
@@ -1492,7 +2616,11 @@ pub async fn handle_list_models(State(shared): State<SharedState>) -> Response {
             }
             Json(serde_json::json!({ "object": "list", "data": models })).into_response()
         }
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("DB error: {}", e)).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("DB error: {}", e),
+        )
+            .into_response(),
     }
 }
 
@@ -1510,11 +2638,15 @@ pub async fn handle_audio_speech(State(_shared): State<SharedState>) -> Response
 
 pub async fn handle_health(State(shared): State<SharedState>) -> Response {
     let port = shared.state.server_port.read().await.clone();
-    let running = shared.state.server_running.load(std::sync::atomic::Ordering::SeqCst);
+    let running = shared
+        .state
+        .server_running
+        .load(std::sync::atomic::Ordering::SeqCst);
     Json(serde_json::json!({
         "status": "ok",
         "running": running,
         "port": port,
         "url": format!("http://127.0.0.1:{}", port),
-    })).into_response()
+    }))
+    .into_response()
 }

--- a/src-tauri/src/server/router.rs
+++ b/src-tauri/src/server/router.rs
@@ -1,4 +1,5 @@
 use axum::{
+    extract::DefaultBodyLimit,
     Router,
     routing::{get, post},
 };
@@ -38,7 +39,8 @@ pub fn create_router(app: AppHandle, state: Arc<AppState>) -> Router {
         .route("/v1/audio/transcriptions", post(handle_audio_transcriptions))
         .route("/v1/audio/speech", post(handle_audio_speech))
         // Anthropic Messages API
-        .route("/v1/messages", post(handle_messages))
+        .route("/v1/messages", post(handle_messages).layer(DefaultBodyLimit::max(32 * 1024 * 1024)))
+        .route("/v1/messages/count_tokens", post(handle_messages_count_tokens).layer(DefaultBodyLimit::max(32 * 1024 * 1024)))
         // Health check
         .route("/health", get(handle_health))
         // Service routes (Knowledge Base, MCP, etc.)

--- a/src/pages/UsagePage.tsx
+++ b/src/pages/UsagePage.tsx
@@ -141,6 +141,9 @@ export function UsagePage() {
     responses: `${baseUrl}/responses`,
     anthropic: `${baseUrl}/messages`,
   };
+  // API/SDK examples use the `/v1` base. Claude Code is different: it adds
+  // `/v1/messages` itself to ANTHROPIC_BASE_URL.
+  const anthropicClientBaseUrl = baseUrl.replace(/\/v1\/?$/, "");
 
   const scripts: Record<Protocol, Record<Platform, string>> = {
     chat: {
@@ -349,7 +352,7 @@ public class AnthropicTest {
       }
       let body: string;
       if (isAnthropic) {
-        body = JSON.stringify({ model: selModel, max_tokens: 1024, messages: [{ role: "user", content: "Say hello in one sentence" }] });
+        body = JSON.stringify({ model: selModel, max_tokens: 1024, stream: false, messages: [{ role: "user", content: "Say hello in one sentence" }] });
       } else if (isResponses) {
         body = JSON.stringify({ model: selModel, input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "Say hello in one sentence" }] }] });
       } else {
@@ -510,9 +513,9 @@ public class AnthropicTest {
             </div>
             <div className="flex items-center gap-2">
               <code className="flex-1 break-all rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm font-mono text-slate-900">
-                {baseUrl}
+                {activeProtocol === "anthropic" ? anthropicClientBaseUrl : baseUrl}
               </code>
-              <button onClick={() => copy(baseUrl, "baseurl")} className="action-secondary px-3 py-2.5" title="复制 Base URL">
+              <button onClick={() => copy(activeProtocol === "anthropic" ? anthropicClientBaseUrl : baseUrl, "baseurl")} className="action-secondary px-3 py-2.5" title="复制 Base URL">
                 {copied === "baseurl" ? <Check size={16} className="text-emerald-600" /> : <Copy size={16} />}
               </button>
             </div>


### PR DESCRIPTION
## 问题根因

Issue #7 中的 Claude Code 配置把 `ANTHROPIC_BASE_URL` 设置为了完整接口地址：

```json
"ANTHROPIC_BASE_URL": "http://127.0.0.1:8777/v1/messages"
```

但 Claude Code 会自行在 `ANTHROPIC_BASE_URL` 后追加 `/v1/messages?beta=true`。因此上面的配置会形成重复路径，正确配置应为：

```json
"ANTHROPIC_BASE_URL": "http://127.0.0.1:8777"
```

此外，原实现虽然有 `/v1/messages` 路由，但会先无条件转换成 OpenAI 格式，再选择上游通道。这会造成原生 Anthropic 上游被重复转换；更严重的是，原生 Anthropic 的 SSE 响应会被当作 OpenAI SSE 解析。Claude Code 的 `anthropic-beta`、工具调用、多轮 tool result、流式 usage 与重试场景也因此无法可靠工作。

## 改动内容

- 按上游通道类型分流：原生 Anthropic 上游保持 Messages 请求、响应、错误和 SSE 的协议语义；OpenAI 上游固定使用 `/v1/chat/completions` 并进行双向转换。
- 补齐 Anthropic ↔ OpenAI Chat Completions 的 system、文本、图片、tools、tool_choice、tool_use、tool_result 和多轮工具调用映射。
- 重写 OpenAI SSE 到 Anthropic SSE 的转换：处理分片、CRLF、并行工具调用、事件顺序、最终 usage 与 stop reason。
- 保留原生上游的 `?beta=true`、Anthropic 扩展头、重试相关头及流式字节；同时避免透传调用方凭据、Cookie、Host 等敏感或 hop-by-hop 头。
- 完善失败转移、安全扫描/脱敏、请求日志、token 配额结算与 32 MiB Messages 请求体限制。
- 对 OpenAI Chat 上游无法安全表达的 Anthropic 特性采用明确的兼容策略，避免伪造 thinking 或静默破坏工具参数。
- 修正“LLM 使用”页：Anthropic/Claude Code 展示并复制网关根地址；页面测试明确设置 `stream: false`，按单个 JSON Message 验证连接。

## 为什么这样改

Claude Code 的下游协议是 Anthropic Messages，而用户配置的上游既可能是 Anthropic，也可能是仅兼容 OpenAI Chat Completions 的服务。网关必须在选择上游后再执行相应的协议处理：

- 对原生 Anthropic 上游，转换会丢失 beta、缓存、thinking 签名或 SSE 事件语义，因此应尽量原样转发。
- 对 OpenAI Chat 上游，必须将 Anthropic 工具调用与流式事件转换为对应的 Chat Completions 结构，并再转换回来，才能让 Claude Code 完成工具调用和多轮会话。

本 PR 仅处理 Claude Code / Anthropic Messages 兼容；Codex / OpenAI Responses 的上游适配不在本次范围。

## 验证

- `cargo test --quiet`：26 项通过
- `node_modules/.bin/tsc --noEmit`：通过
- `git diff --check`：通过
- claude code

<img width="844" height="763" alt="image" src="https://github.com/user-attachments/assets/69feb25d-46ba-4d14-9509-8b31327cce26" />


Fixes #7