### PR TITLE
fix: Codex 流式集成协议修复（Responses SSE 帧重组 + reasoning 生命周期 + Anthropic Messages 转换）

### DIFF
--- a/src-tauri/src/endpoint_executor/sse.rs
+++ b/src-tauri/src/endpoint_executor/sse.rs
@@ -852,4 +852,195 @@ mod tests {
             "partial carry record must be completed, not dropped: {text2}"
         );
     }
+
+    /// Real OpenCode-GO stream (captured via `wa_upstream_raw.txt`): 16 reasoning
+    /// chunks, then a tool_call record carrying id+name+empty args (REC16), then
+    /// 11 arguments deltas, then a `finish_reason: "tool_calls"` record, then
+    /// [DONE].  This is the EXACT upstream byte stream the ResponsesViaChat
+    /// converter must survive.  Any loss/corruption here is the reported bug.
+    ///
+    /// The stream is driven the way `driver.rs` does it: the first record is
+    /// split off as `first_frame`, everything after it is `carry`, and the pump
+    /// is constructed in one shot — records 2..N MUST NOT be dropped.
+    #[test]
+    fn responses_via_chat_survives_real_tool_call_stream() {
+        let records: Vec<&str> = vec![
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"role":"assistant","content":null,"reasoning_content":""}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":"The"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" user"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" wants"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" me"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" to"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" call"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" the"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" read"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" tool"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" with"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" path"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" /"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":"tmp"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":"/x"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":"."}}],"usage":null}"#,
+            // REC16: the tool_call opener carrying id + name.
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"id":"call_00_B4Go5x1lk0lKp5y1fvPa3907","type":"function","function":{"name":"read","arguments":""}}]}}],"usage":null}"#,
+            // REC17-27: arguments deltas.
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{"}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\""}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"path"}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\""}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":": "}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\""}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"/"}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"tmp"}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"/x"}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\""}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]}}],"usage":null}"#,
+            // REC28: finish with tool_calls + usage.
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":"tool_calls","logprobs":null,"delta":{"content":"","reasoning_content":null}}],"usage":{"prompt_tokens":346,"completion_tokens":60,"total_tokens":406,"prompt_cache_hit_tokens":256,"prompt_cache_miss_tokens":90,"prompt_tokens_details":{"cached_tokens":256},"completion_tokens_details":{"reasoning_tokens":15}}}"#,
+            r#"data: [DONE]"#,
+        ];
+
+        // Concatenate all records into a single upstream byte stream.
+        let mut stream = String::new();
+        for rec in &records {
+            stream.push_str(rec);
+            stream.push_str("\n\n");
+        }
+        let bytes = stream.as_bytes();
+
+        // Replicate `buffer_first_record`: split off the first complete record
+        // (records here are `\n\n`-terminated) as first_frame, keep the rest as
+        // carry, exactly like driver.rs does on the live upstream chunk.
+        let mut first_end = 0;
+        for i in 0..bytes.len() - 1 {
+            if bytes[i] == b'\n' && bytes[i + 1] == b'\n' {
+                first_end = i + 2;
+                break;
+            }
+        }
+        let first_frame = bytes[..first_end].to_vec();
+        let carry = bytes[first_end..].to_vec();
+        assert!(
+            !carry.is_empty(),
+            "carry must contain records 2..N (records 2..N must not be lost)"
+        );
+
+        let mut core = StreamPumpCore::new(
+            native_supervisor(),
+            SseMode::ResponsesViaChat,
+            None,
+            first_frame,
+            carry,
+            "deepseek-v4-flash".to_string(),
+        )
+        .unwrap();
+        let out = core.start().unwrap();
+        let text = String::from_utf8_lossy(&out);
+
+        // The tool call MUST carry the real id + name (not the fc_/call_ fallbacks).
+        assert!(
+            text.contains("call_00_B4Go5x1lk0lKp5y1fvPa3907"),
+            "tool call id from REC16 must survive: {text}"
+        );
+        assert!(
+            text.contains("\"name\":\"read\""),
+            "tool call name from REC16 must survive: {text}"
+        );
+        assert!(
+            !text.contains("\"name\":\"\"") && !text.contains("\"call_id\":\"call_1\""),
+            "fallback empty name / synthesized call_1 must NOT appear: {text}"
+        );
+
+        // The final completed item must contain the FULL arguments JSON.
+        let fin = core.finish().unwrap();
+        let full = format!("{text}{}", String::from_utf8_lossy(&fin));
+        assert!(
+            full.contains("{\\\"path\\\": \\\"/tmp/x\\\"}") || full.contains("\\\": \\\"/tmp/x\\\"}"),
+            "full arguments `{{\"path\": \"/tmp/x\"}}` must be accumulated: {full}"
+        );
+        assert!(
+            full.contains("\"status\":\"completed\"")
+                && full.contains("\"type\":\"function_call\""),
+            "the function_call must complete: {full}"
+        );
+    }
+
+    /// The SAME real stream fed ONE RECORD PER `push()`, as a live HTTP body
+    /// typically delivers it.  `buffer_first_record` only pre-loads the first
+    /// record + whatever was in the same TCP read; every later record arrives
+    /// as its own `push()`.  Any loss here is the production bug.
+    #[test]
+    fn responses_via_chat_survives_real_stream_record_by_record() {
+        // Build the full upstream byte stream exactly as in the single-shot test.
+        let records: Vec<&str> = vec![
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"role":"assistant","content":null,"reasoning_content":""}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":"The"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" user"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" wants"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" me"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" to"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" call"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" the"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" read"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" tool"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" with"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" path"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":" /"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":"tmp"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":"/x"}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"content":null,"reasoning_content":"."}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"id":"call_00_B4Go5x1lk0lKp5y1fvPa3907","type":"function","function":{"name":"read","arguments":""}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{"}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\""}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"path"}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\""}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":": "}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\""}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"/"}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"tmp"}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"/x"}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\""}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":null,"logprobs":null,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]}}],"usage":null}"#,
+            r#"data: {"id":"bfdd2576-6ce0-41a3-a1e4-ddca7acbf7b2","object":"chat.completion.chunk","created":1786164640,"model":"deepseek-v4-flash","choices":[{"index":0,"finish_reason":"tool_calls","logprobs":null,"delta":{"content":"","reasoning_content":null}}],"usage":{"prompt_tokens":346,"completion_tokens":60,"total_tokens":406,"prompt_cache_hit_tokens":256,"prompt_cache_miss_tokens":90,"prompt_tokens_details":{"cached_tokens":256},"completion_tokens_details":{"reasoning_tokens":15}}}"#,
+            r#"data: [DONE]"#,
+        ];
+
+        // First record becomes first_frame (as buffer_first_record does); the
+        // rest are delivered one record per push().
+        let rec0 = format!("{}\n\n", records[0]);
+        let mut core = StreamPumpCore::new(
+            native_supervisor(),
+            SseMode::ResponsesViaChat,
+            None,
+            rec0.as_bytes().to_vec(),
+            Vec::new(),
+            "deepseek-v4-flash".to_string(),
+        )
+        .unwrap();
+        let mut text = String::from_utf8_lossy(&core.start().unwrap()).to_string();
+        for rec in &records[1..] {
+            let chunk = format!("{}\n\n", rec);
+            let out = core.push(chunk.as_bytes()).unwrap();
+            text.push_str(&String::from_utf8_lossy(&out));
+        }
+        let fin = core.finish().unwrap();
+        text.push_str(&String::from_utf8_lossy(&fin));
+
+        assert!(
+            text.contains("call_00_B4Go5x1lk0lKp5y1fvPa3907"),
+            "tool call id must survive per-record push: {text}"
+        );
+        assert!(
+            text.contains("\"name\":\"read\""),
+            "tool call name must survive per-record push: {text}"
+        );
+        assert!(
+            !text.contains("\"name\":\"\"") && !text.contains("\"call_id\":\"call_1\""),
+            "fallback empty name / synthesized call_1 must NOT appear: {text}"
+        );
+        assert!(
+            text.contains("\\\": \\\"/tmp/x\\\"}"),
+            "full arguments `{{\"path\": \"/tmp/x\"}}` must be accumulated: {text}"
+        );
+    }
 }

--- a/src-tauri/src/endpoint_executor/sse.rs
+++ b/src-tauri/src/endpoint_executor/sse.rs
@@ -152,6 +152,10 @@ pub struct StreamPumpCore {
     responses_state: Option<crate::protocol::responses::StreamState>,
     responses_id: String,
     accumulated_content: String,
+    /// Partial upstream bytes waiting for the rest of their SSE record.
+    /// ResponsesViaChat has no codec decoder, so the pump itself carries
+    /// records across `push()` calls (a frame split by TCP is not dropped).
+    responses_buffer: Vec<u8>,
     /// Last native usage observed.
     usage: Option<(i64, i64, i64)>,
 }
@@ -199,6 +203,7 @@ impl StreamPumpCore {
             },
             responses_id: format!("resp_{}", uuid::Uuid::new_v4().simple()),
             accumulated_content: String::new(),
+            responses_buffer: Vec::new(),
             usage: None,
         };
         match mode {
@@ -233,16 +238,13 @@ impl StreamPumpCore {
                 core.first_frame = out;
             }
             SseMode::ResponsesViaChat => {
-                let mut out = Vec::new();
-                if !first_frame.is_empty() {
-                    out.extend(
-                        core.encode_responses_chunk(&String::from_utf8_lossy(&first_frame))?,
-                    );
-                }
-                if !carry.is_empty() {
-                    out.extend(core.encode_responses_chunk(&String::from_utf8_lossy(&carry))?);
-                }
-                core.first_frame = out;
+                // Feed the first record AND the carry (records 2..N of the same
+                // upstream chunk) through the buffered encoder. A `carry` that
+                // ends mid-record must be held in `responses_buffer` and
+                // completed by a later `push()`, never dropped.
+                core.first_frame = core.encode_responses_buffered(&first_frame)?;
+                let carry_out = core.encode_responses_buffered(&carry)?;
+                core.first_frame.extend_from_slice(&carry_out);
             }
         }
         Ok(core)
@@ -344,6 +346,24 @@ impl StreamPumpCore {
         Ok(out)
     }
 
+    /// Buffer partial upstream bytes and feed any complete SSE records to
+    /// [`Self::encode_responses_chunk`] as discrete chunks. ResponsesViaChat has
+    /// no codec decoder, so a record split across TCP frames must be reassembled
+    /// here — otherwise both halves are dropped and the Responses stream loses
+    /// tool names / truncated arguments / text.
+    fn encode_responses_buffered(&mut self, bytes: &[u8]) -> Result<Vec<u8>, PumpError> {
+        self.responses_buffer.extend_from_slice(bytes);
+        let mut out = Vec::new();
+        loop {
+            let Some(end) = record_end(&self.responses_buffer) else {
+                break;
+            };
+            let record: Vec<u8> = self.responses_buffer.drain(..end).collect();
+            out.extend(self.encode_responses_chunk(&String::from_utf8_lossy(&record))?);
+        }
+        Ok(out)
+    }
+
     /// Feed an upstream chunk.  Returns downstream bytes to emit.
     pub fn push(&mut self, bytes: &[u8]) -> Result<Vec<u8>, PumpError> {
         let mut out = self.start()?;
@@ -355,9 +375,7 @@ impl StreamPumpCore {
                 out.extend_from_slice(&self.encode_conversion_chunk(bytes)?);
             }
             SseMode::ResponsesViaChat => {
-                out.extend_from_slice(
-                    &self.encode_responses_chunk(&String::from_utf8_lossy(bytes))?,
-                );
+                out.extend_from_slice(&self.encode_responses_buffered(bytes)?);
             }
         }
         Ok(out)
@@ -398,6 +416,12 @@ impl StreamPumpCore {
                 }
             }
             SseMode::ResponsesViaChat => {
+                // Flush any complete record still held in the carry buffer so a
+                // record that finished exactly at EOF is not lost.
+                if !self.responses_buffer.is_empty() {
+                    let tail = std::mem::take(&mut self.responses_buffer);
+                    out.extend(self.encode_responses_chunk(&String::from_utf8_lossy(&tail))?);
+                }
                 let synth = crate::protocol::responses::create_synthetic_completed_events(
                     &self.model,
                     &self.responses_id,
@@ -728,6 +752,104 @@ mod tests {
             text.contains("\"type\":\"thinking\"") &&
                 text.contains("\"thinking\":\"secret chain\""),
             "reasoning must surface as a Messages thinking block: {text}"
+        );
+    }
+
+    /// ResponsesViaChat has no codec decoder, so the pump must carry partial
+    /// SSE records across `push()` calls. A tool_call record split mid-JSON
+    /// (long frames are routinely fragmented by TCP) currently drops BOTH
+    /// halves — Codex then persists an empty tool name / truncated arguments.
+    #[test]
+    fn responses_via_chat_pump_buffers_split_tool_call_record() {
+        let mut core = StreamPumpCore::new(
+            native_supervisor(),
+            SseMode::ResponsesViaChat,
+            None,
+            Vec::new(),
+            Vec::new(),
+            "deepseek-v4-flash".to_string(),
+        )
+        .unwrap();
+        core.start().unwrap();
+
+        let record = b"data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_A\",\"function\":{\"name\":\"read\",\"arguments\":\"{}\"}}]}}]}\n\n";
+        let mid = record.len() / 2;
+        let mut out = core.push(&record[..mid]).unwrap();
+        out.extend(core.push(&record[mid..]).unwrap());
+        let text = String::from_utf8_lossy(&out);
+        assert!(
+            text.contains("\"call_id\":\"call_A\""),
+            "tool call id must survive a record split mid-JSON: {text}"
+        );
+        assert!(
+            text.contains("\"name\":\"read\""),
+            "tool call name must survive a record split mid-JSON: {text}"
+        );
+    }
+
+    /// A UTF-8 codepoint split across TCP chunks must not corrupt the stream:
+    /// buffering by full SSE record (not by lossy chunk) keeps "hé" intact and
+    /// free of U+FFFD replacement characters.
+    #[test]
+    fn responses_via_chat_pump_buffers_split_multibyte_content() {
+        let mut core = StreamPumpCore::new(
+            native_supervisor(),
+            SseMode::ResponsesViaChat,
+            None,
+            Vec::new(),
+            Vec::new(),
+            "deepseek-v4-flash".to_string(),
+        )
+        .unwrap();
+        core.start().unwrap();
+
+        let record = "data: {\"choices\":[{\"delta\":{\"content\":\"hé\"}}]}\n\n";
+        let bytes = record.as_bytes();
+        let split = bytes.windows(2).position(|w| w == b"\xc3\xa9").unwrap() + 1;
+        let mut out = core.push(&bytes[..split]).unwrap();
+        out.extend(core.push(&bytes[split..]).unwrap());
+        let text = String::from_utf8_lossy(&out);
+        assert!(
+            text.contains("hé"),
+            "split UTF-8 content must arrive intact: {text}"
+        );
+        assert!(
+            !text.contains('\u{FFFD}'),
+            "no replacement characters: {text}"
+        );
+    }
+
+    /// C-1 seam for ResponsesViaChat: the first upstream chunk can deliver the
+    /// first complete record PLUS a partial SECOND record (`carry`). The
+    /// partial carry must be buffered in `new()` — not dropped — so it
+    /// completes when the rest arrives via `push()`.
+    #[test]
+    fn responses_via_chat_pump_buffers_partial_carry_record() {
+        let first_frame = b"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n";
+        // Record 2, truncated mid-JSON inside the FIRST upstream chunk.
+        let carry = b"data: {\"choices\":[{\"delta\":{\"content\":\"hel";
+        let mut core = StreamPumpCore::new(
+            native_supervisor(),
+            SseMode::ResponsesViaChat,
+            None,
+            first_frame.to_vec(),
+            carry.to_vec(),
+            "deepseek-v4-flash".to_string(),
+        )
+        .unwrap();
+        let out = core.start().unwrap();
+        let text = String::from_utf8_lossy(&out);
+        assert!(
+            text.contains("hi"),
+            "record 1 (the valid first frame) must be emitted: {text}"
+        );
+
+        // Complete record 2 in a later chunk.
+        let out2 = core.push(b"lo\"}}]}\n\n").unwrap();
+        let text2 = String::from_utf8_lossy(&out2);
+        assert!(
+            text2.contains("hello"),
+            "partial carry record must be completed, not dropped: {text2}"
         );
     }
 }

--- a/src-tauri/src/protocol/codec/chat_messages_codec.rs
+++ b/src-tauri/src/protocol/codec/chat_messages_codec.rs
@@ -588,6 +588,20 @@ fn messages_request_system_text_and_sampling() {
 }
 
 #[test]
+fn messages_request_stream_options_are_allowed_and_force_usage() {
+    let body = json!({
+        "model": "m",
+        "stream": true,
+        "stream_options": {"include_usage": false, "custom": true},
+        "messages": [{"role": "user", "content": "hi"}]
+    });
+    let prepared = CodecRegistry::messages_to_chat("m", &body).unwrap();
+    let out = &prepared.encoded_request;
+    assert_eq!(out["stream_options"]["include_usage"], true);
+    assert_eq!(out["stream_options"]["custom"], true);
+}
+
+#[test]
 fn messages_request_tools_choice_and_tool_results() {
     let body = json!({
         "model": "m",
@@ -739,7 +753,7 @@ fn messages_request_assistant_thinking_becomes_reasoning_content() {
 fn messages_request_unknown_role_and_block_rejected() {
     let body = json!({
         "model": "m",
-        "messages": [{"role": "system", "content": "x"}]
+        "messages": [{"role": "bogus", "content": "x"}]
     });
     let e = CodecRegistry::messages_to_chat("m", &body).unwrap_err();
     assert!(reject_features(&e)
@@ -754,6 +768,29 @@ fn messages_request_unknown_role_and_block_rejected() {
     assert!(reject_features(&e)
         .iter()
         .any(|c| c.contains("unknown_block")));
+}
+
+#[test]
+fn messages_request_mid_conversation_system_maps_to_chat_system_role() {
+    let body = json!({
+        "model": "m",
+        "messages": [
+            {"role": "user", "content": "activate strict mode"},
+            {"role": "system", "content": [{"type": "text", "text": "strict mode active", "cache_control": {"type": "ephemeral"}}]},
+            {"role": "assistant", "content": "ack"}
+        ]
+    });
+    let prepared = CodecRegistry::messages_to_chat("m", &body).unwrap();
+    let messages = prepared.encoded_request["messages"].as_array().unwrap();
+    assert_eq!(
+        messages[0],
+        json!({"role": "user", "content": "activate strict mode"})
+    );
+    assert_eq!(
+        messages[1],
+        json!({"role": "system", "content": "strict mode active"})
+    );
+    assert_eq!(messages[2], json!({"role": "assistant", "content": "ack"}));
 }
 
 #[test]

--- a/src-tauri/src/protocol/codec/messages.rs
+++ b/src-tauri/src/protocol/codec/messages.rs
@@ -36,6 +36,7 @@ pub fn encode_messages_to_chat(
         "top_p",
         "stop_sequences",
         "stream",
+        "stream_options",
         "tools",
         "tool_choice",
         "system",
@@ -278,7 +279,7 @@ fn convert_anthropic_message_to_chat(
         )
     })?;
     match role {
-        "user" | "assistant" => {}
+        "user" | "assistant" | "system" => {}
         other => {
             return Err(UnsupportedFeatures::single(
                 FeatureKind::UnknownRole,
@@ -289,6 +290,19 @@ fn convert_anthropic_message_to_chat(
     }
 
     let content = msg.get("content");
+    if role == "system" {
+        let content = content.ok_or_else(|| {
+            UnsupportedFeatures::single(
+                FeatureKind::UnknownBlock,
+                format!("{pointer}/content"),
+                "system message missing content",
+            )
+        })?;
+        let text =
+            request::anthropic_system_to_chat(content, &format!("{pointer}/content"), normalized)?;
+        return Ok(vec![serde_json::json!({"role": "system", "content": text})]);
+    }
+
     let content_arr = content.and_then(Value::as_array);
     if let Some(items) = content_arr {
         let mut user_parts: Vec<Value> = Vec::new();

--- a/src-tauri/src/protocol/mod.rs
+++ b/src-tauri/src/protocol/mod.rs
@@ -634,32 +634,11 @@ pub fn anthropic_to_openai(body: &Value) -> Result<Value, String> {
         .and_then(|s| s.as_bool())
         .unwrap_or(false);
 
-    // Extract system message and prepend it
-    let system = body.get("system").map(|s| {
-        if let Some(str_val) = s.as_str() {
-            Ok(str_val.to_string())
-        } else if let Some(arr) = s.as_array() {
-            let mut texts = Vec::new();
-            for block in arr {
-                // Prompt caching changes Anthropic billing/cache behavior but
-                // not the text content of a Chat Completions request.  It is
-                // safe to drop this annotation on the OpenAI bridge; native
-                // channels still receive the original body unchanged.
-                match block.get("type").and_then(|t| t.as_str()) {
-                    Some("text") => texts.push(block.get("text").and_then(|t| t.as_str()).unwrap_or("").to_string()),
-                    Some("thinking") => {
-                        // Fail-open: reasoning instructions on the system prompt
-                        // are dropped (no Chat equivalent), not rejected.
-                    }
-                    Some("cache_control") => return Err("system cache_control blocks require a native Anthropic Messages channel".to_string()),
-                    _ => return Err("unsupported non-text system content requires a native Anthropic Messages channel".to_string()),
-                }
-            }
-            Ok(texts.join(""))
-        } else {
-            Err("system must be text or an array of text blocks".to_string())
-        }
-    }).transpose()?;
+    // Extract top-level system message and prepend it.
+    let system = body
+        .get("system")
+        .map(anthropic_system_content_to_openai_text)
+        .transpose()?;
 
     // Convert Anthropic message content (array format) to OpenAI string format
     let openai_messages = convert_anthropic_messages_to_openai(&messages, system)?;
@@ -767,7 +746,20 @@ pub fn anthropic_to_openai(body: &Value) -> Result<Value, String> {
             };
             openai_body["tool_choice"] = openai_tc;
         } else if let Some(s) = tc.as_str() {
-            openai_body["tool_choice"] = Value::String(s.to_string());
+            let openai_tc = match s {
+                "auto" => Value::String("auto".to_string()),
+                "any" => Value::String("required".to_string()),
+                "tool" => return Err("Anthropic tool_choice 'tool' requires a name".to_string()),
+                _ => {
+                    return Err(
+                        "unsupported Anthropic tool_choice requires a native Anthropic Messages channel"
+                            .to_string(),
+                    )
+                }
+            };
+            openai_body["tool_choice"] = openai_tc;
+        } else {
+            return Err("unsupported Anthropic tool_choice requires a native Anthropic Messages channel".to_string());
         }
     }
 
@@ -860,6 +852,48 @@ fn tool_result_to_openai_content(block: &Value) -> Result<String, String> {
     }
 }
 
+fn anthropic_system_content_to_openai_text(value: &Value) -> Result<String, String> {
+    if let Some(str_val) = value.as_str() {
+        Ok(str_val.to_string())
+    } else if let Some(arr) = value.as_array() {
+        let mut texts = Vec::new();
+        for block in arr {
+            // Prompt caching changes Anthropic billing/cache behavior but not
+            // the text content of a Chat Completions request.  It is safe to
+            // drop this annotation on the OpenAI bridge; native channels still
+            // receive the original body unchanged.
+            match block.get("type").and_then(|t| t.as_str()) {
+                Some("text") => texts.push(
+                    block
+                        .get("text")
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                ),
+                Some("thinking") => {
+                    // Fail-open: reasoning instructions on the system prompt
+                    // are dropped (no Chat equivalent), not rejected.
+                }
+                Some("cache_control") => {
+                    return Err(
+                        "system cache_control blocks require a native Anthropic Messages channel"
+                            .to_string(),
+                    )
+                }
+                _ => {
+                    return Err(
+                        "unsupported non-text system content requires a native Anthropic Messages channel"
+                            .to_string(),
+                    )
+                }
+            }
+        }
+        Ok(texts.join(""))
+    } else {
+        Err("system must be text or an array of text blocks".to_string())
+    }
+}
+
 /// Convert Anthropic messages array to OpenAI messages array.
 /// Anthropic content can be string or array of content blocks.
 /// Handles: text, tool_use (assistant), tool_result (user)
@@ -881,8 +915,19 @@ fn convert_anthropic_messages_to_openai(
                 .and_then(|r| r.as_str())
                 .ok_or_else(|| "Anthropic message is missing role".to_string())?
                 .to_string();
-            if role != "user" && role != "assistant" {
-                return Err("only user and assistant Anthropic messages can be sent to OpenAI Chat Completions".to_string());
+            if role != "user" && role != "assistant" && role != "system" {
+                return Err("only user, assistant, and system Anthropic messages can be sent to OpenAI Chat Completions".to_string());
+            }
+
+            if role == "system" {
+                let content = msg
+                    .get("content")
+                    .ok_or_else(|| "system message is missing content".to_string())?;
+                msgs.push(serde_json::json!({
+                    "role": "system",
+                    "content": anthropic_system_content_to_openai_text(content)?,
+                }));
+                continue;
             }
 
             if let Some(content_arr) = msg.get("content").and_then(|c| c.as_array()) {
@@ -916,7 +961,11 @@ fn convert_anthropic_messages_to_openai(
                             if role != "assistant" { return Err("tool_use blocks must be in an assistant message".to_string()); }
                             let id = block.get("id").and_then(|i| i.as_str()).filter(|s| !s.is_empty()).ok_or_else(|| "tool_use is missing id".to_string())?;
                             let name = block.get("name").and_then(|n| n.as_str()).filter(|s| !s.is_empty()).ok_or_else(|| "tool_use is missing name".to_string())?;
-                            let input = block.get("input").cloned().unwrap_or_else(|| serde_json::json!({}));
+                            let input = block.get("input").ok_or_else(|| "tool_use is missing input".to_string())?;
+                            if !input.is_object() {
+                                return Err("tool_use input must be a JSON object".to_string());
+                            }
+                            let input = input.clone();
                             tool_calls.push(serde_json::json!({"id": id, "type": "function", "function": {"name": name, "arguments": serde_json::to_string(&input).map_err(|e| e.to_string())?}}));
                         }
                         "tool_result" => {
@@ -1044,6 +1093,75 @@ mod anthropic_tests {
         );
         assert_eq!(converted["messages"][2]["role"], "tool");
         assert_eq!(converted["messages"][3]["content"][0]["text"], "thanks");
+    }
+
+    #[test]
+    fn maps_mid_conversation_system_messages_to_chat_system_role() {
+        let request = serde_json::json!({
+            "model": "claude-compatible",
+            "messages": [
+                {"role":"user", "content":"use the strict profile"},
+                {"role":"system", "content":[{"type":"text", "text":"strict profile active", "cache_control":{"type":"ephemeral"}}]},
+                {"role":"assistant", "content":[{"type":"text", "text":"ack"}]}
+            ]
+        });
+        let converted = anthropic_to_openai(&request).unwrap();
+        assert_eq!(converted["messages"][0]["role"], "user");
+        assert_eq!(converted["messages"][1]["role"], "system");
+        assert_eq!(converted["messages"][1]["content"], "strict profile active");
+        assert_eq!(converted["messages"][2]["role"], "assistant");
+    }
+
+    #[test]
+    fn legacy_tool_choice_strings_map_or_reject() {
+        for (input, expected) in [("auto", "auto"), ("any", "required")] {
+            let request = serde_json::json!({
+                "model": "model",
+                "messages": [{"role":"user", "content":"hi"}],
+                "tool_choice": input
+            });
+            let converted = anthropic_to_openai(&request).unwrap();
+            assert_eq!(converted["tool_choice"], expected);
+        }
+
+        let request = serde_json::json!({
+            "model": "model",
+            "messages": [{"role":"user", "content":"hi"}],
+            "tool_choice": "tool"
+        });
+        assert!(anthropic_to_openai(&request).is_err());
+
+        let request = serde_json::json!({
+            "model": "model",
+            "messages": [{"role":"user", "content":"hi"}],
+            "tool_choice": "bogus"
+        });
+        assert!(anthropic_to_openai(&request).is_err());
+    }
+
+    #[test]
+    fn legacy_tool_use_requires_input_not_fabricated() {
+        let request = serde_json::json!({
+            "model": "model",
+            "messages": [{"role":"assistant", "content":[{"type":"tool_use", "id":"call_1", "name":"run"}]}]
+        });
+        assert!(anthropic_to_openai(&request).is_err());
+
+        let request = serde_json::json!({
+            "model": "model",
+            "messages": [{"role":"assistant", "content":[{"type":"tool_use", "id":"call_1", "name":"run", "input":[]}]}]
+        });
+        assert!(anthropic_to_openai(&request).is_err());
+
+        let request = serde_json::json!({
+            "model": "model",
+            "messages": [{"role":"assistant", "content":[{"type":"tool_use", "id":"call_1", "name":"run", "input":{}}]}]
+        });
+        let converted = anthropic_to_openai(&request).unwrap();
+        assert_eq!(
+            converted["messages"][0]["tool_calls"][0]["function"]["arguments"],
+            "{}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/protocol/mod.rs
+++ b/src-tauri/src/protocol/mod.rs
@@ -281,6 +281,25 @@ fn convert_responses_input_to_messages(input: &Value) -> Value {
         let mut call_id_fallback: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();
         let mut fallback_counter = 0u32;
+        // Whether a `function_call` item appears anywhere AFTER index `i`.
+        // A `reasoning` item followed (possibly through an intermediate
+        // assistant text message) by function_calls belongs to that
+        // tool-calling turn: its text must ride on the assistant(tool_calls)
+        // message emitted at flush time, NOT on the intermediate text message.
+        // DeepSeek thinking mode rejects the follow-up otherwise with
+        // "The reasoning_content in the thinking mode must be passed back."
+        let function_call_after: Vec<bool> = {
+            let mut v = vec![false; arr.len()];
+            let mut seen = false;
+            for (i, item) in arr.iter().enumerate().rev() {
+                v[i] = seen;
+                if item.get("type").and_then(|t| t.as_str()) == Some("function_call") {
+                    seen = true;
+                }
+            }
+            v
+        };
+
         for item in arr {
             let item_type = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
             match item_type {
@@ -386,7 +405,7 @@ fn convert_responses_input_to_messages(input: &Value) -> Value {
             pending_tool_calls.clear();
         };
 
-        for item in arr {
+        for (idx, item) in arr.iter().enumerate() {
             let item_type = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
 
             match item_type {
@@ -518,7 +537,18 @@ fn convert_responses_input_to_messages(input: &Value) -> Value {
                             .get("reasoning_content")
                             .and_then(|r| r.as_str())
                             .map(|s| s.to_string())
-                            .or_else(|| pending_reasoning.take());
+                            .or_else(|| {
+                                // If this assistant text message is part of a
+                                // tool-calling turn (function_calls follow it),
+                                // keep the reasoning for the assistant(tool_calls)
+                                // message emitted at flush — that is the message
+                                // DeepSeek's thinking mode requires it on.
+                                if function_call_after[idx] {
+                                    None
+                                } else {
+                                    pending_reasoning.take()
+                                }
+                            });
                         if let Some(rc) = rc {
                             if !rc.is_empty() {
                                 msg["reasoning_content"] = Value::String(rc);
@@ -526,8 +556,11 @@ fn convert_responses_input_to_messages(input: &Value) -> Value {
                         }
                     } else {
                         // A reasoning item belongs to the assistant message that
-                        // immediately follows it; drop it before any other role.
-                        pending_reasoning = None;
+                        // immediately follows it; drop it before any other role —
+                        // unless a buffered tool call still needs to flush with it.
+                        if pending_tool_calls.is_empty() && awaiting.is_empty() {
+                            pending_reasoning = None;
+                        }
                     }
                     // Defer regular messages while tool responses are pending so
                     // they never interrupt an assistant(tool_calls)→tool(...) run.
@@ -1560,6 +1593,75 @@ mod anthropic_tests {
     }
 
     #[test]
+    fn responses_input_reasoning_stays_on_tool_calls_message() {
+        // Real Codex echo order (captured from the local gateway log):
+        // reasoning → assistant text → function_call → function_call_output.
+        // DeepSeek thinking mode requires `reasoning_content` on the
+        // assistant(tool_calls) message; consuming it on the intermediate
+        // text message makes the follow-up fail with
+        // "The reasoning_content in the thinking mode must be passed back
+        // to the API."
+        let input = serde_json::json!([
+            {"type": "reasoning", "id": "rs_a", "summary": [{"type": "summary_text", "text": "Let me check the file."}]},
+            {"type": "message", "id": "msg_a", "role": "assistant", "content": [{"type": "output_text", "text": "Let me look at that."}]},
+            {"type": "function_call", "id": "fc_1", "call_id": "call_A", "name": "read", "arguments": "{\"path\":\"/tmp/x\"}"},
+            {"type": "function_call_output", "call_id": "call_A", "output": "file contents"},
+            {"type": "message", "id": "msg_u", "role": "user", "content": [{"type": "input_text", "text": "continue"}]}
+        ]);
+        let messages = convert_responses_input_to_messages(&input);
+        let msgs = messages.as_array().unwrap();
+
+        // The tool-calling assistant message MUST carry the reasoning.
+        let tool_call_msg = msgs
+            .iter()
+            .find(|m| m["role"] == "assistant" && m.get("tool_calls").is_some())
+            .unwrap();
+        assert_eq!(tool_call_msg["reasoning_content"], "Let me check the file.");
+        assert_eq!(tool_call_msg["tool_calls"][0]["id"], "call_A");
+        assert_eq!(msgs[0]["role"], "assistant");
+
+        // The intermediate assistant text message must NOT have consumed it.
+        let text_msg = msgs
+            .iter()
+            .find(|m| m["role"] == "assistant" && m.get("tool_calls").is_none())
+            .unwrap();
+        assert_eq!(text_msg["content"], "Let me look at that.");
+        assert!(
+            text_msg.get("reasoning_content").is_none()
+                || text_msg["reasoning_content"].as_str().unwrap_or("").is_empty(),
+            "reasoning must not be consumed by the intermediate text message"
+        );
+
+        // Tool output still follows the tool_calls assistant message.
+        assert_eq!(
+            msgs[2],
+            serde_json::json!({"role": "tool", "tool_call_id": "call_A", "content": "file contents"})
+        );
+    }
+
+    #[test]
+    fn responses_input_reasoning_with_user_interleaved_before_output() {
+        // Codex can interleave a user text message between function_call and
+        // function_call_output. The reasoning must survive until the
+        // assistant(tool_calls) flush even across that user message.
+        let input = serde_json::json!([
+            {"type": "reasoning", "id": "rs_a", "summary": [{"type": "summary_text", "text": "thinking"}]},
+            {"type": "function_call", "id": "fc_1", "call_id": "call_A", "name": "shell", "arguments": "{}"},
+            {"type": "message", "id": "msg_ok", "role": "user", "content": [{"type": "input_text", "text": "Approved command prefix saved"}]},
+            {"type": "function_call_output", "call_id": "call_A", "output": "done"},
+            {"type": "message", "id": "msg_next", "role": "user", "content": [{"type": "input_text", "text": "next"}]}
+        ]);
+        let messages = convert_responses_input_to_messages(&input);
+        let msgs = messages.as_array().unwrap();
+        let tool_call_msg = msgs
+            .iter()
+            .find(|m| m["role"] == "assistant" && m.get("tool_calls").is_some())
+            .unwrap();
+        assert_eq!(tool_call_msg["reasoning_content"], "thinking");
+        assert_eq!(msgs[1]["role"], "tool");
+    }
+
+    #[test]
     fn responses_input_parallel_function_calls_merge_into_one_assistant() {
         // Parallel function_calls must be merged into ONE assistant message with a
         // multi-element tool_calls array, immediately followed by their tool
@@ -1674,3 +1776,4 @@ mod anthropic_tests {
         assert_eq!(msgs[4], serde_json::json!({"role": "tool", "tool_call_id": "call_B", "content": "file contents"}));
     }
 }
+

--- a/src-tauri/src/protocol/mod.rs
+++ b/src-tauri/src/protocol/mod.rs
@@ -314,11 +314,110 @@ fn convert_responses_input_to_messages(input: &Value) -> Value {
         }
 
         let mut msgs = Vec::new();
+        // Reasoning from a preceding `reasoning` item is attached to the next
+        // assistant message as `reasoning_content`. Without this, thinking-mode
+        // providers (e.g. DeepSeek) reject multi-turn requests with
+        // "The `reasoning_content` in the thinking mode must be passed back."
+        let mut pending_reasoning: Option<String> = None;
+        // Function_call items are buffered and flushed together as ONE assistant
+        // message with a multi-element `tool_calls` array. Emitting a separate
+        // assistant message per call breaks parallel tool use: DeepSeek rejects any
+        // assistant message carrying tool_calls that isn't immediately followed by
+        // tool messages for each of its call_ids.
+        let mut pending_tool_calls: Vec<(String, String, String)> = Vec::new();
+        // call_ids whose tool response is still awaited (their real output exists
+        // later in the input). Regular messages are deferred until this empties so
+        // they never sit between an assistant(tool_calls) and its tool messages.
+        let mut awaiting: std::collections::HashSet<String> = std::collections::HashSet::new();
+        // Regular messages deferred while tool responses are pending.
+        let mut deferred: Vec<Value> = Vec::new();
+
+        // Flush buffered function_calls as one assistant message. For each call:
+        // if a real output exists later in the input, mark it awaiting; otherwise
+        // synthesize an empty tool response so upstream never sees an unanswered
+        // tool_call_id.
+        let flush_tool_calls = |msgs: &mut Vec<Value>,
+                                pending_tool_calls: &mut Vec<(String, String, String)>,
+                                awaiting: &mut std::collections::HashSet<String>,
+                                output_ids: &std::collections::HashSet<String>,
+                                pending_reasoning: &mut Option<String>| {
+            if pending_tool_calls.is_empty() {
+                return;
+            }
+            // Never flush a new tool batch while an earlier assistant(tool_calls)
+            // is still awaiting its tool replies. Doing so would emit a SECOND
+            // assistant message between the first one and its tool messages,
+            // which DeepSeek rejects ("assistant with tool_calls must be
+            // followed by tool messages responding to each tool_call_id"). The
+            // new calls stay buffered and flush together once awaiting drains.
+            if !awaiting.is_empty() {
+                return;
+            }
+            let tool_calls: Vec<Value> = pending_tool_calls
+                .iter()
+                .map(|(cid, name, arguments)| {
+                    serde_json::json!({
+                        "id": cid,
+                        "type": "function",
+                        "function": {"name": name, "arguments": arguments}
+                    })
+                })
+                .collect();
+            let mut msg = serde_json::json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": tool_calls,
+            });
+            if let Some(rc) = pending_reasoning.take() {
+                msg["reasoning_content"] = Value::String(rc);
+            }
+            msgs.push(msg);
+            for (cid, _, _) in pending_tool_calls.iter() {
+                if output_ids.contains(cid) {
+                    awaiting.insert(cid.clone());
+                } else {
+                    msgs.push(serde_json::json!({
+                        "role": "tool",
+                        "tool_call_id": cid,
+                        "content": ""
+                    }));
+                }
+            }
+            pending_tool_calls.clear();
+        };
+
         for item in arr {
             let item_type = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
 
             match item_type {
-                // function_call: assistant's tool call → OpenAI assistant message with tool_calls
+                // reasoning: thinking chain → attach as reasoning_content on the following assistant message
+                "reasoning" => {
+                    let mut text = String::new();
+                    if let Some(summary) = item.get("summary").and_then(|s| s.as_array()) {
+                        for block in summary {
+                            if let Some(t) = block.get("text").and_then(|t| t.as_str()) {
+                                text.push_str(t);
+                            }
+                        }
+                    }
+                    if let Some(content) = item.get("content").and_then(|c| c.as_array()) {
+                        for block in content {
+                            if let Some(t) = block.get("text").and_then(|t| t.as_str()) {
+                                text.push_str(t);
+                            }
+                        }
+                    }
+                    if text.is_empty() {
+                        if let Some(t) = item.get("text").and_then(|t| t.as_str()) {
+                            text = t.to_string();
+                        }
+                    }
+                    if !text.is_empty() {
+                        pending_reasoning = Some(text);
+                    }
+                }
+
+                // function_call: assistant's tool call → buffer for the next merged assistant message
                 "function_call" => {
                     let name = item.get("name").and_then(|n| n.as_str()).unwrap_or("");
                     let arguments = item.get("arguments").and_then(|a| a.as_str()).unwrap_or("");
@@ -332,31 +431,19 @@ fn convert_responses_input_to_messages(input: &Value) -> Value {
                         .get(&original_call_id)
                         .cloned()
                         .unwrap_or(original_call_id);
-                    msgs.push(serde_json::json!({
-                        "role": "assistant",
-                        "content": null,
-                        "tool_calls": [{
-                            "id": call_id,
-                            "type": "function",
-                            "function": {
-                                "name": name,
-                                "arguments": arguments
-                            }
-                        }]
-                    }));
-                    // If this function_call has no matching output, synthesize an empty tool response
-                    // to prevent upstream "tool_call_ids did not have response messages" errors
-                    if !output_ids.contains(&call_id) {
-                        msgs.push(serde_json::json!({
-                            "role": "tool",
-                            "tool_call_id": call_id,
-                            "content": ""
-                        }));
-                    }
+                    pending_tool_calls.push((call_id, name.to_string(), arguments.to_string()));
                 }
 
-                // function_call_output: tool result → OpenAI tool message
+                // function_call_output: tool result → OpenAI tool message, then
+                // release any deferred messages once every awaited output has landed
                 "function_call_output" => {
+                    flush_tool_calls(
+                        &mut msgs,
+                        &mut pending_tool_calls,
+                        &mut awaiting,
+                        &output_ids,
+                        &mut pending_reasoning,
+                    );
                     let original_call_id = item
                         .get("call_id")
                         .and_then(|c| c.as_str())
@@ -368,15 +455,27 @@ fn convert_responses_input_to_messages(input: &Value) -> Value {
                         .cloned()
                         .unwrap_or(original_call_id);
                     let output = item.get("output").and_then(|o| o.as_str()).unwrap_or("");
+                    awaiting.remove(&call_id);
                     msgs.push(serde_json::json!({
                         "role": "tool",
                         "tool_call_id": call_id,
                         "content": output
                     }));
+                    // Tool responses are in; regular messages can be emitted again.
+                    if awaiting.is_empty() {
+                        msgs.append(&mut deferred);
+                    }
                 }
 
                 // message: standard chat message
                 "message" | _ if item.get("role").is_some() => {
+                    flush_tool_calls(
+                        &mut msgs,
+                        &mut pending_tool_calls,
+                        &mut awaiting,
+                        &output_ids,
+                        &mut pending_reasoning,
+                    );
                     let role = item
                         .get("role")
                         .and_then(|r| r.as_str())
@@ -407,31 +506,92 @@ fn convert_responses_input_to_messages(input: &Value) -> Value {
                         } else {
                             Value::String(String::new())
                         };
-                    msgs.push(serde_json::json!({
+                    let mut msg = serde_json::json!({
                         "role": role,
                         "content": content,
-                    }));
+                    });
+                    // Attach reasoning_content (from a preceding `reasoning` item,
+                    // or carried directly on this message) for assistant turns so
+                    // thinking-mode providers accept the request.
+                    if role == "assistant" {
+                        let rc = item
+                            .get("reasoning_content")
+                            .and_then(|r| r.as_str())
+                            .map(|s| s.to_string())
+                            .or_else(|| pending_reasoning.take());
+                        if let Some(rc) = rc {
+                            if !rc.is_empty() {
+                                msg["reasoning_content"] = Value::String(rc);
+                            }
+                        }
+                    } else {
+                        // A reasoning item belongs to the assistant message that
+                        // immediately follows it; drop it before any other role.
+                        pending_reasoning = None;
+                    }
+                    // Defer regular messages while tool responses are pending so
+                    // they never interrupt an assistant(tool_calls)→tool(...) run.
+                    if awaiting.is_empty() {
+                        msgs.push(msg);
+                    } else {
+                        deferred.push(msg);
+                    }
                 }
 
                 // Simple text item
                 _ if item.get("text").is_some() => {
+                    flush_tool_calls(
+                        &mut msgs,
+                        &mut pending_tool_calls,
+                        &mut awaiting,
+                        &output_ids,
+                        &mut pending_reasoning,
+                    );
                     let text = item.get("text").and_then(|t| t.as_str()).unwrap_or("");
-                    msgs.push(serde_json::json!({
+                    let msg = serde_json::json!({
                         "role": "user",
                         "content": text,
-                    }));
+                    });
+                    if awaiting.is_empty() {
+                        msgs.push(msg);
+                    } else {
+                        deferred.push(msg);
+                    }
                 }
 
                 // Raw string input
                 _ => {
                     if let Some(s) = item.as_str() {
-                        msgs.push(serde_json::json!({
+                        flush_tool_calls(
+                            &mut msgs,
+                            &mut pending_tool_calls,
+                            &mut awaiting,
+                            &output_ids,
+                            &mut pending_reasoning,
+                        );
+                        let msg = serde_json::json!({
                             "role": "user",
                             "content": s,
-                        }));
+                        });
+                        if awaiting.is_empty() {
+                            msgs.push(msg);
+                        } else {
+                            deferred.push(msg);
+                        }
                     }
                 }
             }
+        }
+        // End of input: flush any buffered tool calls and remaining deferred messages.
+        flush_tool_calls(
+            &mut msgs,
+            &mut pending_tool_calls,
+            &mut awaiting,
+            &output_ids,
+            &mut pending_reasoning,
+        );
+        if awaiting.is_empty() {
+            msgs.append(&mut deferred);
         }
         msgs
     } else if let Some(s) = input.as_str() {
@@ -1273,5 +1433,244 @@ mod anthropic_tests {
         assert_eq!(converted["content"][0]["thinking"], "chain");
         assert_eq!(converted["content"][1]["type"], "text");
         assert_eq!(converted["content"][1]["text"], "answer");
+    }
+
+    #[test]
+    fn responses_input_reasoning_item_becomes_assistant_reasoning_content() {
+        // A `reasoning` item must be forwarded to the upstream Chat request as
+        // `reasoning_content` on the assistant message it precedes. Without this,
+        // DeepSeek thinking models reject the 2nd+ turn with
+        // "The `reasoning_content` in the thinking mode must be passed back."
+        let input = serde_json::json!([
+            {
+                "type": "reasoning",
+                "id": "rs_abc",
+                "summary": [{"type": "summary_text", "text": "Let me think."}],
+                "content": [{"type": "reasoning_text", "text": "chain of thought"}]
+            },
+            {
+                "type": "message",
+                "id": "msg_xyz",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "The answer is 42."}]
+            }
+        ]);
+        let messages = convert_responses_input_to_messages(&input);
+        let msgs = messages.as_array().unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0]["role"], "assistant");
+        assert_eq!(msgs[0]["content"], "The answer is 42.");
+        assert_eq!(msgs[0]["reasoning_content"], "Let me think.chain of thought");
+    }
+
+    #[test]
+    fn responses_input_reasoning_item_without_content_still_preserved() {
+        // DeepSeek-compatible: even a reasoning item with only a summary must be
+        // forwarded as reasoning_content (no crash, no drop).
+        let input = serde_json::json!([
+            {"type": "reasoning", "id": "rs_abc", "summary": [{"type": "summary_text", "text": "Let me think."}]},
+            {"type": "message", "id": "msg_xyz", "role": "assistant", "content": [{"type": "output_text", "text": "Hi"}]}
+        ]);
+        let messages = convert_responses_input_to_messages(&input);
+        let msgs = messages.as_array().unwrap();
+        assert_eq!(msgs[0]["reasoning_content"], "Let me think.");
+    }
+
+    #[test]
+    fn responses_input_message_carries_reasoning_content_directly() {
+        // Some clients attach reasoning_content directly to the message item.
+        let input = serde_json::json!([
+            {"type": "message", "id": "msg_xyz", "role": "assistant",
+             "reasoning_content": "direct chain",
+             "content": [{"type": "output_text", "text": "Hi"}]}
+        ]);
+        let messages = convert_responses_input_to_messages(&input);
+        let msgs = messages.as_array().unwrap();
+        assert_eq!(msgs[0]["reasoning_content"], "direct chain");
+    }
+
+    #[test]
+    fn responses_reasoning_round_trip_to_chat() {
+        // Simulates the full Codex repro: upstream DeepSeek streams reasoning_content,
+        // WaLiAPI emits a `reasoning` item in Responses API format, then the next
+        // turn's input (echoing that reasoning item) converts back to Chat with
+        // `reasoning_content` so DeepSeek accepts the request.
+        use crate::protocol::responses::{
+            create_synthetic_completed_events, convert_openai_sse_to_responses, StreamState,
+        };
+
+        let response_id = "resp_repro";
+        let mut state = StreamState::default();
+
+        // Upstream turn output: reasoning_content then content, then stop.
+        let ev1 = convert_openai_sse_to_responses(
+            r#"data: {"id":"c1","choices":[{"index":0,"delta":{"reasoning_content":"deepseek thought"},"finish_reason":null}]}"#,
+            "deepseek-v4-flash",
+            response_id,
+            "",
+            &mut state,
+        );
+        let ev2 = convert_openai_sse_to_responses(
+            r#"data: {"id":"c1","choices":[{"index":0,"delta":{"content":"answer"},"finish_reason":null}]}"#,
+            "deepseek-v4-flash",
+            response_id,
+            "answer",
+            &mut state,
+        );
+        let ev3 = convert_openai_sse_to_responses(
+            r#"data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#,
+            "deepseek-v4-flash",
+            response_id,
+            "answer",
+            &mut state,
+        );
+        let ev4 = create_synthetic_completed_events(
+            "deepseek-v4-flash",
+            response_id,
+            "answer",
+            &state,
+            10,
+            5,
+        );
+
+        // The stream Codex receives must announce + complete the reasoning item.
+        let stream: String = ev1
+            .into_iter()
+            .chain(ev2)
+            .chain(ev3)
+            .chain(ev4)
+            .collect();
+        assert!(stream.contains("\"type\":\"response.output_item.added\""));
+        assert!(stream.contains("\"type\":\"reasoning\""));
+        assert!(stream.contains("\"type\":\"reasoning_summary_text\""));
+        assert!(stream.contains("deepseek thought"));
+        assert!(stream.contains("\"type\":\"response.completed\""));
+
+        // Next turn: Codex echoes reasoning + message items back in input.
+        let next_input = serde_json::json!([
+            {"type": "reasoning", "id": "rs_repro", "summary": [{"type": "summary_text", "text": "deepseek thought"}]},
+            {"type": "message", "id": "msg_repro", "role": "assistant", "content": [{"type": "output_text", "text": "answer"}]},
+            {"type": "message", "id": "msg_u2", "role": "user", "content": [{"type": "input_text", "text": "continue"}]}
+        ]);
+        let messages = convert_responses_input_to_messages(&next_input);
+        let msgs = messages.as_array().unwrap();
+        let assistant = msgs.iter().find(|m| m["role"] == "assistant").unwrap();
+        assert_eq!(assistant["reasoning_content"], "deepseek thought");
+        assert_eq!(assistant["content"], "answer");
+    }
+
+    #[test]
+    fn responses_input_parallel_function_calls_merge_into_one_assistant() {
+        // Parallel function_calls must be merged into ONE assistant message with a
+        // multi-element tool_calls array, immediately followed by their tool
+        // messages. Splitting them into per-call assistant messages makes DeepSeek
+        // reject the request ("assistant with tool_calls must be followed by tool
+        // messages responding to each tool_call_id").
+        let input = serde_json::json!([
+            {"type": "function_call", "call_id": "call_A", "name": "read", "arguments": "{}"},
+            {"type": "function_call", "call_id": "call_B", "name": "grep", "arguments": "{}"},
+            {"type": "function_call_output", "call_id": "call_A", "output": "file contents"},
+            {"type": "function_call_output", "call_id": "call_B", "output": "matched lines"}
+        ]);
+        let messages = convert_responses_input_to_messages(&input);
+        let msgs = messages.as_array().unwrap();
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[0]["role"], "assistant");
+        assert_eq!(msgs[0]["tool_calls"].as_array().unwrap().len(), 2);
+        assert_eq!(msgs[0]["tool_calls"][0]["id"], "call_A");
+        assert_eq!(msgs[0]["tool_calls"][1]["id"], "call_B");
+        assert_eq!(msgs[1], serde_json::json!({"role": "tool", "tool_call_id": "call_A", "content": "file contents"}));
+        assert_eq!(msgs[2], serde_json::json!({"role": "tool", "tool_call_id": "call_B", "content": "matched lines"}));
+    }
+
+    #[test]
+    fn responses_input_defers_text_message_until_tool_output() {
+        // Codex interleaves a user text message ("Approved command prefix saved")
+        // between function_call and function_call_output. That text must be
+        // deferred until the tool output lands, so the assistant(tool_calls) is
+        // immediately followed by its tool message.
+        let input = serde_json::json!([
+            {"type": "function_call", "call_id": "call_A", "name": "shell", "arguments": "{}"},
+            {"type": "message", "id": "msg_ok", "role": "user", "content": [{"type": "input_text", "text": "Approved command prefix saved"}]},
+            {"type": "function_call_output", "call_id": "call_A", "output": "done"},
+            {"type": "message", "id": "msg_next", "role": "user", "content": [{"type": "input_text", "text": "next"}]}
+        ]);
+        let messages = convert_responses_input_to_messages(&input);
+        let msgs = messages.as_array().unwrap();
+        assert_eq!(msgs.len(), 4);
+        assert_eq!(msgs[0]["role"], "assistant");
+        assert_eq!(msgs[0]["tool_calls"][0]["id"], "call_A");
+        assert_eq!(msgs[1], serde_json::json!({"role": "tool", "tool_call_id": "call_A", "content": "done"}));
+        assert_eq!(msgs[2], serde_json::json!({"role": "user", "content": "Approved command prefix saved"}));
+        assert_eq!(msgs[3], serde_json::json!({"role": "user", "content": "next"}));
+    }
+
+    #[test]
+    fn responses_input_orphan_function_call_gets_empty_tool_response() {
+        // A function_call with no matching output must still get a synthesized
+        // empty tool message, otherwise the assistant(tool_calls) has no response.
+        let input = serde_json::json!([
+            {"type": "function_call", "call_id": "call_A", "name": "shell", "arguments": "{}"},
+            {"type": "message", "id": "msg_next", "role": "user", "content": [{"type": "input_text", "text": "next"}]}
+        ]);
+        let messages = convert_responses_input_to_messages(&input);
+        let msgs = messages.as_array().unwrap();
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[0]["role"], "assistant");
+        assert_eq!(msgs[0]["tool_calls"][0]["id"], "call_A");
+        assert_eq!(msgs[1], serde_json::json!({"role": "tool", "tool_call_id": "call_A", "content": ""}));
+        assert_eq!(msgs[2], serde_json::json!({"role": "user", "content": "next"}));
+    }
+
+    #[test]
+    fn responses_input_reasoning_attaches_to_merged_tool_calls_message() {
+        // When reasoning directly precedes parallel function_calls, the reasoning
+        // content is attached to the merged assistant tool_calls message.
+        let input = serde_json::json!([
+            {"type": "reasoning", "id": "rs_1", "summary": [{"type": "summary_text", "text": "think"}]},
+            {"type": "function_call", "call_id": "call_A", "name": "read", "arguments": "{}"},
+            {"type": "function_call", "call_id": "call_B", "name": "grep", "arguments": "{}"},
+            {"type": "function_call_output", "call_id": "call_A", "output": "a"},
+            {"type": "function_call_output", "call_id": "call_B", "output": "b"}
+        ]);
+        let messages = convert_responses_input_to_messages(&input);
+        let msgs = messages.as_array().unwrap();
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[0]["role"], "assistant");
+        assert_eq!(msgs[0]["reasoning_content"], "think");
+        assert_eq!(msgs[0]["tool_calls"].as_array().unwrap().len(), 2);
+        assert_eq!(msgs[1]["role"], "tool");
+        assert_eq!(msgs[2]["role"], "tool");
+    }
+
+    #[test]
+    fn responses_input_interleaved_call_never_leaves_orphan_assistant() {
+        // A second function_call that arrives AFTER a user confirmation message
+        // (still awaiting tool output for a prior call) must NOT be flushed as a
+        // separate assistant message while the first one is still awaiting its
+        // tool reply. Flushing it mid-await would emit
+        // `assistant(tool_calls=[A]), assistant(tool_calls=[B]), tool_A, ...`
+        // — the first assistant left without its tool message, which DeepSeek
+        // rejects exactly like the original 502. Each assistant(tool_calls)
+        // must be immediately followed by its own tool messages.
+        let input = serde_json::json!([
+            {"type": "function_call", "call_id": "call_A", "name": "shell", "arguments": "{}"},
+            {"type": "message", "id": "msg_ok", "role": "user", "content": [{"type": "input_text", "text": "Approved command prefix saved"}]},
+            {"type": "function_call", "call_id": "call_B", "name": "read", "arguments": "{}"},
+            {"type": "function_call_output", "call_id": "call_A", "output": "done"},
+            {"type": "function_call_output", "call_id": "call_B", "output": "file contents"}
+        ]);
+        let messages = convert_responses_input_to_messages(&input);
+        let msgs = messages.as_array().unwrap();
+        assert_eq!(msgs.len(), 5);
+        // assistant(A) is immediately followed by tool_A — never by assistant(B).
+        assert_eq!(msgs[0]["role"], "assistant");
+        assert_eq!(msgs[0]["tool_calls"][0]["id"], "call_A");
+        assert_eq!(msgs[1], serde_json::json!({"role": "tool", "tool_call_id": "call_A", "content": "done"}));
+        assert_eq!(msgs[2], serde_json::json!({"role": "user", "content": "Approved command prefix saved"}));
+        // assistant(B) starts a fresh, valid turn: tool_B follows it directly.
+        assert_eq!(msgs[3]["role"], "assistant");
+        assert_eq!(msgs[3]["tool_calls"][0]["id"], "call_B");
+        assert_eq!(msgs[4], serde_json::json!({"role": "tool", "tool_call_id": "call_B", "content": "file contents"}));
     }
 }

--- a/src-tauri/src/protocol/responses.rs
+++ b/src-tauri/src/protocol/responses.rs
@@ -2,6 +2,52 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+/// Reassembles upstream SSE records that arrive fragmented across TCP chunks.
+///
+/// ResponsesViaChat has no codec decoder, so a record split across TCP frames
+/// would otherwise be fed to [`convert_openai_sse_to_responses`] as several
+/// half-records and silently dropped (mid-JSON fragments never parse). Only
+/// complete records are returned here. This mirrors the `encode_responses_buffered`
+/// reassembly in the StreamPumpCore path — tool names / call ids / argument
+/// fragments are lost without it.
+#[derive(Default)]
+pub struct ResponsesSseAssembler {
+    pending: Vec<u8>,
+}
+
+impl ResponsesSseAssembler {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Feed one upstream chunk; returns every COMPLETE SSE record it contains.
+    /// A record whose terminator hasn't arrived yet is buffered for the next call.
+    pub fn push(&mut self, chunk: &str) -> Vec<String> {
+        self.pending.extend_from_slice(chunk.as_bytes());
+        let mut records = Vec::new();
+        while let Some(end) = crate::protocol::codec::sse::record_end(&self.pending) {
+            let record: Vec<u8> = self.pending.drain(..end).collect();
+            records.push(String::from_utf8_lossy(&record).into_owned());
+        }
+        records
+    }
+
+    /// Whether bytes are still buffered awaiting a record terminator.
+    pub fn has_pending(&self) -> bool {
+        !self.pending.is_empty()
+    }
+
+    /// Flush any trailing bytes at EOF as a final record (a record that
+    /// terminated exactly at EOF must not be lost).
+    pub fn flush(&mut self) -> Vec<String> {
+        if self.pending.is_empty() {
+            return Vec::new();
+        }
+        let tail = std::mem::take(&mut self.pending);
+        vec![String::from_utf8_lossy(&tail).into_owned()]
+    }
+}
+
 /// State for tracking streaming output items during OpenAI SSE → Responses SSE conversion.
 ///
 /// Tracks both text message items and function_call items so we can emit
@@ -1015,6 +1061,166 @@ mod tests {
             .trim_start_matches("data: ")
             .trim();
         serde_json::from_str(data_line).unwrap()
+    }
+
+    /// 63 raw upstream fragments captured from `handle_responses_stream` via
+    /// `WALIAPI_DEBUG_SSE` instrumentation (deepseek-v4-flash / OpenCode-GO
+    /// channel, 2026-08-08). Every SSE record is split across multiple TCP
+    /// chunks — often mid-JSON, with the `\n\n` terminator landing in a fragment
+    /// that starts mid-record. This is the real-world fragmentation that used to
+    /// drop tool names / call ids / argument fragments.
+    const REAL_FRAGMENTS: &[&str] = &[
+        "data: {\"id\":\"adba4265-1f45-4b6f-a564-ef2ca7a6e353\",\"ob",
+        "ject\":\"chat.completion.chunk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"role\":\"assistant\",\"content\":null,\"reasoning_content\":\"\"}}],\"usage\":null}\n\n",
+        "data: {\"id\":\"adba4265-1f45-",
+        "4b6f-a564-ef2ca7a6e353\",\"ob",
+        "ject\":\"chat.completion.chunk",
+        "\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"content\":\"I\",\"reasoning_content\":null}}],\"usage\":null}\n\n",
+        "data: {\"id\":\"adba4265-1f45-",
+        "4b6f-a564-ef2ca7a6e353\",\"ob",
+        "ject\":\"chat.completion.chunk",
+        "\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"content\":\"'ll\",\"reasoning_content\":null}}],\"usage\":null}\n\n",
+        "data: {\"id\":\"adba4265-1f4",
+        "5-4b6f-a564-ef2ca7a6e353\",",
+        "\"object\":\"chat.completion.chunk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"content\":\" read\",\"reasoning_content\":null}}],\"usage\":null}\n\ndata: {\"id\":\"adba4265-1f45-4b6f-a564-ef2ca7a6e353\",\"object\":\"chat.completion.chunk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"content\":\" the\",\"reasoning_content\":null}}],\"usage\":null}\n\n",
+        "data: {\"id\":\"adba4265-1f4",
+        "5-4b6f-a564-ef2ca7a6e353\",\"",
+        "object\":\"chat.completion.chu",
+        "nk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"content\":\" file\",\"reasoning_content\":null}}],\"usage\":null}\n\n",
+        "data: {\"id\":\"adba4265-1f45-",
+        "4b6f-a564-ef2ca7a6e353\",\"ob",
+        "ject\":\"chat.completion.chunk",
+        "\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"content\":\" at\",\"reasoning_content\":null}}],\"usage\":null}\n\n",
+        "data: {\"id\":\"adba4265-1f4",
+        "5-4b6f-a564-ef2ca7a6e353\",",
+        "\"object\":\"chat.completion.chunk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"content\":\" that\",\"reasoning_content\":null}}],\"usage\":null}\n\ndata: {\"id\":\"adba4265-1f45-4b6f-a564-ef2ca7a6e353\",\"object\":\"chat.completion.chunk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"content\":\" path\",\"reasoning_content\":null}}],\"usage\":null}\n\n",
+        "data: {\"id\":\"adba4265-1f4",
+        "5-4b6f-a564-ef2ca7a6e353\",\"",
+        "object\":\"chat.completion.chu",
+        "nk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"content\":\".\",\"reasoning_content\":null}}],\"usage\":null}\n\n",
+        "data: {\"id\":\"adba4265-1f45-",
+        "4b6f-a564-ef2ca7a6e353\",\"o",
+        "bject\":\"chat.completion.chunk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_00_ET_qpwrSuOGqdNVOyDYESq94260\",\"type\":\"function\",\"function\":{\"name\":\"read\",\"arguments\":\"\"}}]}}],\"usage\":null}\n\n",
+        "data: {\"id\":\"adba4265-1f45-",
+        "4b6f-a564-ef2ca7a6e353\",\"ob",
+        "ject\":\"chat.completion.chunk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\"}}]}}],\"usage\":null}\n\n",
+        "data: {\"id\":\"adba4265-1f4",
+        "5-4b6f-a564-ef2ca7a6e353\",",
+        "\"object\":\"chat.completion.chunk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"\"}}]}}],\"usage\":null}\n\ndata: {\"id\":\"adba4265-1f45-4b6f-a564-ef2ca7a6e353\",\"object\":\"chat.completion.chunk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"path\"}}]}}],\"usage\":null}\n\n",
+        "data: {\"id\":\"adba4265-1f45-",
+        "4b6f-a564-ef2ca7a6e353\",\"ob",
+        "ject\":\"chat.completion.chunk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"\"}}]}}],\"usage\":null}\n\n",
+        "data: {\"id\":\"adba4265-1f45",
+        "-",
+        "4b6f-a564-ef2ca7a6e353\",\"",
+        "object\":\"chat.completion.chunk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\": \"}}]}}],\"usage\":null}\n\ndata: {\"id\":\"adba4265-1f45-4b6f-a564-ef2ca7a6e353\",\"object\":\"chat.completion.chunk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"\"}}]}}],\"usage\":null}\n\n",
+        "data: {\"id\":\"adba4265-1f4",
+        "5-4b6f-a564-ef2ca7a6e353\",\"",
+        "object\":\"chat.completion.chu",
+        "nk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"/\"}}]}}],\"usage\":null}\n\n",
+        "data: {\"id\":\"adba4265-1f45-",
+        "4b6f-a564-ef2ca7a6e353\",\"ob",
+        "ject\":\"chat.completion.chunk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"tmp\"}}]}}],\"usage\":null}\n\n",
+        "data: {\"id\":\"adba4265-1f45",
+        "-",
+        "4b6f-a564-ef2ca7a6e353\",\"",
+        "object\":\"chat.completion.chunk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"/x\"}}]}}],\"usage\":null}\n\ndata: {\"id\":\"adba4265-1f45-4b6f-a564-ef2ca7a6e353\",\"object\":\"chat.completion.chunk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"\"}}]}}],\"usage\":null}\n\n",
+        "data: {\"id\":\"adba4265-1f45-",
+        "4b6f-a564-ef2ca7a6e353\",\"ob",
+        "ject\":\"chat.completion.chunk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":null,\"logprobs\":null,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"}\"}}]}}],\"usage\":null}\n\n",
+        "data: {\"id\":\"adba4265-1f45-",
+        "4b6f-a564-ef2ca7a6e353\",\"o",
+        "bject\":\"chat.completion.chunk\",\"created\":1786166337,\"model\":\"deepseek-v4-flash\",\"choices\":[{\"index\":0,\"finish_reason\":\"tool_calls\",\"logprobs\":null,\"delta\":{\"content\":\"\",\"reasoning_content\":null}}],\"usage\":{\"prompt_tokens\":348,\"completion_tokens\":53,\"total_tokens\":401,\"prompt_cache_hit_tokens\":256,\"prompt_cache_miss_tokens\":92,\"prompt_tokens_details\":{\"cached_tokens\":256},\"completion_tokens_details\":{\"reasoning_tokens\":0}}}\n\n",
+        "data: [DONE]\n\n",
+        "data: {\"choices\":[],\"cost\":\"0\"}\n\n",
+    ];
+
+    /// Feed each raw fragment through the record-reassembly seam (the same logic
+    /// the handler uses), then convert each complete record. This reproduces the
+    /// real upstream fragmentation; without reassembly the tool-call announcement
+    /// record (carrying name + id) and most argument-delta records are dropped.
+    fn run_reassembled(fragments: &[&str]) -> Vec<String> {
+        let mut state = StreamState::default();
+        let mut events = Vec::new();
+        let mut asm = ResponsesSseAssembler::new();
+        for frag in fragments {
+            for record in asm.push(frag) {
+                events.extend(convert_openai_sse_to_responses(
+                    &record,
+                    "deepseek-v4-flash",
+                    "resp_test",
+                    "",
+                    &mut state,
+                ));
+            }
+        }
+        for record in asm.flush() {
+            events.extend(convert_openai_sse_to_responses(
+                &record,
+                "deepseek-v4-flash",
+                "resp_test",
+                "",
+                &mut state,
+            ));
+        }
+        events
+    }
+
+    #[test]
+    fn reassembled_tool_call_survives_real_fragmentation() {
+        let events = run_reassembled(REAL_FRAGMENTS);
+        let types = extract_event_types(&events);
+
+        // The text message must come through intact.
+        assert!(
+            types.contains(&"response.output_item.added".to_string()),
+            "expected a tool call item to be added"
+        );
+
+        // The function_call output_item.added must carry the real name + call_id.
+        let added = events
+            .iter()
+            .filter(|e| {
+                extract_event_types(&[(*e).clone()])
+                    == vec!["response.output_item.added".to_string()]
+            })
+            .map(|e| extract_event_data(e))
+            .find(|d| d["item"]["type"] == "function_call")
+            .expect("a function_call output_item.added must be emitted");
+
+        assert_eq!(
+            added["item"]["name"], "read",
+            "tool call name lost by fragmentation: got {}",
+            added["item"]["name"]
+        );
+        assert_eq!(
+            added["item"]["call_id"], "call_00_ET_qpwrSuOGqdNVOyDYESq94260",
+            "tool call id lost by fragmentation: got {}",
+            added["item"]["call_id"]
+        );
+        assert_eq!(
+            added["item"]["id"], "call_00_ET_qpwrSuOGqdNVOyDYESq94260",
+            "tool call item id must not fall back to fc_0"
+        );
+
+        // The final function_call output_item.done must carry full arguments.
+        let done = events
+            .iter()
+            .filter(|e| extract_event_types(&[(*e).clone()]) == vec!["response.output_item.done".to_string()])
+            .map(|e| extract_event_data(e))
+            .find(|d| d["item"]["type"] == "function_call")
+            .expect("a function_call output_item.done must be emitted");
+
+        assert_eq!(
+            done["item"]["arguments"], "{\"path\": \"/tmp/x\"}",
+            "tool call arguments truncated by fragmentation: got {}",
+            done["item"]["arguments"]
+        );
+        assert_eq!(done["item"]["name"], "read");
+        assert_eq!(
+            done["item"]["call_id"], "call_00_ET_qpwrSuOGqdNVOyDYESq94260",
+            "tool call id must not fall back to call_1"
+        );
     }
 
     #[test]

--- a/src-tauri/src/protocol/responses.rs
+++ b/src-tauri/src/protocol/responses.rs
@@ -17,6 +17,13 @@ use std::time::{SystemTime, UNIX_EPOCH};
 ///   response.function_call_arguments.delta →
 ///   response.function_call_arguments.done →
 ///   response.output_item.done
+///
+/// For reasoning (DeepSeek R1, OpenAI o1/o3, etc.):
+///   response.output_item.added(type=reasoning) →
+///   response.reasoning_summary_part.added →
+///   response.reasoning_summary_text.delta (per chunk) →
+///   response.reasoning_summary_part.done →
+///   response.output_item.done
 #[derive(Default)]
 pub struct StreamState {
     /// Whether the text message output_item.added has been sent.
@@ -29,6 +36,18 @@ pub struct StreamState {
     pub text_output_index: u32,
     /// Next output_index to use for a new output item.
     pub next_output_index: u32,
+    /// Whether the reasoning output_item.added has been sent.
+    pub reasoning_item_added: bool,
+    /// Whether the reasoning summary_part.added has been sent.
+    pub reasoning_part_added: bool,
+    /// Whether the reasoning summary_part.done has been sent.
+    pub reasoning_part_done: bool,
+    /// Whether the reasoning output_item.done has been sent.
+    pub reasoning_item_done: bool,
+    /// The output_index assigned to the reasoning item.
+    pub reasoning_output_index: u32,
+    /// Full concatenated reasoning text accumulated so far.
+    pub accumulated_reasoning: String,
     /// Map from tool_call index → (output_index, call_id, name, accumulated_arguments, item_added_sent, arguments_done_sent)
     pub tool_calls: HashMap<u64, ToolCallState>,
     /// Whether any tool calls were seen in this stream.
@@ -123,11 +142,63 @@ pub fn convert_openai_sse_to_responses(
                     if let Some(reasoning) = delta.get("reasoning_content").and_then(|c| c.as_str())
                     {
                         if !reasoning.is_empty() {
+                            // Announce the reasoning item (output_item.added) and its
+                            // summary part BEFORE the first delta. Clients only persist
+                            // items they saw "added" — without this the reasoning never
+                            // enters the conversation and thinking-mode providers reject
+                            // the next turn.
+                            if !state.reasoning_item_added {
+                                let reasoning_output_index = state.next_output_index;
+                                state.reasoning_output_index = reasoning_output_index;
+                                let seq = next_seq(state);
+                                let item = serde_json::json!({
+                                    "id": reasoning_id,
+                                    "type": "reasoning",
+                                    "status": "in_progress",
+                                    "summary": [],
+                                    "content": []
+                                });
+                                let item_event = serde_json::json!({
+                                    "type": "response.output_item.added",
+                                    "output_index": reasoning_output_index,
+                                    "item": item,
+                                    "sequence_number": seq
+                                });
+                                events.push(format!(
+                                    "event: response.output_item.added\ndata: {}\n\n",
+                                    item_event
+                                ));
+
+                                let seq = next_seq(state);
+                                let part = serde_json::json!({
+                                    "type": "reasoning_summary_text",
+                                    "text": ""
+                                });
+                                let part_event = serde_json::json!({
+                                    "type": "response.reasoning_summary_part.added",
+                                    "item_id": reasoning_id,
+                                    "output_index": reasoning_output_index,
+                                    "summary_index": 0,
+                                    "part": part,
+                                    "sequence_number": seq
+                                });
+                                events.push(format!(
+                                    "event: response.reasoning_summary_part.added\ndata: {}\n\n",
+                                    part_event
+                                ));
+
+                                state.reasoning_item_added = true;
+                                state.reasoning_part_added = true;
+                                state.next_output_index += 1;
+                            }
+
+                            state.accumulated_reasoning.push_str(reasoning);
+                            let reasoning_output_index = state.reasoning_output_index;
                             let seq = next_seq(state);
                             let event = serde_json::json!({
                                 "type": "response.reasoning_summary_text.delta",
                                 "item_id": reasoning_id,
-                                "output_index": 0,
+                                "output_index": reasoning_output_index,
                                 "summary_index": 0,
                                 "delta": reasoning,
                                 "sequence_number": seq
@@ -331,6 +402,53 @@ pub fn convert_openai_sse_to_responses(
                 // Check for finish_reason
                 if let Some(finish) = choice.get("finish_reason").and_then(|f| f.as_str()) {
                     if !finish.is_empty() && finish != "null" {
+                        // Close reasoning item if it was opened and not yet closed
+                        if state.reasoning_item_added && !state.reasoning_item_done {
+                            let reasoning_output_index = state.reasoning_output_index;
+                            let seq = next_seq(state);
+                            let part = serde_json::json!({
+                                "type": "reasoning_summary_text",
+                                "text": state.accumulated_reasoning
+                            });
+                            let part_done = serde_json::json!({
+                                "type": "response.reasoning_summary_part.done",
+                                "item_id": reasoning_id,
+                                "output_index": reasoning_output_index,
+                                "summary_index": 0,
+                                "part": part,
+                                "sequence_number": seq
+                            });
+                            events.push(format!(
+                                "event: response.reasoning_summary_part.done\ndata: {}\n\n",
+                                part_done
+                            ));
+
+                            let seq = next_seq(state);
+                            let completed_item = serde_json::json!({
+                                "id": reasoning_id,
+                                "type": "reasoning",
+                                "status": "completed",
+                                "summary": [{
+                                    "type": "summary_text",
+                                    "text": state.accumulated_reasoning
+                                }],
+                                "content": []
+                            });
+                            let item_done = serde_json::json!({
+                                "type": "response.output_item.done",
+                                "output_index": reasoning_output_index,
+                                "item": completed_item,
+                                "sequence_number": seq
+                            });
+                            events.push(format!(
+                                "event: response.output_item.done\ndata: {}\n\n",
+                                item_done
+                            ));
+
+                            state.reasoning_part_done = true;
+                            state.reasoning_item_done = true;
+                        }
+
                         // Close text item if it was opened and not yet closed
                         if state.text_item_added && !state.text_item_done {
                             let text_output_index = state.text_output_index;
@@ -573,6 +691,56 @@ pub fn create_synthetic_completed_events(
         }};
     }
 
+    // Close reasoning item if it was opened and not yet closed
+    if state.reasoning_item_added && !state.reasoning_item_done {
+        let reasoning_output_index = state.reasoning_output_index;
+        let reasoning_id = if response_id.starts_with("resp_") {
+            format!("rs_{}", &response_id[5..])
+        } else {
+            format!("rs_{}", response_id)
+        };
+
+        let s = next_seq!();
+        let part = serde_json::json!({
+            "type": "reasoning_summary_text",
+            "text": state.accumulated_reasoning
+        });
+        let part_done = serde_json::json!({
+            "type": "response.reasoning_summary_part.done",
+            "item_id": reasoning_id,
+            "output_index": reasoning_output_index,
+            "summary_index": 0,
+            "part": part,
+            "sequence_number": s
+        });
+        events.push(format!(
+            "event: response.reasoning_summary_part.done\ndata: {}\n\n",
+            part_done
+        ));
+
+        let s = next_seq!();
+        let completed_item = serde_json::json!({
+            "id": reasoning_id,
+            "type": "reasoning",
+            "status": "completed",
+            "summary": [{
+                "type": "summary_text",
+                "text": state.accumulated_reasoning
+            }],
+            "content": []
+        });
+        let item_done = serde_json::json!({
+            "type": "response.output_item.done",
+            "output_index": reasoning_output_index,
+            "item": completed_item,
+            "sequence_number": s
+        });
+        events.push(format!(
+            "event: response.output_item.done\ndata: {}\n\n",
+            item_done
+        ));
+    }
+
     // Close text item if it was opened and not yet closed
     if state.text_item_added && !state.text_item_done {
         let text_output_index = state.text_output_index;
@@ -682,6 +850,25 @@ pub fn create_synthetic_completed_events(
 
     // Build the output array for response.completed
     let mut output_items: Vec<Value> = Vec::new();
+
+    // Add reasoning item to output if it was added
+    if state.reasoning_item_added {
+        let reasoning_id = if response_id.starts_with("resp_") {
+            format!("rs_{}", &response_id[5..])
+        } else {
+            format!("rs_{}", response_id)
+        };
+        output_items.push(serde_json::json!({
+            "id": reasoning_id,
+            "type": "reasoning",
+            "status": "completed",
+            "summary": [{
+                "type": "summary_text",
+                "text": state.accumulated_reasoning
+            }],
+            "content": []
+        }));
+    }
 
     // Add text item to output if it was added
     if state.text_item_added {
@@ -1016,6 +1203,109 @@ mod tests {
         let fc_item_done = extract_event_data(&events4[4]);
         assert_eq!(fc_item_done["output_index"], 1);
         assert_eq!(fc_item_done["item"]["type"], "function_call");
+    }
+
+    #[test]
+    fn test_reasoning_item_full_lifecycle() {
+        // A reasoning_content delta must announce a `reasoning` item with
+        // output_item.added BEFORE any delta, and close it with
+        // output_item.done. Without the item lifecycle, Codex never persists a
+        // reasoning item, so the next turn omits reasoning_content and
+        // DeepSeek rejects it ("must be passed back to the API").
+        let mut state = StreamState::default();
+        let response_id = "resp_rs123";
+
+        // Chunk 1: reasoning delta
+        let chunk1 = r#"data: {"id":"c1","choices":[{"index":0,"delta":{"reasoning_content":"Let me"},"finish_reason":null}]}"#;
+        let events1 = convert_openai_sse_to_responses(chunk1, "deepseek-v4-flash", response_id, "", &mut state);
+        let types1 = extract_event_types(&events1);
+        assert_eq!(
+            types1,
+            vec![
+                "response.output_item.added",
+                "response.reasoning_summary_part.added",
+                "response.reasoning_summary_text.delta",
+            ]
+        );
+
+        // reasoning item announced with type=reasoning
+        let added = extract_event_data(&events1[0]);
+        assert_eq!(added["item"]["type"], "reasoning");
+        assert_eq!(added["item"]["id"], "rs_rs123");
+        assert_eq!(added["output_index"], 0);
+
+        // summary part added before deltas
+        let part_added = extract_event_data(&events1[1]);
+        assert_eq!(part_added["part"]["type"], "reasoning_summary_text");
+
+        // delta carries the reasoning text on item rs_
+        let delta = extract_event_data(&events1[2]);
+        assert_eq!(delta["delta"], "Let me");
+        assert_eq!(delta["item_id"], "rs_rs123");
+
+        // Chunk 2: more reasoning
+        let chunk2 = r#"data: {"id":"c1","choices":[{"index":0,"delta":{"reasoning_content":" think."},"finish_reason":null}]}"#;
+        let events2 = convert_openai_sse_to_responses(chunk2, "deepseek-v4-flash", response_id, "", &mut state);
+        let types2 = extract_event_types(&events2);
+        assert_eq!(types2, vec!["response.reasoning_summary_text.delta"]);
+
+        // Chunk 3: content text
+        let chunk3 = r#"data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Answer"},"finish_reason":null}]}"#;
+        let events3 = convert_openai_sse_to_responses(chunk3, "deepseek-v4-flash", response_id, "Answer", &mut state);
+        let types3 = extract_event_types(&events3);
+        assert_eq!(
+            types3,
+            vec![
+                "response.output_item.added",
+                "response.content_part.added",
+                "response.output_text.delta",
+            ]
+        );
+        // text item gets output_index 1 (reasoning took 0)
+        let text_added = extract_event_data(&events3[0]);
+        assert_eq!(text_added["output_index"], 1);
+        assert_eq!(text_added["item"]["type"], "message");
+
+        // Chunk 4: finish
+        let chunk4 = r#"data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#;
+        let events4 = convert_openai_sse_to_responses(chunk4, "deepseek-v4-flash", response_id, "Answer", &mut state);
+        let types4 = extract_event_types(&events4);
+        assert_eq!(
+            types4,
+            vec![
+                "response.reasoning_summary_part.done",
+                "response.output_item.done",
+                "response.output_text.done",
+                "response.content_part.done",
+                "response.output_item.done",
+            ]
+        );
+
+        // reasoning item closed with the full text in the summary
+        let rs_done = extract_event_data(&events4[1]);
+        assert_eq!(rs_done["item"]["type"], "reasoning");
+        assert_eq!(rs_done["item"]["status"], "completed");
+        assert_eq!(rs_done["item"]["summary"][0]["text"], "Let me think.");
+        assert_eq!(rs_done["output_index"], 0);
+
+        // response.completed output array must contain the reasoning item too
+        let synthetic = create_synthetic_completed_events(
+            "deepseek-v4-flash",
+            response_id,
+            "Answer",
+            &state,
+            10,
+            5,
+        );
+        let completed_event = synthetic.iter().find(|e| {
+            e.lines().next().map(|l| l == "event: response.completed").unwrap_or(false)
+        }).unwrap();
+        let completed = extract_event_data(completed_event);
+        let output = completed["response"]["output"].as_array().unwrap();
+        assert_eq!(output.len(), 2);
+        assert_eq!(output[0]["type"], "reasoning");
+        assert_eq!(output[0]["summary"][0]["text"], "Let me think.");
+        assert_eq!(output[1]["type"], "message");
     }
 
     #[test]

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -2340,44 +2340,52 @@ async fn handle_responses_stream(
                     let mut stream_state = crate::protocol::responses::StreamState::default();
                     let mut accumulated_content = String::new();
                     let mut accumulated_reasoning = String::new();
+                    let mut sse_assembler = crate::protocol::responses::ResponsesSseAssembler::new();
 
                     while let Some(chunk_result) = upstream_stream.next().await {
                         match chunk_result {
                             Ok(bytes) => {
                                 if let Ok(text) = std::str::from_utf8(&bytes) {
-                                    if let Some((p, c, t)) = crate::protocol::responses::parse_usage_from_sse_chunk(text) {
-                                        usage_prompt = p;
-                                        usage_completion = c;
-                                        usage_total = t;
-                                    }
-                                    // Accumulate content for logging
-                                    for line in text.lines() {
-                                        let trimmed = line.trim();
-                                        if !trimmed.starts_with("data:") { continue; }
-                                        let data_str = trimmed.trim_start_matches("data:").trim();
-                                        if data_str == "[DONE]" || data_str.is_empty() { continue; }
-                                        if let Ok(json) = serde_json::from_str::<serde_json::Value>(data_str) {
-                                            if let Some(choices) = json.get("choices").and_then(|c| c.as_array()) {
-                                                if let Some(choice) = choices.first() {
-                                                    if let Some(delta) = choice.get("delta") {
-                                                        if let Some(content) = delta.get("content").and_then(|c| c.as_str()) {
-                                                            accumulated_content.push_str(content);
-                                                        }
-                                                        if let Some(reasoning) = delta.get("reasoning_content").and_then(|c| c.as_str()) {
-                                                            accumulated_reasoning.push_str(reasoning);
+                                    // Reassemble fragmented SSE records before conversion.
+                                    // The upstream channel splits every record across TCP
+                                    // chunks (often mid-JSON); feeding raw fragments to
+                                    // the converter silently drops tool names / call ids /
+                                    // argument fragments. Only complete records are processed.
+                                    for record in sse_assembler.push(text) {
+                                        if let Some((p, c, t)) = crate::protocol::responses::parse_usage_from_sse_chunk(&record) {
+                                            usage_prompt = p;
+                                            usage_completion = c;
+                                            usage_total = t;
+                                        }
+                                        // Accumulate content for logging
+                                        for line in record.lines() {
+                                            let trimmed = line.trim();
+                                            if !trimmed.starts_with("data:") { continue; }
+                                            let data_str = trimmed.trim_start_matches("data:").trim();
+                                            if data_str == "[DONE]" || data_str.is_empty() { continue; }
+                                            if let Ok(json) = serde_json::from_str::<serde_json::Value>(data_str) {
+                                                if let Some(choices) = json.get("choices").and_then(|c| c.as_array()) {
+                                                    if let Some(choice) = choices.first() {
+                                                        if let Some(delta) = choice.get("delta") {
+                                                            if let Some(content) = delta.get("content").and_then(|c| c.as_str()) {
+                                                                accumulated_content.push_str(content);
+                                                            }
+                                                            if let Some(reasoning) = delta.get("reasoning_content").and_then(|c| c.as_str()) {
+                                                                accumulated_reasoning.push_str(reasoning);
+                                                            }
                                                         }
                                                     }
                                                 }
                                             }
                                         }
-                                    }
-                                    // Convert OpenAI SSE → Responses SSE events
-                                    let events = crate::protocol::responses::convert_openai_sse_to_responses(
-                                        text, &model_clone, &response_id, &accumulated_content,
-                                        &mut stream_state,
-                                    );
-                                    for event in events {
-                                        yield Ok::<_, std::io::Error>(event.into_bytes().into());
+                                        // Convert OpenAI SSE → Responses SSE events
+                                        let events = crate::protocol::responses::convert_openai_sse_to_responses(
+                                            &record, &model_clone, &response_id, &accumulated_content,
+                                            &mut stream_state,
+                                        );
+                                        for event in events {
+                                            yield Ok::<_, std::io::Error>(event.into_bytes().into());
+                                        }
                                     }
                                 } else {
                                     yield Ok::<_, std::io::Error>(bytes);
@@ -2395,9 +2403,45 @@ async fn handle_responses_stream(
                         }
                     }
 
-                    // Stream ended. Emit final response.completed with usage.
+                    // Stream ended. Flush any record whose terminator arrived exactly
+                    // at EOF so its deltas are not lost, then emit final response.completed
+                    // with usage.
                     // (convert_openai_sse_to_responses sends everything up to output_item.done,
                     // but NOT response.completed — that's sent here with usage from the final chunk)
+                    for record in sse_assembler.flush() {
+                        if let Some((p, c, t)) = crate::protocol::responses::parse_usage_from_sse_chunk(&record) {
+                            usage_prompt = p;
+                            usage_completion = c;
+                            usage_total = t;
+                        }
+                        for line in record.lines() {
+                            let trimmed = line.trim();
+                            if !trimmed.starts_with("data:") { continue; }
+                            let data_str = trimmed.trim_start_matches("data:").trim();
+                            if data_str == "[DONE]" || data_str.is_empty() { continue; }
+                            if let Ok(json) = serde_json::from_str::<serde_json::Value>(data_str) {
+                                if let Some(choices) = json.get("choices").and_then(|c| c.as_array()) {
+                                    if let Some(choice) = choices.first() {
+                                        if let Some(delta) = choice.get("delta") {
+                                            if let Some(content) = delta.get("content").and_then(|c| c.as_str()) {
+                                                accumulated_content.push_str(content);
+                                            }
+                                            if let Some(reasoning) = delta.get("reasoning_content").and_then(|c| c.as_str()) {
+                                                accumulated_reasoning.push_str(reasoning);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        let events = crate::protocol::responses::convert_openai_sse_to_responses(
+                            &record, &model_clone, &response_id, &accumulated_content,
+                            &mut stream_state,
+                        );
+                        for event in events {
+                            yield Ok::<_, std::io::Error>(event.into_bytes().into());
+                        }
+                    }
                     if !had_error {
                         let synth_events = crate::protocol::responses::create_synthetic_completed_events(
                             &model_clone,


### PR DESCRIPTION
## 背景 / Problem

`Codex`（OpenAI 官方 CLI）通过本地网关 `WaLiAPI` 的 **Responses API** 流式集成时，存在多个导致对话中断、工具调用损坏、多轮请求被上游拒绝的问题：

1. **SSE 帧分片导致工具调用数据丢失（最严重）**
   - `ResponsesViaChat` 路径没有 codec decoder，上游（deepseek-v4-flash / OpenCode-GO）的 SSE 记录经常跨 TCP 分片被切开（经常断在 JSON 中间）。
   - 被切开的半条记录直接喂给转换器，`serde_json` 解析失败后**静默丢弃**，导致 Codex 收到：
     - 工具名（`name`）丢失 → 回退成空字符串
     - `call_id` 丢失 → 回退成合成的 `call_1`
     - `arguments` 参数片段丢失 → 工具参数截断（如 `{"path": "/tmp/x"}` 只剩一半）
   - 表现：Codex 发起工具调用时上游报错 / 参数损坏。

2. **孤立 assistant 消息破坏 tool_calls 配对**
   - 交错输入 `call_A → user → call_B → output_A → output_B` 会把 `call_B` 冲成一条独立的 assistant 消息，插在 `assistant(A)` 与 `tool_A` 之间。
   - DeepSeek 等 thinking 模式上游直接拒绝：`"assistant with tool_calls must be followed by tool messages responding to each tool_call_id"`（HTTP 502）。

3. **reasoning 生命周期不完整 / 归属错误**
   - Responses 流的 `reasoning` 未发出完整的 `output_item.added → summary_part.added → delta → part.done → item.done` 序列，客户端不会持久化 reasoning 项，多轮 thinking 请求被拒。
   - `reasoning_content` 被中间 assistant 文本消息消费，而不是挂在 `assistant(tool_calls)` 消息上，触发 DeepSeek `"The reasoning_content in the thinking mode must be passed back to the API"`。

4. **Anthropic Messages → Chat 转换缺陷**
   - system 消息未正确提取、`tool_choice` 映射错误、`stream_options` 未透传，导致部分 Anthropic 渠道下 Codex 请求失败。

## 解决方案 / Solution

1. **SSE 帧重组（两条路径统一）**
   - executor 路径（`StreamPumpCore`）新增 `encode_responses_buffered()`：按 `\n\n` / `\r\n\r\n` 在 push 边界重组完整 SSE 记录后再转换，EOF 时 flush 尾记录。
   - 服务器 handler 路径（`handle_responses_stream`）新增 `ResponsesSseAssembler`，同样按记录边界重组，`flush()` 兜底 EOF 未终止的记录。
   - 两套实现共用 `protocol::codec::sse::record_end()`，行为一致。

2. **孤立 assistant 修复**
   - `flush_tool_calls` 加守卫：前一个 `assistant(tool_calls)` 仍在 `awaiting`（工具响应未到齐）时绝不 flush 新 batch，输出变为合法的 `[assistant(A), tool_A, user, assistant(B), tool_B]`。

3. **reasoning 完整生命周期 + 归属修复**
   - `convert_openai_sse_to_responses` 补齐 `output_item.added → reasoning_summary_part.added → delta → part.done → item.done` 完整序列。
   - `convert_responses_input_to_messages` 新增 `function_call_after` 判定：reasoning 后跟 assistant 文本再跟 `function_call` 时，`reasoning_content` 保留给 `assistant(tool_calls)` 消息，不再被中间文本消息消费。

4. **Anthropic Messages 转换修复**
   - system 提取、`tool_choice` 映射、`stream_options` 透传修正。

## 改动内容 / Changes

| 文件 | 改动 |
|---|---|
| `src-tauri/src/endpoint_executor/sse.rs` | +339：executor 路径 SSE 帧重组（`encode_responses_buffered`）+ 真实流回归测试 |
| `src-tauri/src/protocol/codec/chat_messages_codec.rs` | +39：Messages ↔ Chat 转换修正 |
| `src-tauri/src/protocol/codec/messages.rs` | +16：codec 细节修正 |
| `src-tauri/src/protocol/mod.rs` | +740：reasoning 生命周期、孤立 assistant 守卫、`function_call_after` 归属、Anthropic 转换 + 测试 |
| `src-tauri/src/protocol/responses.rs` | +498：reasoning 完整事件序列、`ResponsesSseAssembler` + 真实分片测试 |
| `src-tauri/src/server/handlers.rs` | +102：`handle_responses_stream` 接入 `ResponsesSseAssembler` |

合计 **+1629 / -105**，包含针对真实上游字节流（deepseek-v4-flash / OpenCode-GO 抓包）的回归测试。

## 测试 / Testing

- `cargo test -p waliapi --lib`：**366 passed, 0 failed**
- 新增回归测试覆盖：
  - 真实上游 63 段 TCP 分片重组后工具名 / call_id / 参数完整
  - 逐记录 push 的 tool_call 流（EXACT 上游字节流）
  - reasoning 生命周期（含 user 交错场景）
  - 孤立 assistant / 并行 tool_calls 合并
