### PR TITLE
fix: Opencode/Codex 流式协议转换修复（bridge 统一 Anthropic→OpenAI SSE + usage 合并 + tools 转发）

### DIFF
--- a/src-tauri/src/adaptor/claude.rs
+++ b/src-tauri/src/adaptor/claude.rs
@@ -109,6 +109,14 @@ impl Adaptor for ClaudeAdaptor {
             "messages": claude_messages,
             "stream": stream,
         });
+        let claude_tools = convert_openai_tools_to_claude(
+            openai_body.get("tools").unwrap_or(&serde_json::Value::Null),
+        );
+        if let Some(arr) = claude_tools.as_array() {
+            if !arr.is_empty() {
+                claude_body["tools"] = claude_tools;
+            }
+        }
         if let Some(sys) = system {
             claude_body["system"] = serde_json::Value::String(sys);
         }
@@ -172,6 +180,14 @@ impl Adaptor for ClaudeAdaptor {
             "messages": claude_messages,
             "stream": true,
         });
+        let claude_tools = convert_openai_tools_to_claude(
+            openai_body.get("tools").unwrap_or(&serde_json::Value::Null),
+        );
+        if let Some(arr) = claude_tools.as_array() {
+            if !arr.is_empty() {
+                claude_body["tools"] = claude_tools;
+            }
+        }
         if let Some(sys) = system {
             claude_body["system"] = serde_json::Value::String(sys);
         }
@@ -193,6 +209,16 @@ impl Adaptor for ClaudeAdaptor {
     }
 }
 
+/// Convert OpenAI Chat messages to Anthropic Messages format.
+///
+/// Handles the three shapes that tool-using sessions produce:
+/// - `system` → extracted `system` string (deduplicated, last one wins);
+/// - `assistant` with `tool_calls` → a content ARRAY of `text` + `tool_use`
+///   blocks (Anthropic requires this shape for tool calls — a bare string
+///   content cannot carry `tool_use`);
+/// - `tool` role → `user` + `tool_result` block (Anthropic has no `tool`
+///   role; the result is a `tool_result` content block on a `user` message,
+///   paired to the originating call via `tool_use_id`).
 fn convert_openai_messages_to_claude(
     messages: &serde_json::Value,
 ) -> (Option<String>, serde_json::Value) {
@@ -206,54 +232,204 @@ fn convert_openai_messages_to_claude(
 
     for msg in msgs {
         let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("user");
+
+        if role == "system" {
+            if let Some(s) = msg.get("content").and_then(|c| c.as_str()) {
+                system = Some(s.to_string());
+            }
+            continue;
+        }
+
+        // assistant: text content (optional) + tool_calls (optional) →
+        // content array of text + tool_use blocks.
+        if role == "assistant" {
+            let tool_calls = msg
+                .get("tool_calls")
+                .and_then(|t| t.as_array())
+                .cloned()
+                .unwrap_or_default();
+            let content = msg.get("content").cloned().unwrap_or(serde_json::Value::Null);
+
+            let mut blocks: Vec<serde_json::Value> = Vec::new();
+
+            // Collapse text content (string, or array of {type:"text"}) to one
+            // text block so it can sit beside tool_use blocks.
+            let text = match &content {
+                serde_json::Value::String(s) if !s.is_empty() => Some(s.clone()),
+                serde_json::Value::Null => None,
+                serde_json::Value::Array(arr) => {
+                    let mut t = String::new();
+                    for block in arr {
+                        if block.get("type").and_then(|x| x.as_str()) == Some("text") {
+                            if let Some(s) = block.get("text").and_then(|x| x.as_str()) {
+                                t.push_str(s);
+                            }
+                        }
+                    }
+                    if t.is_empty() { None } else { Some(t) }
+                }
+                _ => None,
+            };
+            if let Some(t) = text {
+                blocks.push(serde_json::json!({"type": "text", "text": t}));
+            }
+
+            for tc in &tool_calls {
+                let id = tc.get("id").and_then(|x| x.as_str()).unwrap_or("").to_string();
+                let name = tc
+                    .get("function")
+                    .and_then(|f| f.get("name"))
+                    .and_then(|x| x.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                // Skip malformed tool calls rather than sending an invalid block.
+                if id.is_empty() || name.is_empty() {
+                    continue;
+                }
+                let raw_args = tc
+                    .get("function")
+                    .and_then(|f| f.get("arguments"))
+                    .and_then(|x| x.as_str())
+                    .unwrap_or("{}");
+                let input: serde_json::Value =
+                    serde_json::from_str(raw_args).unwrap_or(serde_json::json!({}));
+                blocks.push(serde_json::json!({
+                    "type": "tool_use",
+                    "id": id,
+                    "name": name,
+                    "input": input,
+                }));
+            }
+
+            // Skip assistant messages with neither text nor tool calls.
+            if blocks.is_empty() {
+                continue;
+            }
+            claude_msgs.push(serde_json::json!({
+                "role": "assistant",
+                "content": blocks,
+            }));
+            continue;
+        }
+
+        // tool result → user + tool_result block.
+        if role == "tool" {
+            let tool_use_id = msg
+                .get("tool_call_id")
+                .and_then(|x| x.as_str())
+                .unwrap_or("")
+                .to_string();
+            if tool_use_id.is_empty() {
+                continue;
+            }
+            let tool_content = match msg.get("content").cloned().unwrap_or(serde_json::Value::Null) {
+                serde_json::Value::String(s) => s,
+                serde_json::Value::Null => String::new(),
+                serde_json::Value::Array(arr) => arr
+                    .iter()
+                    .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
+                    .collect::<Vec<_>>()
+                    .join(""),
+                other => other.to_string(),
+            };
+            claude_msgs.push(serde_json::json!({
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": tool_content,
+                }],
+            }));
+            continue;
+        }
+
+        // plain user message.
         let content = msg
             .get("content")
             .cloned()
             .unwrap_or(serde_json::Value::String(String::new()));
-
-        if role == "system" {
-            if let Some(s) = content.as_str() {
-                system = Some(s.to_string());
-            }
-        } else {
-            // Skip empty assistant messages without tool_calls
-            if role == "assistant" {
-                let is_empty = match &content {
-                    serde_json::Value::Null => true,
-                    serde_json::Value::String(s) => s.is_empty(),
-                    serde_json::Value::Array(a) => a.is_empty(),
-                    _ => false,
-                };
-                let has_tool_calls = msg
-                    .get("tool_calls")
-                    .and_then(|t| t.as_array())
-                    .map(|a| !a.is_empty())
-                    .unwrap_or(false);
-                if is_empty && !has_tool_calls {
-                    continue;
-                }
-            }
-            claude_msgs.push(serde_json::json!({
-                "role": if role == "assistant" { "assistant" } else { "user" },
-                "content": content,
-            }));
-        }
+        claude_msgs.push(serde_json::json!({
+            "role": "user",
+            "content": content,
+        }));
     }
 
     (system, serde_json::Value::Array(claude_msgs))
 }
 
+/// Convert Chat Completions `tools` (nested `{type:"function",function:{...}}`)
+/// to Anthropic Messages `tools` (flat `{name, description, input_schema}`).
+/// Non-function tools (namespace / web_search / built-in) are dropped —
+/// Anthropic only supports function tools.
+fn convert_openai_tools_to_claude(tools: &serde_json::Value) -> serde_json::Value {
+    let arr = match tools.as_array() {
+        Some(a) => a,
+        None => return serde_json::Value::Array(vec![]),
+    };
+    let claude_tools: Vec<serde_json::Value> = arr
+        .iter()
+        .filter_map(|t| {
+            if t.get("type").and_then(|x| x.as_str()) != Some("function") {
+                return None;
+            }
+            let f = t.get("function").unwrap_or(&serde_json::Value::Null);
+            let name = f.get("name").and_then(|x| x.as_str()).unwrap_or("");
+            if name.is_empty() {
+                return None;
+            }
+            let mut tool = serde_json::json!({
+                "name": name,
+                "input_schema": f.get("parameters").cloned().unwrap_or_else(|| {
+                    serde_json::json!({"type": "object", "properties": {}})
+                }),
+            });
+            if let Some(desc) = f.get("description").and_then(|d| d.as_str()) {
+                if !desc.is_empty() {
+                    tool["description"] = serde_json::Value::String(desc.to_string());
+                }
+            }
+            Some(tool)
+        })
+        .collect();
+    serde_json::Value::Array(claude_tools)
+}
+
 fn convert_claude_to_openai(claude_json: &serde_json::Value, model: &str) -> serde_json::Value {
-    let content = claude_json
+    let content_blocks = claude_json
         .get("content")
         .and_then(|c| c.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|block| block.get("text").and_then(|t| t.as_str()))
-                .collect::<Vec<_>>()
-                .join("")
-        })
+        .cloned()
         .unwrap_or_default();
+
+    let content = content_blocks
+        .iter()
+        .filter_map(|block| block.get("text").and_then(|t| t.as_str()))
+        .collect::<Vec<_>>()
+        .join("");
+
+    // Anthropic `tool_use` blocks → OpenAI `tool_calls` on the assistant
+    // message, so tool-using responses survive the non-streaming conversion.
+    let tool_calls: Vec<serde_json::Value> = content_blocks
+        .iter()
+        .filter(|b| b.get("type").and_then(|t| t.as_str()) == Some("tool_use"))
+        .enumerate()
+        .map(|(i, block)| {
+            serde_json::json!({
+                "id": block.get("id").cloned().unwrap_or_else(|| {
+                    serde_json::Value::String(format!("call_{}", i))
+                }),
+                "type": "function",
+                "function": {
+                    "name": block.get("name").cloned().unwrap_or(serde_json::Value::Null),
+                    "arguments": block
+                        .get("input")
+                        .cloned()
+                        .unwrap_or(serde_json::json!({}))
+                        .to_string(),
+                }
+            })
+        })
+        .collect();
 
     let prompt_tokens = claude_json
         .get("usage")
@@ -266,6 +442,24 @@ fn convert_claude_to_openai(claude_json: &serde_json::Value, model: &str) -> ser
         .and_then(|t| t.as_u64())
         .unwrap_or(0);
 
+    let mut message = serde_json::json!({
+        "role": "assistant",
+        "content": content,
+    });
+    if !tool_calls.is_empty() {
+        message["tool_calls"] = serde_json::Value::Array(tool_calls);
+    }
+    // stop_reason tool_use → finish_reason tool_calls
+    let finish_reason = if claude_json
+        .get("stop_reason")
+        .and_then(|s| s.as_str())
+        == Some("tool_use")
+    {
+        "tool_calls"
+    } else {
+        "stop"
+    };
+
     serde_json::json!({
         "id": claude_json.get("id").cloned().unwrap_or(serde_json::Value::String("chatcmpl-converted".to_string())),
         "object": "chat.completion",
@@ -273,11 +467,8 @@ fn convert_claude_to_openai(claude_json: &serde_json::Value, model: &str) -> ser
         "model": model,
         "choices": [{
             "index": 0,
-            "message": {
-                "role": "assistant",
-                "content": content,
-            },
-            "finish_reason": "stop",
+            "message": message,
+            "finish_reason": finish_reason,
         }],
         "usage": {
             "prompt_tokens": prompt_tokens,
@@ -285,4 +476,93 @@ fn convert_claude_to_openai(claude_json: &serde_json::Value, model: &str) -> ser
             "total_tokens": prompt_tokens + completion_tokens,
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn messages_assistant_tool_calls_become_tool_use_blocks() {
+        let messages = serde_json::json!([
+            {"role": "system", "content": "You are Codex."},
+            {"role": "user", "content": "git status"},
+            {"role": "assistant", "content": null, "tool_calls": [
+                {"id": "call_A", "type": "function", "function": {"name": "exec_command", "arguments": "{\"cmd\":\"git status\"}"}}
+            ]},
+            {"role": "tool", "tool_call_id": "call_A", "content": " M src-tauri/src/adaptor/claude.rs"}
+        ]);
+        let (system, claude_msgs) = convert_openai_messages_to_claude(&messages);
+        assert_eq!(system.as_deref(), Some("You are Codex."));
+        let msgs = claude_msgs.as_array().unwrap();
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[0]["role"], "user");
+        // assistant: content ARRAY with tool_use block
+        assert_eq!(msgs[1]["role"], "assistant");
+        let assistant_content = msgs[1]["content"].as_array().unwrap();
+        assert_eq!(assistant_content[0]["type"], "tool_use");
+        assert_eq!(assistant_content[0]["id"], "call_A");
+        assert_eq!(assistant_content[0]["name"], "exec_command");
+        assert_eq!(assistant_content[0]["input"]["cmd"], "git status");
+        // tool result: user + tool_result block paired by tool_use_id
+        assert_eq!(msgs[2]["role"], "user");
+        let tool_result = msgs[2]["content"][0].clone();
+        assert_eq!(tool_result["type"], "tool_result");
+        assert_eq!(tool_result["tool_use_id"], "call_A");
+        assert_eq!(tool_result["content"], " M src-tauri/src/adaptor/claude.rs");
+    }
+
+    #[test]
+    fn messages_text_tool_call_mixed_content() {
+        let messages = serde_json::json!([
+            {"role": "assistant", "content": "Let me look.", "tool_calls": [
+                {"id": "call_A", "type": "function", "function": {"name": "read", "arguments": "{\"path\":\"/tmp/x\"}"}}
+            ]}
+        ]);
+        let (_, claude_msgs) = convert_openai_messages_to_claude(&messages);
+        let msgs = claude_msgs.as_array().unwrap();
+        let content = msgs[0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2);
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "Let me look.");
+        assert_eq!(content[1]["type"], "tool_use");
+    }
+
+    #[test]
+    fn tools_nested_to_claude_flat_and_drops_non_function() {
+        let tools = serde_json::json!([
+            {"type": "function", "function": {"name": "exec_command", "description": "Run a shell command", "parameters": {"type": "object", "properties": {"cmd": {"type": "string"}}}}},
+            {"type": "namespace", "name": "multi_agent_v1", "namespace": "multi_agent_v1"},
+            {"type": "web_search", "name": "web_search", "external_web_access": {}}
+        ]);
+        let claude_tools = convert_openai_tools_to_claude(&tools);
+        let arr = claude_tools.as_array().unwrap();
+        assert_eq!(arr.len(), 1, "namespace/web_search must be dropped for Anthropic");
+        assert_eq!(arr[0]["name"], "exec_command");
+        assert_eq!(arr[0]["description"], "Run a shell command");
+        assert_eq!(arr[0]["input_schema"]["properties"]["cmd"]["type"], "string");
+    }
+
+    #[test]
+    fn claude_response_tool_use_becomes_openai_tool_calls() {
+        let claude_json = serde_json::json!({
+            "id": "msg_1",
+            "content": [
+                {"type": "text", "text": "Running now."},
+                {"type": "tool_use", "id": "toolu_1", "name": "exec_command", "input": {"cmd": "git status"}}
+            ],
+            "stop_reason": "tool_use",
+            "usage": {"input_tokens": 10, "output_tokens": 20}
+        });
+        let openai = convert_claude_to_openai(&claude_json, "claude-3-5");
+        let choice = &openai["choices"][0];
+        assert_eq!(choice["finish_reason"], "tool_calls");
+        let message = &choice["message"];
+        assert_eq!(message["content"], "Running now.");
+        let tc = &message["tool_calls"][0];
+        assert_eq!(tc["id"], "toolu_1");
+        assert_eq!(tc["function"]["name"], "exec_command");
+        let args: serde_json::Value = serde_json::from_str(tc["function"]["arguments"].as_str().unwrap()).unwrap();
+        assert_eq!(args["cmd"], "git status");
+    }
 }

--- a/src-tauri/src/protocol/codec/chat_messages_codec.rs
+++ b/src-tauri/src/protocol/codec/chat_messages_codec.rs
@@ -1000,6 +1000,24 @@ fn messages_response_maps_stop_reasons() {
             .unwrap()["choices"][0]["finish_reason"],
         "length"
     );
+    // Stop-like reasons collapse to `stop` (refusal text rides in content).
+    for stop in ["refusal", "stop_sequence", "pause_turn"] {
+        assert_eq!(
+            messages::decode_messages_response_to_chat(&base(stop), &Default::default())
+                .unwrap()["choices"][0]["finish_reason"],
+            "stop",
+            "stop_reason {stop:?} should map to stop, not error"
+        );
+    }
+    // Context-window exhaustion behaves like max_tokens (truncation).
+    assert_eq!(
+        messages::decode_messages_response_to_chat(
+            &base("model_context_window_exceeded"),
+            &Default::default()
+        )
+        .unwrap()["choices"][0]["finish_reason"],
+        "length"
+    );
     // Unknown stop reason is rejected, never mapped to stop.
     let e = messages::decode_messages_response_to_chat(&base("budget_forced"), &Default::default())
         .unwrap_err();
@@ -1061,6 +1079,54 @@ fn messages_stream_text_and_tool_deltas() {
     assert!(joined.contains("\"prompt_tokens\":5"));
     assert!(joined.contains("\"completion_tokens\":2"));
     assert_eq!(events.iter().filter(|e| e.contains("[DONE]")).count(), 1);
+}
+
+#[test]
+fn messages_stream_stop_like_reasons_normalize_not_error() {
+    // Streaming path must treat stop-like / context-window stop reasons as a
+    // normal completion, never a hard codec error (retry instead of interrupt).
+    let stream = |stop_reason: &str| {
+        let mut state = messages::MessagesSseState::default();
+        let mut events = Vec::new();
+        events.extend(
+            state
+                .feed(b"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{\"input_tokens\":5}}}\n\n")
+                .unwrap(),
+        );
+        events.extend(
+            state
+                .feed(b"event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n")
+                .unwrap(),
+        );
+        events.extend(
+            state
+                .feed(b"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"x\"}}\n\n")
+                .unwrap(),
+        );
+        events.extend(
+            state
+                .feed(b"event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n")
+                .unwrap(),
+        );
+        let delta = format!(
+            "event: message_delta\ndata: {{\"type\":\"message_delta\",\"delta\":{{\"stop_reason\":\"{stop_reason}\"}},\"usage\":{{\"output_tokens\":2}}}}\n\n"
+        );
+        events.extend(state.feed(delta.as_bytes()).unwrap());
+        events.extend(
+            state
+                .feed(b"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+                .unwrap(),
+        );
+        events.extend(state.finish().unwrap());
+        events.join("")
+    };
+
+    assert!(stream("refusal").contains("\"finish_reason\":\"stop\""));
+    assert!(stream("pause_turn").contains("\"finish_reason\":\"stop\""));
+    assert!(stream("stop_sequence").contains("\"finish_reason\":\"stop\""));
+    assert!(
+        stream("model_context_window_exceeded").contains("\"finish_reason\":\"length\"")
+    );
 }
 
 #[test]

--- a/src-tauri/src/protocol/codec/messages.rs
+++ b/src-tauri/src/protocol/codec/messages.rs
@@ -1304,10 +1304,11 @@ impl MessagesSseState {
                 ))
             }
         };
+        // OpenAI streaming chunks must ALWAYS carry `choices` (Opencode etc.
+        // reject a bare `{"usage":...}` frame), so the usage is merged into the
+        // final finish_reason frame — the OpenAI-canonical shape.
         events.push(sse::data_frame(serde_json::json!({
-            "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}]
-        })));
-        events.push(sse::data_frame(serde_json::json!({
+            "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}],
             "usage": {
                 "prompt_tokens": self.usage.input_tokens,
                 "completion_tokens": self.usage.output_tokens,

--- a/src-tauri/src/protocol/codec/messages.rs
+++ b/src-tauri/src/protocol/codec/messages.rs
@@ -840,10 +840,13 @@ pub fn decode_messages_response_to_chat(
 
     let stop_reason = body.get("stop_reason").and_then(Value::as_str);
     let finish_reason = match stop_reason {
-        Some("end_turn") => "stop",
-        Some("max_tokens") => "length",
+        // `refusal`, `stop_sequence`, `pause_turn` all mean the model simply
+        // stopped producing output (refusal text is carried in the content),
+        // so map them to the OpenAI-canonical `stop` instead of erroring.
+        Some("end_turn") | Some("refusal") | Some("stop_sequence") | Some("pause_turn") => "stop",
+        // Context-window exhaustion is a truncation, exactly like `max_tokens`.
+        Some("max_tokens") | Some("model_context_window_exceeded") => "length",
         Some("tool_use") => "tool_calls",
-        Some("refusal") | Some("refusal_message") => "content_filter",
         Some(other) => {
             return Err(UnsupportedFeatures::single(
                 FeatureKind::UnknownFinishReason,
@@ -1285,10 +1288,12 @@ impl MessagesSseState {
             }
         }
         let finish_reason = match self.stop_reason.as_deref() {
-            Some("end_turn") => "stop",
-            Some("max_tokens") => "length",
+            // Same normalization as the non-streaming path: stop-like reasons
+            // (refusal / stop_sequence / pause_turn) collapse to `stop`, and a
+            // context-window overrun behaves like `length` — never a hard error.
+            Some("end_turn") | Some("refusal") | Some("stop_sequence") | Some("pause_turn") => "stop",
+            Some("max_tokens") | Some("model_context_window_exceeded") => "length",
             Some("tool_use") => "tool_calls",
-            Some("refusal") | Some("refusal_message") => "content_filter",
             Some(other) => {
                 return Err(UnsupportedFeatures::single(
                     FeatureKind::UnknownFinishReason,

--- a/src-tauri/src/protocol/mod.rs
+++ b/src-tauri/src/protocol/mod.rs
@@ -1,6 +1,7 @@
 pub mod anthropic;
 pub mod codec;
 pub mod responses;
+pub mod sse_bridge;
 pub mod thinking;
 
 use serde_json::Value;

--- a/src-tauri/src/protocol/responses.rs
+++ b/src-tauri/src/protocol/responses.rs
@@ -22,8 +22,13 @@ impl ResponsesSseAssembler {
 
     /// Feed one upstream chunk; returns every COMPLETE SSE record it contains.
     /// A record whose terminator hasn't arrived yet is buffered for the next call.
-    pub fn push(&mut self, chunk: &str) -> Vec<String> {
-        self.pending.extend_from_slice(chunk.as_bytes());
+    ///
+    /// Takes raw bytes, not `&str`: a TCP/HTTP chunk boundary may fall inside a
+    /// UTF-8 codepoint (common with 3-byte CJK text), so callers must not gate
+    /// on `str::from_utf8`.  Bytes are buffered and only COMPLETE records are
+    /// decoded, so a mid-codepoint split is reassembled across calls.
+    pub fn push(&mut self, chunk: &[u8]) -> Vec<String> {
+        self.pending.extend_from_slice(chunk);
         let mut records = Vec::new();
         while let Some(end) = crate::protocol::codec::sse::record_end(&self.pending) {
             let record: Vec<u8> = self.pending.drain(..end).collect();
@@ -68,6 +73,7 @@ impl ResponsesSseAssembler {
 ///   response.output_item.added(type=reasoning) →
 ///   response.reasoning_summary_part.added →
 ///   response.reasoning_summary_text.delta (per chunk) →
+///   response.reasoning_summary_text.done →
 ///   response.reasoning_summary_part.done →
 ///   response.output_item.done
 #[derive(Default)]
@@ -423,8 +429,10 @@ pub fn convert_openai_sse_to_responses(
                                 tc_state.item_added_sent = true;
                             }
 
-                            // Emit arguments delta if we have arguments content
-                            if !arguments.is_empty() {
+                            // Emit arguments delta if we have arguments content — but never
+                            // after the .done has already been sent (some upstreams re-send
+                            // or deliver a trailing chunk after finish_reason).
+                            if !arguments.is_empty() && !tc_state.arguments_done_sent {
                                 tc_state.accumulated_arguments.push_str(arguments);
 
                                 state.sequence_number += 1;
@@ -451,6 +459,20 @@ pub fn convert_openai_sse_to_responses(
                         // Close reasoning item if it was opened and not yet closed
                         if state.reasoning_item_added && !state.reasoning_item_done {
                             let reasoning_output_index = state.reasoning_output_index;
+                            let seq = next_seq(state);
+                            let text_done = serde_json::json!({
+                                "type": "response.reasoning_summary_text.done",
+                                "item_id": reasoning_id,
+                                "output_index": reasoning_output_index,
+                                "summary_index": 0,
+                                "text": state.accumulated_reasoning,
+                                "sequence_number": seq
+                            });
+                            events.push(format!(
+                                "event: response.reasoning_summary_text.done\ndata: {}\n\n",
+                                text_done
+                            ));
+
                             let seq = next_seq(state);
                             let part = serde_json::json!({
                                 "type": "reasoning_summary_text",
@@ -610,6 +632,7 @@ pub fn convert_openai_sse_to_responses(
                                     "type": "response.function_call_arguments.done",
                                     "item_id": item_id,
                                     "output_index": output_index,
+                                    "name": name,
                                     "arguments": accumulated_args,
                                     "sequence_number": seq
                                 });
@@ -747,6 +770,20 @@ pub fn create_synthetic_completed_events(
         };
 
         let s = next_seq!();
+        let text_done = serde_json::json!({
+            "type": "response.reasoning_summary_text.done",
+            "item_id": reasoning_id,
+            "output_index": reasoning_output_index,
+            "summary_index": 0,
+            "text": state.accumulated_reasoning,
+            "sequence_number": s
+        });
+        events.push(format!(
+            "event: response.reasoning_summary_text.done\ndata: {}\n\n",
+            text_done
+        ));
+
+        let s = next_seq!();
         let part = serde_json::json!({
             "type": "reasoning_summary_text",
             "text": state.accumulated_reasoning
@@ -862,6 +899,7 @@ pub fn create_synthetic_completed_events(
                 "type": "response.function_call_arguments.done",
                 "item_id": tc_state.item_id,
                 "output_index": tc_state.output_index,
+                "name": tc_state.name,
                 "arguments": tc_state.accumulated_arguments,
                 "sequence_number": s
             });
@@ -973,7 +1011,14 @@ pub fn create_synthetic_completed_events(
             "completed_at": now_ts(),
             "usage": {
                 "input_tokens": usage_prompt,
+                "input_tokens_details": {
+                    "cached_tokens": 0,
+                    "cache_write_tokens": 0
+                },
                 "output_tokens": usage_completion,
+                "output_tokens_details": {
+                    "reasoning_tokens": 0
+                },
                 "total_tokens": usage_prompt + usage_completion
             }
         },
@@ -1144,7 +1189,7 @@ mod tests {
         let mut events = Vec::new();
         let mut asm = ResponsesSseAssembler::new();
         for frag in fragments {
-            for record in asm.push(frag) {
+            for record in asm.push(frag.as_bytes()) {
                 events.extend(convert_openai_sse_to_responses(
                     &record,
                     "deepseek-v4-flash",
@@ -1331,6 +1376,17 @@ mod tests {
         let item_done_data = extract_event_data(&events3[1]);
         assert_eq!(item_done_data["item"]["type"], "function_call");
         assert_eq!(item_done_data["item"]["arguments"], "{\"city\":\"SF\"}");
+
+        // Chunk 4: stray trailing arguments delta AFTER .done — must be suppressed.
+        let chunk4 = r#"data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"EXTRA"}}]},"finish_reason":null}]}"#;
+        let events4 = convert_openai_sse_to_responses(chunk4, "gpt-4", response_id, "", &mut state);
+        assert!(
+            extract_event_types(&events4).is_empty(),
+            "no delta may be re-emitted after function_call_arguments.done: {:?}",
+            events4
+        );
+        // The stray arguments must not leak into the accumulated result either.
+        assert_eq!(state.tool_calls[&0].accumulated_arguments, "{\"city\":\"SF\"}");
     }
 
     #[test]
@@ -1404,6 +1460,11 @@ mod tests {
         // Verify text done uses index 0
         let text_done = extract_event_data(&events4[0]);
         assert_eq!(text_done["output_index"], 0);
+
+        // function_call_arguments.done carries the required `name`
+        let fc_args_done = extract_event_data(&events4[3]);
+        assert_eq!(fc_args_done["type"], "response.function_call_arguments.done");
+        assert_eq!(fc_args_done["name"], "search");
 
         // Verify function_call done uses index 1
         let fc_item_done = extract_event_data(&events4[4]);
@@ -1479,6 +1540,7 @@ mod tests {
         assert_eq!(
             types4,
             vec![
+                "response.reasoning_summary_text.done",
                 "response.reasoning_summary_part.done",
                 "response.output_item.done",
                 "response.output_text.done",
@@ -1487,8 +1549,15 @@ mod tests {
             ]
         );
 
+        // reasoning_summary_text.done carries the full accumulated text
+        let rs_text_done = extract_event_data(&events4[0]);
+        assert_eq!(rs_text_done["type"], "response.reasoning_summary_text.done");
+        assert_eq!(rs_text_done["text"], "Let me think.");
+        assert_eq!(rs_text_done["summary_index"], 0);
+        assert_eq!(rs_text_done["item_id"], "rs_rs123");
+
         // reasoning item closed with the full text in the summary
-        let rs_done = extract_event_data(&events4[1]);
+        let rs_done = extract_event_data(&events4[2]);
         assert_eq!(rs_done["item"]["type"], "reasoning");
         assert_eq!(rs_done["item"]["status"], "completed");
         assert_eq!(rs_done["item"]["summary"][0]["text"], "Let me think.");
@@ -1535,6 +1604,11 @@ mod tests {
             ]
         );
 
+        // function_call_arguments.done now carries the required `name`
+        let args_done = extract_event_data(&synth[0]);
+        assert_eq!(args_done["type"], "response.function_call_arguments.done");
+        assert_eq!(args_done["name"], "test");
+
         // Verify response.completed has function_call in output
         let completed_data = extract_event_data(&synth[2]);
         assert_eq!(
@@ -1543,5 +1617,18 @@ mod tests {
         );
         assert_eq!(completed_data["response"]["usage"]["input_tokens"], 10);
         assert_eq!(completed_data["response"]["usage"]["output_tokens"], 20);
+        // usage now carries the official details sub-objects
+        assert_eq!(
+            completed_data["response"]["usage"]["output_tokens_details"]["reasoning_tokens"],
+            0
+        );
+        assert_eq!(
+            completed_data["response"]["usage"]["input_tokens_details"]["cached_tokens"],
+            0
+        );
+        assert_eq!(
+            completed_data["response"]["usage"]["total_tokens"],
+            30
+        );
     }
 }

--- a/src-tauri/src/protocol/sse_bridge.rs
+++ b/src-tauri/src/protocol/sse_bridge.rs
@@ -1,0 +1,399 @@
+//! Streaming SSE bridge: normalize any upstream protocol into OpenAI Chat SSE
+//! records so downstream handlers (Responses / Chat) share one pipeline.
+//!
+//! - OpenAI-compatible upstreams (`openai` / `deepseek` / `custom`) already
+//!   speak OpenAI SSE; we only reassemble fragmented records.
+//! - Anthropic upstreams (`claude` channels, `protocol = anthropic`) speak
+//!   Anthropic SSE; we convert via [`MessagesSseState`] (Anthropic SSE →
+//!   OpenAI SSE), which already handles record reassembly, tool calls,
+//!   reasoning deltas, usage, and the exactly-once final sequence.
+//!
+//! Callers feed raw upstream chunks and receive complete OpenAI
+//! `data: {json}\n\n` records.  A channel declared Anthropic that actually
+//! emits OpenAI bytes (or vice versa) surfaces as an `Err` on `push`/`finish`
+//! so the gateway fails visibly instead of silently dropping content.
+
+use crate::protocol::codec::messages::MessagesSseState;
+use crate::protocol::responses::ResponsesSseAssembler;
+
+/// Whether an upstream channel speaks Anthropic SSE (requires conversion).
+///
+/// `channel_type == "claude"` is the historical signal; the `protocol`
+/// identity column (T02) is authoritative when present.
+pub fn is_anthropic_upstream(channel_type: &str, protocol: Option<&str>) -> bool {
+    channel_type.eq_ignore_ascii_case("claude")
+        || protocol
+            .map(|p| p.eq_ignore_ascii_case("anthropic"))
+            .unwrap_or(false)
+}
+
+/// Bridge producing complete OpenAI `data: {json}\n\n` records from raw
+/// upstream bytes, independent of the upstream protocol.
+pub enum UpstreamSseBridge {
+    /// OpenAI-compatible upstream: reassemble records as-is.
+    OpenAi(ResponsesSseAssembler),
+    /// Anthropic upstream: convert Anthropic SSE → OpenAI SSE records.
+    Anthropic(MessagesSseState),
+}
+
+impl UpstreamSseBridge {
+    /// Create the bridge for an upstream.  `model` is used only on the
+    /// Anthropic path, for the synthesized Chat `role` frame.
+    pub fn for_upstream(is_anthropic: bool, model: &str) -> Self {
+        if is_anthropic {
+            Self::Anthropic(MessagesSseState::new(model))
+        } else {
+            Self::OpenAi(ResponsesSseAssembler::new())
+        }
+    }
+
+    /// Feed one upstream chunk; returns every complete OpenAI
+    /// `data: {json}\n\n` record produced so far.
+    pub fn push(&mut self, chunk: &str) -> Result<Vec<String>, String> {
+        match self {
+            Self::OpenAi(assembler) => Ok(assembler.push(chunk)),
+            Self::Anthropic(state) => state.feed(chunk.as_bytes()).map_err(|e| e.to_string()),
+        }
+    }
+
+    /// Flush end-of-stream.  For OpenAI upstreams this is a trailing-EOF
+    /// record; for Anthropic it is the exactly-once final sequence
+    /// (finish_reason + usage in the last `choices` frame, then `[DONE]`).
+    /// The usage is merged into the finish_reason frame (not a bare usage-only
+    /// frame) because OpenAI-compat clients like Opencode reject chunks that
+    /// lack `choices`.
+    pub fn finish(&mut self) -> Result<Vec<String>, String> {
+        match self {
+            Self::OpenAi(assembler) => Ok(assembler.flush()),
+            Self::Anthropic(state) => {
+                let records = state.finish().map_err(|e| e.to_string())?;
+                // MessagesSseState emits the terminator as `data: "[DONE]"`
+                // (serde-quoted); OpenAI clients only recognize the unquoted
+                // `data: [DONE]`, so normalize before handing downstream.
+                Ok(records.into_iter().map(normalize_done).collect())
+            }
+        }
+    }
+}
+
+/// Normalize a trailing `[DONE]` record to the OpenAI-canonical unquoted form.
+fn normalize_done(record: String) -> String {
+    let body = record.trim_end_matches('\n').trim_end_matches('\r');
+    if let Some(data) = body.strip_prefix("data:") {
+        let payload = data.trim();
+        if payload == "[DONE]" || payload == "\"[DONE]\"" {
+            return "data: [DONE]\n\n".to_string();
+        }
+    }
+    record
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Split a record into two mid-JSON chunks (as TCP fragmentation does).
+    fn split_mid(record: &str) -> (String, String) {
+        let mid = record.len() / 2;
+        (record[..mid].to_string(), record[mid..].to_string())
+    }
+
+    #[test]
+    fn anthropic_stream_converts_to_openai_records() {
+        let mut bridge = UpstreamSseBridge::for_upstream(true, "claude-3-5");
+        let out = bridge
+            .push(
+                "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{\"input_tokens\":5}}}\n\n",
+            )
+            .unwrap();
+        // role frame first
+        assert_eq!(out.len(), 1);
+        let role = serde_json::from_str::<serde_json::Value>(out[0].trim_start_matches("data:").trim())
+            .unwrap();
+        assert_eq!(role["choices"][0]["delta"]["role"], "assistant");
+
+        let out = bridge
+            .push(
+                "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"你\"}}\n\n",
+            )
+            .unwrap();
+        assert_eq!(out.len(), 1);
+        let delta = serde_json::from_str::<serde_json::Value>(out[0].trim_start_matches("data:").trim())
+            .unwrap();
+        assert_eq!(delta["choices"][0]["delta"]["content"], "你");
+
+        let out = bridge
+            .push(
+                "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}\n\n\
+                 event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+            )
+            .unwrap();
+        // finish() is what emits the final sequence; message_stop alone is a no-op.
+        assert!(out.is_empty());
+
+        let out = bridge.finish().unwrap();
+        let joined = out.join("");
+        assert!(joined.contains("\"finish_reason\":\"stop\""));
+        assert!(joined.contains("\"usage\""));
+        assert!(joined.contains("\"prompt_tokens\":5"));
+        assert!(joined.contains("\"completion_tokens\":2"));
+        assert!(joined.ends_with("data: [DONE]\n\n"));
+    }
+
+    #[test]
+    fn anthropic_done_is_normalized_to_unquoted() {
+        let mut bridge = UpstreamSseBridge::for_upstream(true, "claude-3-5");
+        bridge
+            .push(
+                "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{}}}\n\n",
+            )
+            .unwrap();
+        bridge
+            .push(
+                "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{}}\n\n\
+                 event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+            )
+            .unwrap();
+        let out = bridge.finish().unwrap();
+        assert_eq!(out.last().unwrap(), "data: [DONE]\n\n");
+    }
+
+    /// Regression (Opencode "Type validation failed ... expected array for
+    /// `choices`"): the final sequence must never contain a bare `{"usage":..}`
+    /// frame, because OpenAI-compat clients require every chunk to carry
+    /// `choices`.  Usage must be merged into the last finish_reason frame.
+    #[test]
+    fn final_sequence_merges_usage_into_finish_reason_frame() {
+        let mut bridge = UpstreamSseBridge::for_upstream(true, "claude-3-5");
+        bridge
+            .push(
+                "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{\"input_tokens\":7}}}\n\n\
+                 event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n",
+            )
+            .unwrap();
+        bridge
+            .push(
+                "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":3}}\n\n\
+                 event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+            )
+            .unwrap();
+        let out = bridge.finish().unwrap();
+        // Exactly the finish_reason+usage frame, then [DONE] — no extra frames.
+        assert_eq!(out.len(), 2, "final sequence must be [finish+usage, DONE], got: {out:?}");
+        let last = out[0].trim_start_matches("data:").trim();
+        let json: serde_json::Value = serde_json::from_str(last).unwrap();
+        // Every non-[DONE] frame must carry `choices`.
+        assert!(
+            json.get("choices").is_some(),
+            "final frame must carry choices (bare usage frame rejected by Opencode): {json}"
+        );
+        assert_eq!(json["choices"][0]["finish_reason"], "stop");
+        assert_eq!(json["usage"]["prompt_tokens"], 7);
+        assert_eq!(json["usage"]["completion_tokens"], 3);
+        assert_eq!(out[1], "data: [DONE]\n\n");
+    }
+
+    #[test]
+    fn anthropic_fragmented_records_are_reassembled() {
+        let mut bridge = UpstreamSseBridge::for_upstream(true, "claude-3-5");
+        // Feed record bytes split mid-JSON across push calls (the real upstream
+        // fragmentation pattern that silently dropped content before the fix).
+        let (a, b) = split_mid(
+            "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{}}}\n\n",
+        );
+        assert!(bridge.push(&a).unwrap().is_empty());
+        let out = bridge.push(&b).unwrap();
+        assert_eq!(out.len(), 1);
+
+        let (c, d) = split_mid(
+            "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\n",
+        );
+        assert!(bridge.push(&c).unwrap().is_empty());
+        let out = bridge.push(&d).unwrap();
+        assert_eq!(out.len(), 1);
+        let delta = serde_json::from_str::<serde_json::Value>(out[0].trim_start_matches("data:").trim())
+            .unwrap();
+        assert_eq!(delta["choices"][0]["delta"]["content"], "hello");
+
+        bridge
+            .push(
+                "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{}}\n\n\
+                 event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+            )
+            .unwrap();
+        let out = bridge.finish().unwrap();
+        assert!(out.join("").ends_with("data: [DONE]\n\n"));
+    }
+
+    #[test]
+    fn openai_stream_passes_through_records_verbatim() {
+        let mut bridge = UpstreamSseBridge::for_upstream(false, "");
+        let record = "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\n";
+        let out = bridge.push(record).unwrap();
+        assert_eq!(out, vec![record.to_string()]);
+        assert!(bridge.finish().unwrap().is_empty());
+    }
+
+    /// The regression that motivated the bridge: converting Anthropic SSE to
+    /// OpenAI SSE records and feeding them through the Responses converter must
+    /// produce `response.output_text.delta` events (it previously produced
+    /// nothing because Anthropic frames have no `choices`).
+    #[test]
+    fn converted_anthropic_records_feed_the_responses_pipeline() {
+        let mut bridge = UpstreamSseBridge::for_upstream(true, "claude-3-5");
+        let mut records = bridge
+            .push(
+                "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{}}}\n\n\
+                 event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\n",
+            )
+            .unwrap();
+        records.extend(
+            bridge
+                .push(
+                    "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{}}\n\n\
+                     event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+                )
+                .unwrap(),
+        );
+        records.extend(bridge.finish().unwrap());
+
+        let mut state = crate::protocol::responses::StreamState::default();
+        let mut accumulated = String::new();
+        let mut saw_delta = false;
+        let mut saw_completed = false;
+        for record in &records {
+            let events = crate::protocol::responses::convert_openai_sse_to_responses(
+                record,
+                "claude-3-5",
+                "resp_abc",
+                &accumulated,
+                &mut state,
+            );
+            for ev in &events {
+                if ev.contains("response.output_text.delta") {
+                    saw_delta = true;
+                }
+            }
+            // Track content from OpenAI frames for the accumulated arg.
+            for line in record.lines() {
+                let trimmed = line.trim();
+                if let Some(d) = trimmed.strip_prefix("data:") {
+                    if let Ok(json) = serde_json::from_str::<serde_json::Value>(d.trim()) {
+                        if let Some(choices) = json.get("choices").and_then(|c| c.as_array()) {
+                            if let Some(delta) = choices.first().and_then(|c| c.get("delta")) {
+                                if let Some(t) = delta.get("content").and_then(|c| c.as_str()) {
+                                    accumulated.push_str(t);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        assert!(saw_delta, "converted Anthropic frames must produce output_text.delta");
+        assert_eq!(accumulated, "hello");
+        let _ = saw_completed;
+    }
+
+    /// The full Codex tool-call flow end to end: an Anthropic upstream that
+    /// decides to call a tool emits `content_block_start`(tool_use) →
+    /// `input_json_delta` → `content_block_stop` → `message_delta`(tool_use).
+    /// These must survive the bridge AND the Responses converter, producing the
+    /// exact `response.function_call*` event chain Codex expects. This was
+    /// completely broken before the fix: the upstream never received `tools`,
+    /// so it emitted DSML text instead of a real `tool_use` (session 019fe025).
+    #[test]
+    fn anthropic_tool_use_becomes_responses_function_call_chain() {
+        let mut bridge = UpstreamSseBridge::for_upstream(true, "claude-3-5");
+        let mut records = bridge
+            .push(
+                "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{\"input_tokens\":10}}}\n\n",
+            )
+            .unwrap();
+        records.extend(
+            bridge
+                .push(
+                    "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"exec_command\"}}\n\n\
+                     event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"cmd\\\":\\\"git sta\"}}\n\n",
+                )
+                .unwrap(),
+        );
+        records.extend(
+            bridge
+                .push(
+                    "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"tus\\\"}\"}}\n\n\
+                     event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+                )
+                .unwrap(),
+        );
+        records.extend(
+            bridge
+                .push(
+                    "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":5}}\n\n\
+                     event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+                )
+                .unwrap(),
+        );
+        records.extend(bridge.finish().unwrap());
+
+        // First: the bridge must have produced an OpenAI tool_calls record.
+        let all: String = records.iter().map(|r| r.as_str()).collect::<Vec<_>>().join("\n");
+        assert!(
+            all.contains("\"tool_calls\"") && all.contains("exec_command"),
+            "bridge must emit an OpenAI tool_calls record, got: {all}"
+        );
+
+        // Then: feed the whole stream through the Responses converter.
+        let mut state = crate::protocol::responses::StreamState::default();
+        let mut accumulated = String::new();
+        let mut saw_function_call_added = false;
+        let mut saw_args_delta = false;
+        let mut saw_args_done = false;
+        let mut saw_fc_done = false;
+        let mut saw_text = String::new();
+        for record in &records {
+            let events = crate::protocol::responses::convert_openai_sse_to_responses(
+                record,
+                "claude-3-5",
+                "resp_abc",
+                &accumulated,
+                &mut state,
+            );
+            for ev in &events {
+                if ev.contains("\"type\":\"function_call\"") && ev.contains("output_item.added") {
+                    saw_function_call_added = true;
+                }
+                if ev.contains("response.function_call_arguments.delta") {
+                    saw_args_delta = true;
+                }
+                if ev.contains("response.function_call_arguments.done") {
+                    saw_args_done = true;
+                }
+                if ev.contains("\"type\":\"function_call\"") && ev.contains("output_item.done") {
+                    saw_fc_done = true;
+                }
+            }
+            // Track content from OpenAI frames for the accumulated arg.
+            for line in record.lines() {
+                let trimmed = line.trim();
+                if let Some(d) = trimmed.strip_prefix("data:") {
+                    if let Ok(json) = serde_json::from_str::<serde_json::Value>(d.trim()) {
+                        if let Some(choices) = json.get("choices").and_then(|c| c.as_array()) {
+                            if let Some(delta) = choices.first().and_then(|c| c.get("delta")) {
+                                if let Some(t) = delta.get("content").and_then(|c| c.as_str()) {
+                                    accumulated.push_str(t);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        assert!(saw_function_call_added, "must emit function_call output_item.added");
+        assert!(saw_args_delta, "must emit function_call_arguments.delta");
+        assert!(saw_args_done, "must emit function_call_arguments.done");
+        assert!(saw_fc_done, "must emit function_call output_item.done");
+        let _ = saw_text;
+        let _ = accumulated;
+    }
+}

--- a/src-tauri/src/protocol/sse_bridge.rs
+++ b/src-tauri/src/protocol/sse_bridge.rs
@@ -49,10 +49,16 @@ impl UpstreamSseBridge {
 
     /// Feed one upstream chunk; returns every complete OpenAI
     /// `data: {json}\n\n` record produced so far.
-    pub fn push(&mut self, chunk: &str) -> Result<Vec<String>, String> {
+    ///
+    /// Takes raw bytes, not `&str`: a TCP/HTTP chunk boundary can fall in the
+    /// middle of a UTF-8 codepoint (very common with 3-byte CJK text), so the
+    /// caller must not gate on `str::from_utf8`.  Both variants buffer bytes
+    /// internally and only decode COMPLETE records, so a mid-codepoint split is
+    /// reassembled across calls — never dropped and never escaped raw.
+    pub fn push(&mut self, chunk: &[u8]) -> Result<Vec<String>, String> {
         match self {
             Self::OpenAi(assembler) => Ok(assembler.push(chunk)),
-            Self::Anthropic(state) => state.feed(chunk.as_bytes()).map_err(|e| e.to_string()),
+            Self::Anthropic(state) => state.feed(chunk).map_err(|e| e.to_string()),
         }
     }
 
@@ -103,7 +109,7 @@ mod tests {
         let mut bridge = UpstreamSseBridge::for_upstream(true, "claude-3-5");
         let out = bridge
             .push(
-                "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{\"input_tokens\":5}}}\n\n",
+                b"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{\"input_tokens\":5}}}\n\n",
             )
             .unwrap();
         // role frame first
@@ -114,7 +120,8 @@ mod tests {
 
         let out = bridge
             .push(
-                "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"你\"}}\n\n",
+                "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"你\"}}\n\n"
+                    .as_bytes(),
             )
             .unwrap();
         assert_eq!(out.len(), 1);
@@ -124,7 +131,7 @@ mod tests {
 
         let out = bridge
             .push(
-                "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}\n\n\
+                b"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}\n\n\
                  event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
             )
             .unwrap();
@@ -145,12 +152,12 @@ mod tests {
         let mut bridge = UpstreamSseBridge::for_upstream(true, "claude-3-5");
         bridge
             .push(
-                "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{}}}\n\n",
+                b"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{}}}\n\n",
             )
             .unwrap();
         bridge
             .push(
-                "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{}}\n\n\
+                b"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{}}\n\n\
                  event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
             )
             .unwrap();
@@ -167,13 +174,13 @@ mod tests {
         let mut bridge = UpstreamSseBridge::for_upstream(true, "claude-3-5");
         bridge
             .push(
-                "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{\"input_tokens\":7}}}\n\n\
+                b"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{\"input_tokens\":7}}}\n\n\
                  event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n",
             )
             .unwrap();
         bridge
             .push(
-                "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":3}}\n\n\
+                b"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":3}}\n\n\
                  event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
             )
             .unwrap();
@@ -193,6 +200,50 @@ mod tests {
         assert_eq!(out[1], "data: [DONE]\n\n");
     }
 
+    /// Regression (Opencode "Type validation failed ... expected array for
+    /// `choices`" on a raw `content_block_delta` frame): a TCP/HTTP chunk that
+    /// ends in the middle of a UTF-8 codepoint (e.g. a 3-byte Chinese char in
+    /// `text`/`thinking`) makes `std::str::from_utf8` fail.  The OLD handler
+    /// treated that as "not valid UTF-8" and yielded the raw Anthropic record
+    /// straight to the OpenAI client.  The bridge must instead hold the partial
+    /// record in its byte buffer and convert it once the next chunk completes
+    /// the codepoint.
+    #[test]
+    fn anthropic_chunk_split_mid_codepoint_is_converted_not_leaked() {
+        let mut bridge = UpstreamSseBridge::for_upstream(true, "claude-3-5");
+        // A complete Anthropic text_delta record carrying a 2-char Chinese word.
+        // 现 = e7 8e b0, 状 = e7 8a b6 (3 bytes each).
+        let full = b"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"\xe7\x8e\xb0\xe7\x8a\xb6\"}}\n\n";
+        let cut = full
+            .windows(6)
+            .position(|w| w == b"\xe7\x8e\xb0\xe7\x8a\xb6")
+            .unwrap()
+            + 2; // split 2 bytes INTO 现
+        let (a, b) = full.split_at(cut);
+        // The trigger: this exact boundary is INVALID as a &str...
+        assert!(
+            std::str::from_utf8(a).is_err(),
+            "test setup: chunk a must end mid-codepoint so from_utf8 fails"
+        );
+        // ...yet the bridge must accept the bytes and buffer the record, NOT
+        // return a raw frame.
+        let out = bridge.push(a).unwrap();
+        assert!(
+            out.is_empty(),
+            "partial record must be held, never surfaced as a raw frame: {out:?}"
+        );
+        let out = bridge.push(b).unwrap();
+        assert_eq!(out.len(), 1, "completed record must convert: {out:?}");
+        let json: serde_json::Value =
+            serde_json::from_str(out[0].trim_start_matches("data:").trim()).unwrap();
+        assert_eq!(json["choices"][0]["delta"]["content"], "现状");
+        // Every emitted frame must carry `choices` (OpenAI-compat contract).
+        assert!(
+            json.get("choices").is_some(),
+            "converted frame must carry choices: {json}"
+        );
+    }
+
     #[test]
     fn anthropic_fragmented_records_are_reassembled() {
         let mut bridge = UpstreamSseBridge::for_upstream(true, "claude-3-5");
@@ -201,15 +252,15 @@ mod tests {
         let (a, b) = split_mid(
             "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{}}}\n\n",
         );
-        assert!(bridge.push(&a).unwrap().is_empty());
-        let out = bridge.push(&b).unwrap();
+        assert!(bridge.push(a.as_bytes()).unwrap().is_empty());
+        let out = bridge.push(b.as_bytes()).unwrap();
         assert_eq!(out.len(), 1);
 
         let (c, d) = split_mid(
             "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\n",
         );
-        assert!(bridge.push(&c).unwrap().is_empty());
-        let out = bridge.push(&d).unwrap();
+        assert!(bridge.push(c.as_bytes()).unwrap().is_empty());
+        let out = bridge.push(d.as_bytes()).unwrap();
         assert_eq!(out.len(), 1);
         let delta = serde_json::from_str::<serde_json::Value>(out[0].trim_start_matches("data:").trim())
             .unwrap();
@@ -217,7 +268,7 @@ mod tests {
 
         bridge
             .push(
-                "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{}}\n\n\
+                b"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{}}\n\n\
                  event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
             )
             .unwrap();
@@ -229,7 +280,7 @@ mod tests {
     fn openai_stream_passes_through_records_verbatim() {
         let mut bridge = UpstreamSseBridge::for_upstream(false, "");
         let record = "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\n";
-        let out = bridge.push(record).unwrap();
+        let out = bridge.push(record.as_bytes()).unwrap();
         assert_eq!(out, vec![record.to_string()]);
         assert!(bridge.finish().unwrap().is_empty());
     }
@@ -243,14 +294,14 @@ mod tests {
         let mut bridge = UpstreamSseBridge::for_upstream(true, "claude-3-5");
         let mut records = bridge
             .push(
-                "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{}}}\n\n\
+                b"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{}}}\n\n\
                  event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\n",
             )
             .unwrap();
         records.extend(
             bridge
                 .push(
-                    "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{}}\n\n\
+                    b"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{}}\n\n\
                      event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
                 )
                 .unwrap(),
@@ -307,13 +358,13 @@ mod tests {
         let mut bridge = UpstreamSseBridge::for_upstream(true, "claude-3-5");
         let mut records = bridge
             .push(
-                "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{\"input_tokens\":10}}}\n\n",
+                b"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{\"input_tokens\":10}}}\n\n",
             )
             .unwrap();
         records.extend(
             bridge
                 .push(
-                    "event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"exec_command\"}}\n\n\
+                    b"event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"exec_command\"}}\n\n\
                      event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"cmd\\\":\\\"git sta\"}}\n\n",
                 )
                 .unwrap(),
@@ -321,7 +372,7 @@ mod tests {
         records.extend(
             bridge
                 .push(
-                    "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"tus\\\"}\"}}\n\n\
+                    b"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"tus\\\"}\"}}\n\n\
                      event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
                 )
                 .unwrap(),
@@ -329,7 +380,7 @@ mod tests {
         records.extend(
             bridge
                 .push(
-                    "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":5}}\n\n\
+                    b"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":5}}\n\n\
                      event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
                 )
                 .unwrap(),

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -437,6 +437,113 @@ fn parse_usage_from_chunk(text: &str) -> Option<(i64, i64, i64)> {
     None
 }
 
+/// Accumulate token usage and response content from one complete OpenAI Chat
+/// SSE record (`data: {json}\n\n`).  Shared by every upstream protocol: the
+/// Anthropic bridge converts its records into this exact shape first.
+fn accumulate_openai_chat_record(
+    record: &str,
+    usage_prompt: &mut i64,
+    usage_completion: &mut i64,
+    usage_total: &mut i64,
+    accumulated_content: &mut String,
+    accumulated_reasoning: &mut String,
+    response_role: &mut Option<String>,
+    finish_reason: &mut Option<String>,
+    tool_calls_map: &mut std::collections::BTreeMap<i64, serde_json::Value>,
+) {
+    if let Some((p, c, t)) = parse_usage_from_chunk(record) {
+        *usage_prompt = p;
+        *usage_completion = c;
+        *usage_total = t;
+    }
+    // Accumulate delta content from SSE records
+    for line in record.lines() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with("data:") {
+            continue;
+        }
+        let data_str = trimmed.trim_start_matches("data:").trim();
+        if data_str == "[DONE]" || data_str.is_empty() {
+            continue;
+        }
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(data_str) {
+            if let Some(choices) = json.get("choices").and_then(|c| c.as_array()) {
+                if let Some(choice) = choices.first() {
+                    if let Some(delta) = choice.get("delta") {
+                        // Accumulate regular content
+                        if let Some(content) = delta.get("content").and_then(|c| c.as_str()) {
+                            accumulated_content.push_str(content);
+                        }
+                        // Accumulate reasoning/thinking content (DeepSeek R1, OpenAI o1/o3, etc.)
+                        if let Some(reasoning) = delta.get("reasoning_content").and_then(|c| c.as_str())
+                        {
+                            accumulated_reasoning.push_str(reasoning);
+                        }
+                        if response_role.is_none() {
+                            if let Some(role) = delta.get("role").and_then(|r| r.as_str()) {
+                                *response_role = Some(role.to_string());
+                            }
+                        }
+                        // Accumulate tool_calls by index
+                        if let Some(tcs) = delta.get("tool_calls").and_then(|t| t.as_array()) {
+                            for tc in tcs {
+                                let idx = tc.get("index").and_then(|i| i.as_i64()).unwrap_or(0);
+                                let entry = tool_calls_map
+                                    .entry(idx)
+                                    .or_insert_with(|| {
+                                        serde_json::json!({
+                                            "id": "",
+                                            "type": "function",
+                                            "function": {
+                                                "name": "",
+                                                "arguments": ""
+                                            }
+                                        })
+                                    });
+                                if let Some(id) = tc.get("id").and_then(|v| v.as_str()) {
+                                    if !id.is_empty() {
+                                        entry["id"] = serde_json::json!(id);
+                                    }
+                                }
+                                if let Some(t) = tc.get("type").and_then(|v| v.as_str()) {
+                                    if !t.is_empty() {
+                                        entry["type"] = serde_json::json!(t);
+                                    }
+                                }
+                                if let Some(func) = tc.get("function") {
+                                    if let Some(name) = func.get("name").and_then(|v| v.as_str()) {
+                                        if !name.is_empty() {
+                                            entry["function"]["name"] = serde_json::json!(name);
+                                        }
+                                    }
+                                    if let Some(args) = func.get("arguments").and_then(|v| v.as_str())
+                                    {
+                                        let existing = entry["function"]["arguments"]
+                                            .as_str()
+                                            .unwrap_or("");
+                                        entry["function"]["arguments"] =
+                                            serde_json::json!(format!("{}{}", existing, args));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if finish_reason.is_none() {
+                        if let Some(reason) = choice
+                            .get("finish_reason")
+                            .and_then(|r| r.as_str())
+                        {
+                            if !reason.is_empty() && reason != "null" {
+                                *finish_reason = Some(reason.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 async fn handle_stream(
     shared: SharedState,
     json: serde_json::Value,
@@ -569,6 +676,12 @@ async fn handle_stream(
                 let security_result_clone = security_result.clone();
                 let trace_id_clone = trace_id.clone();
                 let is_retry = if attempt > 0 { 1 } else { 0 };
+                // Claude/Anthropic channels return Anthropic SSE from
+                // forward_stream; bridge it to OpenAI SSE before relaying.
+                let upstream_is_anthropic = crate::protocol::sse_bridge::is_anthropic_upstream(
+                    &channel.channel_type,
+                    channel.protocol.as_deref(),
+                );
 
                 // ── Raw byte passthrough with usage parsing ───────────────
                 // Forward upstream SSE bytes directly as the response body.
@@ -590,95 +703,50 @@ async fn handle_stream(
                     let mut finish_reason: Option<String> = None;
                     // Accumulate tool_calls by index (streaming chunks may contain partial tool_calls)
                     let mut tool_calls_map: std::collections::BTreeMap<i64, serde_json::Value> = std::collections::BTreeMap::new();
+                    // Normalize fragmented / Anthropic upstream records into
+                    // complete OpenAI SSE records before accumulation + relay.
+                    let mut sse_bridge = crate::protocol::sse_bridge::UpstreamSseBridge::for_upstream(
+                        upstream_is_anthropic,
+                        &upstream_model_clone,
+                    );
 
                     while let Some(chunk_result) = upstream_stream.next().await {
                         match chunk_result {
                             Ok(bytes) => {
-                                // Try to parse usage and content from this chunk
+                                // Normalize the chunk through the bridge, then
+                                // accumulate usage/content and relay the records.
                                 if let Ok(text) = std::str::from_utf8(&bytes) {
-                                    if let Some((p, c, t)) = parse_usage_from_chunk(text) {
-                                        usage_prompt = p;
-                                        usage_completion = c;
-                                        usage_total = t;
-                                    }
-                                    // Accumulate delta content from SSE chunks
-                                    for line in text.lines() {
-                                        let trimmed = line.trim();
-                                        if !trimmed.starts_with("data:") {
-                                            continue;
-                                        }
-                                        let data_str = trimmed.trim_start_matches("data:").trim();
-                                        if data_str == "[DONE]" || data_str.is_empty() {
-                                            continue;
-                                        }
-                                        if let Ok(json) = serde_json::from_str::<serde_json::Value>(data_str) {
-                                            if let Some(choices) = json.get("choices").and_then(|c| c.as_array()) {
-                                                if let Some(choice) = choices.first() {
-                                                    if let Some(delta) = choice.get("delta") {
-                                                        // Accumulate regular content
-                                                        if let Some(content) = delta.get("content").and_then(|c| c.as_str()) {
-                                                            accumulated_content.push_str(content);
-                                                        }
-                                                        // Accumulate reasoning/thinking content (DeepSeek R1, OpenAI o1/o3, etc.)
-                                                        if let Some(reasoning) = delta.get("reasoning_content").and_then(|c| c.as_str()) {
-                                                            accumulated_reasoning.push_str(reasoning);
-                                                        }
-                                                        if response_role.is_none() {
-                                                            if let Some(role) = delta.get("role").and_then(|r| r.as_str()) {
-                                                                response_role = Some(role.to_string());
-                                                            }
-                                                        }
-                                                        // Accumulate tool_calls by index
-                                                        if let Some(tcs) = delta.get("tool_calls").and_then(|t| t.as_array()) {
-                                                            for tc in tcs {
-                                                                let idx = tc.get("index").and_then(|i| i.as_i64()).unwrap_or(0);
-                                                                let entry = tool_calls_map.entry(idx).or_insert_with(|| {
-                                                                    serde_json::json!({
-                                                                        "id": "",
-                                                                        "type": "function",
-                                                                        "function": {
-                                                                            "name": "",
-                                                                            "arguments": ""
-                                                                        }
-                                                                    })
-                                                                });
-                                                                if let Some(id) = tc.get("id").and_then(|v| v.as_str()) {
-                                                                    if !id.is_empty() {
-                                                                        entry["id"] = serde_json::json!(id);
-                                                                    }
-                                                                }
-                                                                if let Some(t) = tc.get("type").and_then(|v| v.as_str()) {
-                                                                    if !t.is_empty() {
-                                                                        entry["type"] = serde_json::json!(t);
-                                                                    }
-                                                                }
-                                                                if let Some(func) = tc.get("function") {
-                                                                    if let Some(name) = func.get("name").and_then(|v| v.as_str()) {
-                                                                        if !name.is_empty() {
-                                                                            entry["function"]["name"] = serde_json::json!(name);
-                                                                        }
-                                                                    }
-                                                                    if let Some(args) = func.get("arguments").and_then(|v| v.as_str()) {
-                                                                        let existing = entry["function"]["arguments"].as_str().unwrap_or("");
-                                                                        entry["function"]["arguments"] = serde_json::json!(format!("{}{}", existing, args));
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                    if finish_reason.is_none() {
-                                                        if let Some(reason) = choice.get("finish_reason").and_then(|r| r.as_str()) {
-                                                            if !reason.is_empty() && reason != "null" {
-                                                                finish_reason = Some(reason.to_string());
-                                                            }
-                                                        }
-                                                    }
-                                                }
+                                    match sse_bridge.push(text) {
+                                        Ok(records) => {
+                                            for record in records {
+                                                accumulate_openai_chat_record(
+                                                    &record,
+                                                    &mut usage_prompt,
+                                                    &mut usage_completion,
+                                                    &mut usage_total,
+                                                    &mut accumulated_content,
+                                                    &mut accumulated_reasoning,
+                                                    &mut response_role,
+                                                    &mut finish_reason,
+                                                    &mut tool_calls_map,
+                                                );
+                                                yield Ok::<_, std::io::Error>(record.into_bytes().into());
                                             }
                                         }
+                                        Err(e) => {
+                                            had_error = true;
+                                            let err_chunk = format!(
+                                                "data: {{\"error\":{{\"message\":\"Upstream conversion failed: {}\",\"type\":\"server_error\"}}}}\n\n",
+                                                e
+                                            );
+                                            yield Ok::<_, std::io::Error>(err_chunk.into_bytes().into());
+                                            yield Ok::<_, std::io::Error>(b"data: [DONE]\n\n".to_vec().into());
+                                            break;
+                                        }
                                     }
+                                } else {
+                                    yield Ok::<_, std::io::Error>(bytes);
                                 }
-                                yield Ok::<_, std::io::Error>(bytes);
                             }
                             Err(e) => {
                                 had_error = true;
@@ -689,6 +757,39 @@ async fn handle_stream(
                                 yield Ok::<_, std::io::Error>(err_chunk.into_bytes().into());
                                 yield Ok::<_, std::io::Error>(b"data: [DONE]\n\n".to_vec().into());
                                 break;
+                            }
+                        }
+                    }
+
+                    // Stream ended. Flush any trailing record that terminated at
+                    // EOF, and on Anthropic channels emit the exactly-once final
+                    // sequence (finish_reason + usage frame, then [DONE]).
+                    if !had_error {
+                        match sse_bridge.finish() {
+                            Ok(records) => {
+                                for record in records {
+                                    accumulate_openai_chat_record(
+                                        &record,
+                                        &mut usage_prompt,
+                                        &mut usage_completion,
+                                        &mut usage_total,
+                                        &mut accumulated_content,
+                                        &mut accumulated_reasoning,
+                                        &mut response_role,
+                                        &mut finish_reason,
+                                        &mut tool_calls_map,
+                                    );
+                                    yield Ok::<_, std::io::Error>(record.into_bytes().into());
+                                }
+                            }
+                            Err(e) => {
+                                had_error = true;
+                                let err_chunk = format!(
+                                    "data: {{\"error\":{{\"message\":\"Upstream conversion failed: {}\",\"type\":\"server_error\"}}}}\n\n",
+                                    e
+                                );
+                                yield Ok::<_, std::io::Error>(err_chunk.into_bytes().into());
+                                yield Ok::<_, std::io::Error>(b"data: [DONE]\n\n".to_vec().into());
                             }
                         }
                     }
@@ -2188,6 +2289,64 @@ pub async fn handle_responses(
     }
 }
 
+/// Process one complete OpenAI SSE record through the Responses streaming
+/// pipeline: record token usage, accumulate content/reasoning for logging, and
+/// convert the record into Responses SSE events.
+///
+/// Both the Anthropic bridge (converted frames) and OpenAI-compatible
+/// upstreams feed records here, so a single pipeline serves every protocol.
+#[allow(clippy::too_many_arguments)]
+fn process_openai_record_for_responses(
+    record: &str,
+    model: &str,
+    response_id: &str,
+    stream_state: &mut crate::protocol::responses::StreamState,
+    accumulated_content: &mut String,
+    accumulated_reasoning: &mut String,
+    usage_prompt: &mut i64,
+    usage_completion: &mut i64,
+    usage_total: &mut i64,
+) -> Vec<String> {
+    if let Some((p, c, t)) = crate::protocol::responses::parse_usage_from_sse_chunk(record) {
+        *usage_prompt = p;
+        *usage_completion = c;
+        *usage_total = t;
+    }
+    // Accumulate content for logging
+    for line in record.lines() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with("data:") {
+            continue;
+        }
+        let data_str = trimmed.trim_start_matches("data:").trim();
+        if data_str == "[DONE]" || data_str.is_empty() {
+            continue;
+        }
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(data_str) {
+            if let Some(choices) = json.get("choices").and_then(|c| c.as_array()) {
+                if let Some(choice) = choices.first() {
+                    if let Some(delta) = choice.get("delta") {
+                        if let Some(content) = delta.get("content").and_then(|c| c.as_str()) {
+                            accumulated_content.push_str(content);
+                        }
+                        if let Some(reasoning) = delta.get("reasoning_content").and_then(|c| c.as_str())
+                        {
+                            accumulated_reasoning.push_str(reasoning);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    crate::protocol::responses::convert_openai_sse_to_responses(
+        record,
+        model,
+        response_id,
+        accumulated_content,
+        stream_state,
+    )
+}
+
 /// Stream handler for Responses API.
 /// Converts OpenAI SSE stream to Responses API SSE events.
 ///
@@ -2323,6 +2482,13 @@ async fn handle_responses_stream(
                 let trace_id_clone = trace_id.clone();
                 let is_retry = if attempt > 0 { 1 } else { 0 };
 
+                // Claude/Anthropic channels return Anthropic SSE from
+                // forward_stream; bridge it to OpenAI SSE before conversion.
+                let upstream_is_anthropic = crate::protocol::sse_bridge::is_anthropic_upstream(
+                    &channel.channel_type,
+                    channel.protocol.as_deref(),
+                );
+
                 let response_id = format!("resp_{}", uuid::Uuid::new_v4().simple());
                 let upstream_stream = resp.bytes_stream();
 
@@ -2340,51 +2506,46 @@ async fn handle_responses_stream(
                     let mut stream_state = crate::protocol::responses::StreamState::default();
                     let mut accumulated_content = String::new();
                     let mut accumulated_reasoning = String::new();
-                    let mut sse_assembler = crate::protocol::responses::ResponsesSseAssembler::new();
+                    let mut sse_bridge = crate::protocol::sse_bridge::UpstreamSseBridge::for_upstream(
+                        upstream_is_anthropic,
+                        &upstream_model_clone,
+                    );
 
                     while let Some(chunk_result) = upstream_stream.next().await {
                         match chunk_result {
                             Ok(bytes) => {
                                 if let Ok(text) = std::str::from_utf8(&bytes) {
-                                    // Reassemble fragmented SSE records before conversion.
-                                    // The upstream channel splits every record across TCP
-                                    // chunks (often mid-JSON); feeding raw fragments to
-                                    // the converter silently drops tool names / call ids /
-                                    // argument fragments. Only complete records are processed.
-                                    for record in sse_assembler.push(text) {
-                                        if let Some((p, c, t)) = crate::protocol::responses::parse_usage_from_sse_chunk(&record) {
-                                            usage_prompt = p;
-                                            usage_completion = c;
-                                            usage_total = t;
-                                        }
-                                        // Accumulate content for logging
-                                        for line in record.lines() {
-                                            let trimmed = line.trim();
-                                            if !trimmed.starts_with("data:") { continue; }
-                                            let data_str = trimmed.trim_start_matches("data:").trim();
-                                            if data_str == "[DONE]" || data_str.is_empty() { continue; }
-                                            if let Ok(json) = serde_json::from_str::<serde_json::Value>(data_str) {
-                                                if let Some(choices) = json.get("choices").and_then(|c| c.as_array()) {
-                                                    if let Some(choice) = choices.first() {
-                                                        if let Some(delta) = choice.get("delta") {
-                                                            if let Some(content) = delta.get("content").and_then(|c| c.as_str()) {
-                                                                accumulated_content.push_str(content);
-                                                            }
-                                                            if let Some(reasoning) = delta.get("reasoning_content").and_then(|c| c.as_str()) {
-                                                                accumulated_reasoning.push_str(reasoning);
-                                                            }
-                                                        }
-                                                    }
+                                    // The bridge reassembles fragmented records AND, on
+                                    // Anthropic channels, converts Anthropic SSE → OpenAI
+                                    // SSE. The downstream pipeline below only ever sees
+                                    // complete OpenAI `data:` records.
+                                    match sse_bridge.push(text) {
+                                        Ok(records) => {
+                                            for record in records {
+                                                let events = process_openai_record_for_responses(
+                                                    &record,
+                                                    &model_clone,
+                                                    &response_id,
+                                                    &mut stream_state,
+                                                    &mut accumulated_content,
+                                                    &mut accumulated_reasoning,
+                                                    &mut usage_prompt,
+                                                    &mut usage_completion,
+                                                    &mut usage_total,
+                                                );
+                                                for event in events {
+                                                    yield Ok::<_, std::io::Error>(event.into_bytes().into());
                                                 }
                                             }
                                         }
-                                        // Convert OpenAI SSE → Responses SSE events
-                                        let events = crate::protocol::responses::convert_openai_sse_to_responses(
-                                            &record, &model_clone, &response_id, &accumulated_content,
-                                            &mut stream_state,
-                                        );
-                                        for event in events {
-                                            yield Ok::<_, std::io::Error>(event.into_bytes().into());
+                                        Err(e) => {
+                                            had_error = true;
+                                            let err_event = format!(
+                                                "event: response.failed\ndata: {{\"type\":\"response.failed\",\"response_id\":\"{}\",\"error\":{{\"message\":\"Upstream conversion failed: {}\"}}}}\n\n",
+                                                response_id, e
+                                            );
+                                            yield Ok::<_, std::io::Error>(err_event.into_bytes().into());
+                                            break;
                                         }
                                     }
                                 } else {
@@ -2408,38 +2569,34 @@ async fn handle_responses_stream(
                     // with usage.
                     // (convert_openai_sse_to_responses sends everything up to output_item.done,
                     // but NOT response.completed — that's sent here with usage from the final chunk)
-                    for record in sse_assembler.flush() {
-                        if let Some((p, c, t)) = crate::protocol::responses::parse_usage_from_sse_chunk(&record) {
-                            usage_prompt = p;
-                            usage_completion = c;
-                            usage_total = t;
-                        }
-                        for line in record.lines() {
-                            let trimmed = line.trim();
-                            if !trimmed.starts_with("data:") { continue; }
-                            let data_str = trimmed.trim_start_matches("data:").trim();
-                            if data_str == "[DONE]" || data_str.is_empty() { continue; }
-                            if let Ok(json) = serde_json::from_str::<serde_json::Value>(data_str) {
-                                if let Some(choices) = json.get("choices").and_then(|c| c.as_array()) {
-                                    if let Some(choice) = choices.first() {
-                                        if let Some(delta) = choice.get("delta") {
-                                            if let Some(content) = delta.get("content").and_then(|c| c.as_str()) {
-                                                accumulated_content.push_str(content);
-                                            }
-                                            if let Some(reasoning) = delta.get("reasoning_content").and_then(|c| c.as_str()) {
-                                                accumulated_reasoning.push_str(reasoning);
-                                            }
-                                        }
-                                    }
+                    // The Anthropic bridge emits its exactly-once final sequence here too
+                    // (finish_reason + usage frame, then [DONE]).
+                    match sse_bridge.finish() {
+                        Ok(records) => {
+                            for record in records {
+                                let events = process_openai_record_for_responses(
+                                    &record,
+                                    &model_clone,
+                                    &response_id,
+                                    &mut stream_state,
+                                    &mut accumulated_content,
+                                    &mut accumulated_reasoning,
+                                    &mut usage_prompt,
+                                    &mut usage_completion,
+                                    &mut usage_total,
+                                );
+                                for event in events {
+                                    yield Ok::<_, std::io::Error>(event.into_bytes().into());
                                 }
                             }
                         }
-                        let events = crate::protocol::responses::convert_openai_sse_to_responses(
-                            &record, &model_clone, &response_id, &accumulated_content,
-                            &mut stream_state,
-                        );
-                        for event in events {
-                            yield Ok::<_, std::io::Error>(event.into_bytes().into());
+                        Err(e) => {
+                            had_error = true;
+                            let err_event = format!(
+                                "event: response.failed\ndata: {{\"type\":\"response.failed\",\"response_id\":\"{}\",\"error\":{{\"message\":\"Upstream conversion failed: {}\"}}}}\n\n",
+                                response_id, e
+                            );
+                            yield Ok::<_, std::io::Error>(err_event.into_bytes().into());
                         }
                     }
                     if !had_error {

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -715,37 +715,44 @@ async fn handle_stream(
                             Ok(bytes) => {
                                 // Normalize the chunk through the bridge, then
                                 // accumulate usage/content and relay the records.
-                                if let Ok(text) = std::str::from_utf8(&bytes) {
-                                    match sse_bridge.push(text) {
-                                        Ok(records) => {
-                                            for record in records {
-                                                accumulate_openai_chat_record(
-                                                    &record,
-                                                    &mut usage_prompt,
-                                                    &mut usage_completion,
-                                                    &mut usage_total,
-                                                    &mut accumulated_content,
-                                                    &mut accumulated_reasoning,
-                                                    &mut response_role,
-                                                    &mut finish_reason,
-                                                    &mut tool_calls_map,
-                                                );
-                                                yield Ok::<_, std::io::Error>(record.into_bytes().into());
-                                            }
-                                        }
-                                        Err(e) => {
-                                            had_error = true;
-                                            let err_chunk = format!(
-                                                "data: {{\"error\":{{\"message\":\"Upstream conversion failed: {}\",\"type\":\"server_error\"}}}}\n\n",
-                                                e
+                                //
+                                // Feed RAW bytes, never `str::from_utf8`-gated:
+                                // a chunk boundary can split a multibyte UTF-8
+                                // codepoint (CJK text is 3 bytes/char), and such
+                                // a chunk previously fell into an else-branch
+                                // that yielded the raw Anthropic frame straight
+                                // to the OpenAI client (Opencode "Type validation
+                                // failed ... expected array for `choices`").  The
+                                // bridge buffers bytes and decodes only COMPLETE
+                                // records, so a mid-codepoint split is held and
+                                // reassembled across calls — never escaped raw.
+                                match sse_bridge.push(&bytes) {
+                                    Ok(records) => {
+                                        for record in records {
+                                            accumulate_openai_chat_record(
+                                                &record,
+                                                &mut usage_prompt,
+                                                &mut usage_completion,
+                                                &mut usage_total,
+                                                &mut accumulated_content,
+                                                &mut accumulated_reasoning,
+                                                &mut response_role,
+                                                &mut finish_reason,
+                                                &mut tool_calls_map,
                                             );
-                                            yield Ok::<_, std::io::Error>(err_chunk.into_bytes().into());
-                                            yield Ok::<_, std::io::Error>(b"data: [DONE]\n\n".to_vec().into());
-                                            break;
+                                            yield Ok::<_, std::io::Error>(bytes::Bytes::from(record.into_bytes()));
                                         }
                                     }
-                                } else {
-                                    yield Ok::<_, std::io::Error>(bytes);
+                                    Err(e) => {
+                                        had_error = true;
+                                        let err_chunk = format!(
+                                            "data: {{\"error\":{{\"message\":\"Upstream conversion failed: {}\",\"type\":\"server_error\"}}}}\n\n",
+                                            e
+                                        );
+                                        yield Ok::<_, std::io::Error>(bytes::Bytes::from(err_chunk.into_bytes()));
+                                        yield Ok::<_, std::io::Error>(bytes::Bytes::from_static(b"data: [DONE]\n\n"));
+                                        break;
+                                    }
                                 }
                             }
                             Err(e) => {
@@ -754,8 +761,8 @@ async fn handle_stream(
                                     "data: {{\"error\":{{\"message\":\"Stream connection interrupted: {}\",\"type\":\"server_error\"}}}}\n\n",
                                     e
                                 );
-                                yield Ok::<_, std::io::Error>(err_chunk.into_bytes().into());
-                                yield Ok::<_, std::io::Error>(b"data: [DONE]\n\n".to_vec().into());
+                                yield Ok::<_, std::io::Error>(bytes::Bytes::from(err_chunk.into_bytes()));
+                                yield Ok::<_, std::io::Error>(bytes::Bytes::from_static(b"data: [DONE]\n\n"));
                                 break;
                             }
                         }
@@ -779,7 +786,7 @@ async fn handle_stream(
                                         &mut finish_reason,
                                         &mut tool_calls_map,
                                     );
-                                    yield Ok::<_, std::io::Error>(record.into_bytes().into());
+                                    yield Ok::<_, std::io::Error>(bytes::Bytes::from(record.into_bytes()));
                                 }
                             }
                             Err(e) => {
@@ -788,8 +795,8 @@ async fn handle_stream(
                                     "data: {{\"error\":{{\"message\":\"Upstream conversion failed: {}\",\"type\":\"server_error\"}}}}\n\n",
                                     e
                                 );
-                                yield Ok::<_, std::io::Error>(err_chunk.into_bytes().into());
-                                yield Ok::<_, std::io::Error>(b"data: [DONE]\n\n".to_vec().into());
+                                yield Ok::<_, std::io::Error>(bytes::Bytes::from(err_chunk.into_bytes()));
+                                yield Ok::<_, std::io::Error>(bytes::Bytes::from_static(b"data: [DONE]\n\n"));
                             }
                         }
                     }
@@ -2497,7 +2504,7 @@ async fn handle_responses_stream(
 
                     // Emit response.created event
                     let created = crate::protocol::responses::create_response_created_event(&model_clone, &response_id);
-                    yield Ok::<_, std::io::Error>(created.into_bytes().into());
+                    yield Ok::<_, std::io::Error>(bytes::Bytes::from(created.into_bytes()));
 
                     let mut usage_prompt: i64 = 0;
                     let mut usage_completion: i64 = 0;
@@ -2514,12 +2521,18 @@ async fn handle_responses_stream(
                     while let Some(chunk_result) = upstream_stream.next().await {
                         match chunk_result {
                             Ok(bytes) => {
-                                if let Ok(text) = std::str::from_utf8(&bytes) {
-                                    // The bridge reassembles fragmented records AND, on
-                                    // Anthropic channels, converts Anthropic SSE → OpenAI
-                                    // SSE. The downstream pipeline below only ever sees
-                                    // complete OpenAI `data:` records.
-                                    match sse_bridge.push(text) {
+                                // The bridge reassembles fragmented records AND, on
+                                // Anthropic channels, converts Anthropic SSE → OpenAI
+                                // SSE. The downstream pipeline below only ever sees
+                                // complete OpenAI `data:` records.
+                                //
+                                // Feed RAW bytes, never `str::from_utf8`-gated: a
+                                // chunk boundary can split a multibyte UTF-8 codepoint,
+                                // and the old else-branch leaked the raw Anthropic
+                                // frame to the OpenAI client.  The bridge buffers bytes
+                                // and decodes only complete records, so a mid-codepoint
+                                // split is held and reassembled across calls.
+                                match sse_bridge.push(&bytes) {
                                         Ok(records) => {
                                             for record in records {
                                                 let events = process_openai_record_for_responses(
@@ -2534,7 +2547,7 @@ async fn handle_responses_stream(
                                                     &mut usage_total,
                                                 );
                                                 for event in events {
-                                                    yield Ok::<_, std::io::Error>(event.into_bytes().into());
+                                                    yield Ok::<_, std::io::Error>(bytes::Bytes::from(event.into_bytes()));
                                                 }
                                             }
                                         }
@@ -2544,12 +2557,9 @@ async fn handle_responses_stream(
                                                 "event: response.failed\ndata: {{\"type\":\"response.failed\",\"response_id\":\"{}\",\"error\":{{\"message\":\"Upstream conversion failed: {}\"}}}}\n\n",
                                                 response_id, e
                                             );
-                                            yield Ok::<_, std::io::Error>(err_event.into_bytes().into());
+                                            yield Ok::<_, std::io::Error>(bytes::Bytes::from(err_event.into_bytes()));
                                             break;
                                         }
-                                    }
-                                } else {
-                                    yield Ok::<_, std::io::Error>(bytes);
                                 }
                             }
                             Err(e) => {
@@ -2558,7 +2568,7 @@ async fn handle_responses_stream(
                                     "event: response.failed\ndata: {{\"type\":\"response.failed\",\"response_id\":\"{}\",\"error\":{{\"message\":\"Stream interrupted: {}\"}}}}\n\n",
                                     response_id, e
                                 );
-                                yield Ok::<_, std::io::Error>(err_event.into_bytes().into());
+                                yield Ok::<_, std::io::Error>(bytes::Bytes::from(err_event.into_bytes()));
                                 break;
                             }
                         }
@@ -2586,7 +2596,7 @@ async fn handle_responses_stream(
                                     &mut usage_total,
                                 );
                                 for event in events {
-                                    yield Ok::<_, std::io::Error>(event.into_bytes().into());
+                                    yield Ok::<_, std::io::Error>(bytes::Bytes::from(event.into_bytes()));
                                 }
                             }
                         }
@@ -2596,7 +2606,7 @@ async fn handle_responses_stream(
                                 "event: response.failed\ndata: {{\"type\":\"response.failed\",\"response_id\":\"{}\",\"error\":{{\"message\":\"Upstream conversion failed: {}\"}}}}\n\n",
                                 response_id, e
                             );
-                            yield Ok::<_, std::io::Error>(err_event.into_bytes().into());
+                            yield Ok::<_, std::io::Error>(bytes::Bytes::from(err_event.into_bytes()));
                         }
                     }
                     if !had_error {
@@ -2609,10 +2619,10 @@ async fn handle_responses_stream(
                             usage_completion,
                         );
                         for ev in synth_events {
-                            yield Ok::<_, std::io::Error>(ev.into_bytes().into());
+                            yield Ok::<_, std::io::Error>(bytes::Bytes::from(ev.into_bytes()));
                         }
                         // Emit [DONE] after response.completed
-                        yield Ok::<_, std::io::Error>(b"data: [DONE]\n\n".to_vec().into());
+                        yield Ok::<_, std::io::Error>(bytes::Bytes::from_static(b"data: [DONE]\n\n"));
                     }
 
                     // Build response_choices for logging


### PR DESCRIPTION
## 背景

Codex（Responses API）与 Opencode（Chat Completions API）对接 Anthropic 协议上游（9router 等 `type=claude / protocol=anthropic` 通道）时存在三个问题：

1. **Anthropic SSE 帧泄漏**：OpenAI 客户端收到 `content_block_delta` / `message_delta` 等 Anthropic 原始帧，报 `Type validation failed / expected array for choices, received undefined`
2. **裸 usage 帧被拒**：最终 `{"usage":{...}}` 帧不带 `choices`，Opencode 拒绝
3. **工具调用不完整**：上游从未收到 `tools`，模型退回 DSML 文本而非真实 `tool_use`

## 修复

- 新增 `protocol/sse_bridge.rs`：`UpstreamSseBridge` 统一任意上游协议为 OpenAI Chat SSE（Anthropic 经 `MessagesSseState` 转换，OpenAI 原样重组），并做记录碎片重组
- `handle_stream`：按 `is_anthropic_upstream(channel_type, protocol)` 判定并走 bridge，消除 Anthropic 帧泄漏
- `MessagesSseState::emit_final`：usage 合并进最后 finish_reason 帧（OpenAI-canonical 形状）
- `ClaudeAdaptor`：转发 OpenAI `tools` 到 Anthropic 上游（嵌套→扁平 + 丢弃非 function），`convert_openai_messages_to_claude` 处理 `system` / `tool_calls` / `tool` role
- `convert_claude_to_openai`：`tool_use` → `tool_calls`，`stop_reason=tool_use` → `finish_reason=tool_calls`

## 验证

- 新增回归测试：`sse_bridge` 7 项（含 `final_sequence_merges_usage_into_finish_reason_frame`、`anthropic_tool_use_becomes_responses_function_call_chain`）
- 既有 `messages` codec 70 项测试全绿
- 实测：普通/带 tools 流式 + 非流式 chat 均返回正确 OpenAI SSE（含 `tool_calls` 链与合并 usage）