### PR TITLE
fix(protocol): Anthropic 内置工具经 OpenAI Chat 渠道不再整体 400

### DIFF
--- a/src-tauri/src/protocol/legacy/anthropic_decode.rs
+++ b/src-tauri/src/protocol/legacy/anthropic_decode.rs
@@ -70,7 +70,11 @@ pub fn anthropic_to_openai(body: &Value) -> Result<Value, String> {
     // Convert Anthropic tools to OpenAI tools format
     // Anthropic: {"name": "xxx", "description": "xxx", "input_schema": {...}}
     // OpenAI: {"type": "function", "function": {"name": "xxx", "description": "xxx", "parameters": {...}}}
-    // Also handles Anthropic built-in tools (web_search, computer_use, etc.) which are skipped.
+    // Anthropic server-side tools (web_search, computer_use, ...) have no Chat
+    // Completions equivalent and are skipped fail-open so a mixed custom +
+    // built-in request can still use a conversion channel; tool_choice that
+    // forces a skipped built-in still requires a native Anthropic channel.
+    let mut skipped_builtin_names: Vec<String> = Vec::new();
     if let Some(tools) = body.get("tools").and_then(|t| t.as_array()) {
         let mut openai_tools = Vec::new();
         for tool in tools {
@@ -106,10 +110,14 @@ pub fn anthropic_to_openai(body: &Value) -> Result<Value, String> {
                     }));
                 }
                 _ => {
-                    return Err(
-                        "Anthropic built-in tools require a native Anthropic Messages channel"
-                            .to_string(),
-                    )
+                    if !is_anthropic_builtin_tool_type(tool_type) {
+                        return Err(format!(
+                            "unsupported Anthropic tool type '{tool_type}' requires a native Anthropic Messages channel"
+                        ));
+                    }
+                    if let Some(name) = tool.get("name").and_then(|n| n.as_str()) {
+                        skipped_builtin_names.push(name.to_string());
+                    }
                 }
             }
         }
@@ -117,18 +125,40 @@ pub fn anthropic_to_openai(body: &Value) -> Result<Value, String> {
             openai_body["tools"] = Value::Array(openai_tools);
         }
     }
+    // tool_choice is only dropped when it references a toolset that no longer
+    // exists because every tool was a skipped built-in; a request that never
+    // had tools keeps its tool_choice (existing fail-open behavior).
+    let dropped_all_tools = !skipped_builtin_names.is_empty() && openai_body.get("tools").is_none();
+    let keep_tool_choice = !dropped_all_tools;
 
     // Convert tool_choice
     // Anthropic: {"type": "auto"} or {"type": "any"} or {"type": "tool", "name": "xxx"}
     // OpenAI: "auto" or "required" or {"type": "function", "function": {"name": "xxx"}}
+    // OpenAI Chat Completions rejects `tool_choice` without `tools`, so it is
+    // dropped when every tool was a skipped built-in; forcing a skipped
+    // built-in still requires a native Anthropic channel.
     if let Some(tc) = body.get("tool_choice") {
         if let Some(tc_type) = tc.get("type").and_then(|t| t.as_str()) {
             let openai_tc = match tc_type {
                 "auto" => Value::String("auto".to_string()),
-                "any" => Value::String("required".to_string()),
+                "any" => {
+                    if dropped_all_tools {
+                        return Err(
+                            "Anthropic built-in tools require a native Anthropic Messages channel"
+                                .to_string(),
+                        );
+                    }
+                    Value::String("required".to_string())
+                }
                 "tool" => {
                     let name = tc.get("name").and_then(|n| n.as_str()).filter(|s| !s.is_empty())
                         .ok_or_else(|| "Anthropic tool_choice type 'tool' is missing a name".to_string())?;
+                    if skipped_builtin_names.iter().any(|n| n == name) {
+                        return Err(
+                            "Anthropic built-in tools require a native Anthropic Messages channel"
+                                .to_string(),
+                        );
+                    }
                     serde_json::json!({
                         "type": "function",
                         "function": {"name": name}
@@ -136,11 +166,21 @@ pub fn anthropic_to_openai(body: &Value) -> Result<Value, String> {
                 }
                 _ => return Err("unsupported Anthropic tool_choice requires a native Anthropic Messages channel".to_string()),
             };
-            openai_body["tool_choice"] = openai_tc;
+            if keep_tool_choice {
+                openai_body["tool_choice"] = openai_tc;
+            }
         } else if let Some(s) = tc.as_str() {
             let openai_tc = match s {
                 "auto" => Value::String("auto".to_string()),
-                "any" => Value::String("required".to_string()),
+                "any" => {
+                    if dropped_all_tools {
+                        return Err(
+                            "Anthropic built-in tools require a native Anthropic Messages channel"
+                                .to_string(),
+                        );
+                    }
+                    Value::String("required".to_string())
+                }
                 "tool" => return Err("Anthropic tool_choice 'tool' requires a name".to_string()),
                 _ => {
                     return Err(
@@ -149,7 +189,9 @@ pub fn anthropic_to_openai(body: &Value) -> Result<Value, String> {
                     )
                 }
             };
-            openai_body["tool_choice"] = openai_tc;
+            if keep_tool_choice {
+                openai_body["tool_choice"] = openai_tc;
+            }
         } else {
             return Err(
                 "unsupported Anthropic tool_choice requires a native Anthropic Messages channel"
@@ -183,6 +225,25 @@ pub fn anthropic_to_openai(body: &Value) -> Result<Value, String> {
 ///
 /// `None` when the downstream did not ask for thinking (or asked for an
 /// unrecognized type), in which case `reasoning_effort` is left unset.
+/// Anthropic server-side tool families. Versions are encoded as a suffix on
+/// the type (e.g. `web_search_20250305`), so prefix matching is required.
+const ANTHROPIC_BUILTIN_TOOL_TYPES: &[&str] = &[
+    "web_search",
+    "computer_use",
+    "computer",
+    "text_editor",
+    "code_execution",
+    "bash",
+    "code_analysis",
+    "mcp_connector",
+];
+
+fn is_anthropic_builtin_tool_type(tool_type: &str) -> bool {
+    ANTHROPIC_BUILTIN_TOOL_TYPES
+        .iter()
+        .any(|prefix| tool_type == *prefix || tool_type.starts_with(&format!("{prefix}_")))
+}
+
 fn anthropic_thinking_to_reasoning_effort(body: &Value) -> Option<String> {
     let thinking = body.get("thinking")?;
     if !thinking.is_object() {

--- a/src-tauri/src/protocol/legacy/tests/anthropic.rs
+++ b/src-tauri/src/protocol/legacy/tests/anthropic.rs
@@ -220,3 +220,109 @@ fn openai_to_anthropic_maps_reasoning_fail_open() {
     assert_eq!(converted["content"][1]["type"], "text");
     assert_eq!(converted["content"][1]["text"], "answer");
 }
+
+// ---------------------------------------------------------------------------
+// Upstream issue #21: Claude Code sends Anthropic built-in tools (web_search
+// etc.) alongside custom function tools. Built-ins are skipped fail-open so a
+// mixed request can still use an OpenAI Chat conversion channel; forcing a
+// skipped built-in via tool_choice still requires a native channel.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn legacy_builtin_tool_alongside_custom_tool_is_skipped() {
+    let request = serde_json::json!({
+        "model": "claude-sonnet-4-20250514",
+        "max_tokens": 1024,
+        "messages": [{"role":"user", "content":"search the web for rust axum"}],
+        "tools": [
+            {"name": "read_file", "description": "read a file", "input_schema": {"type":"object","properties":{"path":{"type":"string"}}}},
+            {"type": "web_search_20250305", "name": "web_search", "max_uses": 5}
+        ],
+        "tool_choice": {"type": "auto"}
+    });
+    let converted = anthropic_to_openai(&request).unwrap();
+    let tools = converted["tools"].as_array().unwrap();
+    assert_eq!(tools.len(), 1, "custom tool kept, built-in skipped");
+    assert_eq!(tools[0]["function"]["name"], "read_file");
+    assert_eq!(converted["tool_choice"], "auto");
+}
+
+#[test]
+fn legacy_builtin_tool_only_drops_tools_and_tool_choice() {
+    let request = serde_json::json!({
+        "model": "claude-sonnet-4-20250514",
+        "max_tokens": 1024,
+        "messages": [{"role":"user", "content":"hi"}],
+        "tools": [
+            {"type": "web_search_20250305", "name": "web_search"}
+        ],
+        "tool_choice": {"type": "auto"}
+    });
+    let converted = anthropic_to_openai(&request).unwrap();
+    assert!(converted.get("tools").is_none(), "no tools survive");
+    // OpenAI rejects tool_choice without tools, so it must be dropped too.
+    assert!(converted.get("tool_choice").is_none());
+}
+
+#[test]
+fn legacy_tool_choice_forcing_builtin_tool_still_rejected() {
+    let request = serde_json::json!({
+        "model": "claude-sonnet-4-20250514",
+        "max_tokens": 1024,
+        "messages": [{"role":"user", "content":"hi"}],
+        "tools": [
+            {"name": "read_file", "description": "read a file", "input_schema": {"type":"object","properties":{}}},
+            {"type": "web_search_20250305", "name": "web_search"}
+        ],
+        "tool_choice": {"type": "tool", "name": "web_search"}
+    });
+    assert!(anthropic_to_openai(&request).is_err());
+}
+
+#[test]
+fn legacy_tool_choice_any_with_only_builtin_tools_rejected() {
+    let request = serde_json::json!({
+        "model": "claude-sonnet-4-20250514",
+        "max_tokens": 1024,
+        "messages": [{"role":"user", "content":"hi"}],
+        "tools": [
+            {"type": "web_search_20250305", "name": "web_search"}
+        ],
+        "tool_choice": {"type": "any"}
+    });
+    assert!(anthropic_to_openai(&request).is_err());
+}
+
+#[test]
+fn legacy_unknown_tool_type_still_rejected() {
+    let request = serde_json::json!({
+        "model": "claude-sonnet-4-20250514",
+        "max_tokens": 1024,
+        "messages": [{"role":"user", "content":"hi"}],
+        "tools": [
+            {"type": "mystery_tool_20990101", "name": "mystery"}
+        ]
+    });
+    assert!(anthropic_to_openai(&request).is_err());
+}
+
+#[test]
+fn legacy_builtin_tool_families_recognized() {
+    for tool_type in [
+        "web_search_20250305",
+        "computer_20250124",
+        "text_editor_20250429",
+        "code_execution_20250522",
+        "bash_20250124",
+    ] {
+        let request = serde_json::json!({
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "messages": [{"role":"user", "content":"hi"}],
+            "tools": [{"type": tool_type, "name": "t"}]
+        });
+        let converted = anthropic_to_openai(&request)
+            .unwrap_or_else(|e| panic!("{tool_type} should be skipped, got: {e}"));
+        assert!(converted.get("tools").is_none(), "{tool_type}");
+    }
+}


### PR DESCRIPTION
## 问题

Fixes #21

Claude Code 发送的请求 `tools` 数组混有 Anthropic 服务端工具（`web_search_20250305` 等）时，`anthropic_to_openai` 对非 `custom` 类型直接整体报错 "Anthropic built-in tools require a native Anthropic Messages channel"，handler 将其记为渠道不兼容并逐渠道跳过；纯转换渠道组合下网关最终自返回 **400 invalid_request_error**——即使请求同时携带完全可转换的自定义函数工具。

> 注：`anthropic_decode.rs` 中注释声称 "built-in tools are skipped"，与实现不符，本 PR 同时更正。

## 修复（fail-open 跳过）

- 识别内置工具族（`web_search` / `computer_use` / `computer` / `text_editor` / `code_execution` / `bash` / `code_analysis` / `mcp_connector`，前缀匹配覆盖版本后缀）并跳过，自定义工具正常转换
- 仅当 `tool_choice` 强制指向被剔除的内置工具、或 `any` 且全部工具被剔除时，保留"需原生 Anthropic 渠道"明确错误
- 剔除后无剩余 tools 时同步丢弃 `tool_choice`（OpenAI 会拒绝无 tools 的 tool_choice）；**请求本身无 tools 时保留原行为不变**
- 未知工具类型仍拒绝（不静默吞掉非内置的异常类型）

## 测试

`protocol/legacy/tests/anthropic.rs` 新增 6 个用例：混合工具跳过 / 仅内置丢弃 tools+tool_choice / 强制 tool_choice 拒绝 / any 仅内置拒绝 / 未知类型拒绝 / 内置工具族识别矩阵。既有 17 个用例全过。

本地已跑 `cargo clippy`（无新增告警）与 `cargo test --lib`（658 passed；仅 2 个与本改动无关的既有失败，基线复测确认）。