### PR TITLE
fix(core): 上游终态错误立即短路，不再轮询渠道

### DIFF
--- a/src-tauri/src/core/proxy.rs
+++ b/src-tauri/src/core/proxy.rs
@@ -1,4 +1,5 @@
 use crate::adaptor::{get_adaptor, ProxyRequest, TokenUsage};
+use crate::core::attempt::{classify_http_status, FailureClass};
 use crate::core::dispatcher::Dispatcher;
 use crate::db::models::{Channel, RequestLog};
 use crate::db::repository::Repository;
@@ -8,6 +9,14 @@ use crate::utils;
 use rand::Rng;
 use std::sync::Arc;
 use std::time::Instant;
+
+/// Failover only over statuses the new-track classifier marks retryable
+/// (408/409/429/529/5xx).  Caller-terminal and channel-auth-terminal statuses
+/// stop the loop and surface the upstream response verbatim; an ambiguous 404
+/// also stops, matching the handlers' legacy rule.
+fn upstream_status_is_retryable(status: u16) -> bool {
+    matches!(classify_http_status(status), Some(FailureClass::Retryable))
+}
 
 /// Multi-key load balancing for the legacy proxy path.  Selects a random
 /// enabled key from the channel's extra keys, weighted by `weight`.  The
@@ -262,7 +271,19 @@ pub async fn handle_request(
                         eprintln!("[WARN] create_security_findings failed: {}", e);
                     }
                     last_error = Some(error_message);
-                    continue;
+                    if upstream_status_is_retryable(status) {
+                        continue;
+                    }
+                    // Caller-terminal / channel-auth-terminal / ambiguous: the
+                    // same request will fail on every other channel too, so
+                    // surface this upstream response instead of failover.
+                    return Ok(ProxyResult {
+                        status,
+                        body: resp_body,
+                        usage: None,
+                        channel,
+                        duration_ms: duration_ms as u64,
+                    });
                 }
 
                 // Extract and log choices

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -556,7 +556,11 @@ pub async fn handle_chat_completions(
         )
         .await
         {
-            Ok(result) => (StatusCode::OK, Json(result.body)).into_response(),
+            Ok(result) => (
+                StatusCode::from_u16(result.status).unwrap_or(StatusCode::OK),
+                Json(result.body),
+            )
+                .into_response(),
             Err((code, msg)) => {
                 let err_body = serde_json::json!({
                     "error": { "message": msg, "type": "upstream_error", "code": code }
@@ -798,6 +802,10 @@ async fn handle_stream(
     };
 
     let mut last_error = None;
+    // Set when an upstream returned a terminal (non-retryable) status before
+    // any bytes were streamed, so the loop stops and the final response keeps
+    // that status instead of a generic 502.
+    let mut last_error_status: Option<StatusCode> = None;
 
     for (attempt, channel) in selected_channels.into_iter().take(max_attempts).enumerate() {
         let config = Dispatcher::channel_to_config(&channel);
@@ -826,7 +834,13 @@ async fn handle_stream(
                 if !status.is_success() {
                     let body_str = resp.text().await.unwrap_or_default();
                     last_error = Some(format!("{}: {}", channel.name, body_str));
-                    continue;
+                    if retryable_upstream_status(status) {
+                        continue;
+                    }
+                    // Terminal upstream failure and nothing has been streamed
+                    // yet — stop cycling channels; the tail returns this status.
+                    last_error_status = Some(status);
+                    break;
                 }
 
                 let start = std::time::Instant::now();
@@ -1118,7 +1132,8 @@ async fn handle_stream(
             "type": "upstream_error"
         }
     });
-    (StatusCode::BAD_GATEWAY, Json(err_body)).into_response()
+    let status = last_error_status.unwrap_or(StatusCode::BAD_GATEWAY);
+    (status, Json(err_body)).into_response()
 }
 
 // ─── Anthropic Messages API: POST /v1/messages ─────────────────────────────
@@ -2463,9 +2478,15 @@ pub async fn handle_responses(
         .await
         {
             Ok(result) => {
-                // Convert OpenAI response to Responses API format
+                // Convert OpenAI response to Responses API format.  A
+                // caller-terminal upstream status keeps its status code; only
+                // the body is re-framed.
                 let responses_resp = protocol::openai_to_responses(&result.body, &model);
-                (StatusCode::OK, Json(responses_resp)).into_response()
+                (
+                    StatusCode::from_u16(result.status).unwrap_or(StatusCode::OK),
+                    Json(responses_resp),
+                )
+                    .into_response()
             }
             Err((code, msg)) => {
                 let err_body = serde_json::json!({
@@ -2632,6 +2653,10 @@ async fn handle_responses_stream(
     };
 
     let mut last_error = None;
+    // Set when an upstream returned a terminal (non-retryable) status before
+    // any bytes were streamed, so the loop stops and the final response keeps
+    // that status instead of a generic 502.
+    let mut last_error_status: Option<StatusCode> = None;
 
     for (attempt, channel) in selected_channels.into_iter().take(max_attempts).enumerate() {
         let config = Dispatcher::channel_to_config(&channel);
@@ -2659,7 +2684,13 @@ async fn handle_responses_stream(
                 if !status.is_success() {
                     let body_str = resp.text().await.unwrap_or_default();
                     last_error = Some(format!("{}: {}", channel.name, body_str));
-                    continue;
+                    if retryable_upstream_status(status) {
+                        continue;
+                    }
+                    // Terminal upstream failure and nothing has been streamed
+                    // yet — stop cycling channels; the tail returns this status.
+                    last_error_status = Some(status);
+                    break;
                 }
 
                 let start = std::time::Instant::now();
@@ -2941,7 +2972,8 @@ async fn handle_responses_stream(
             "type": "upstream_error"
         }
     });
-    (StatusCode::BAD_GATEWAY, Json(err_body)).into_response()
+    let status = last_error_status.unwrap_or(StatusCode::BAD_GATEWAY);
+    (status, Json(err_body)).into_response()
 }
 
 pub async fn handle_completions(State(_shared): State<SharedState>) -> Response {
@@ -3178,7 +3210,16 @@ pub async fn handle_embeddings(
                         eprintln!("[WARN] create_security_findings failed: {}", e);
                     }
                     last_error = Some(error_message);
-                    continue;
+                    if retryable_upstream_status(status) {
+                        continue;
+                    }
+                    // Terminal upstream statuses (400/401/403/422...) would fail
+                    // identically on every channel — surface this response.
+                    return (
+                        StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::BAD_GATEWAY),
+                        Json(resp_body),
+                    )
+                        .into_response();
                 }
 
                 // Extract usage from response


### PR DESCRIPTION
## 问题

Fixes #40

legacy 执行路径对终态错误分类不完整：

- **非流式 chat（`core/proxy.rs`）与 embeddings**：任何 `>=400` 一律 `continue` 故障转移——400/401/403/422 等调用方终态错误逐渠道重复失败，拖长失败路径、刷满日志
- **流式（`handle_stream` / `handle_responses_stream`）**：非 2xx 无差别 `continue`；全部渠道失败后固定 502，丢失上游真实状态码
- **连带**：`handle_chat_completions` / `handle_responses` 非流式消费端把任何 `Ok(ProxyResult)` 一律回 HTTP 200，即使 `result.status` 是错误状态码

`handle_messages` 非流式已有正确的 `retryable_upstream_status` 短路，本 PR 将同一语义补齐到其余 legacy 路径。

## 修复

复用新轨 `core::attempt::classify_http_status` 的分类（不引入第二套语义）：仅 Retryable（408/409/429/529/5xx）继续故障转移；终态错误立即停止并透传上游状态码与错误体——

- `proxy.rs` 非流式：终态直接返回上游响应
- embeddings：同语义
- 两个流式循环：首字节前终态即 `break`，循环尾部保留上游状态码（此前固定 502）；流已开始后的行为不变
- 两个 `Ok(result)` 消费端：透传 `result.status`

## 测试

本地 `cargo clippy` 无新增告警；`cargo test --lib` 658 passed（仅 2 个与本改动无关的既有失败，基线复测确认）。

（重建自 #43，目标分支更正为 v0.2.3。）