### PR TITLE
fix(core): 统一上游重试判定与 401/403 下游脱敏（FailoverDecision）

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.18.1",
+    "react-router-dom": "^7.18.2",
     "react-syntax-highlighter": "^16.1.1",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
       react-router-dom:
-        specifier: ^7.18.1
-        version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^7.18.2
+        version: 7.18.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-syntax-highlighter:
         specifier: ^16.1.1
         version: 16.1.1(react@19.2.7)
@@ -118,8 +118,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
       react-router-dom:
-        specifier: ^7.18.1
-        version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^7.18.2
+        version: 7.18.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-syntax-highlighter:
         specifier: ^16.1.1
         version: 16.1.1(react@19.2.7)
@@ -1296,15 +1296,15 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
-  react-router-dom@7.18.1:
-    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
+  react-router-dom@7.18.2:
+    resolution: {integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.18.1:
-    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
+  react-router@7.18.2:
+    resolution: {integrity: sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -2701,13 +2701,13 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
-  react-router-dom@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router-dom@7.18.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      react-router: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-router: 7.18.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
-  react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router@7.18.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       cookie: 1.1.1
       react: 19.2.7

--- a/src-tauri/src/core/attempt.rs
+++ b/src-tauri/src/core/attempt.rs
@@ -108,6 +108,48 @@ pub fn terminal_status(class: FailureClass) -> u16 {
     }
 }
 
+/// What a legacy flat retry loop (proxy path / server handlers) should do
+/// after an upstream answered with a non-2xx status: cycle to the next
+/// channel, or stop and answer downstream with `downstream_status`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailoverDecision {
+    /// The same request may still succeed on another channel — keep cycling.
+    Failover,
+    /// The same request would fail on every other channel too — stop and
+    /// surface this status downstream.  Never the raw upstream credential
+    /// failure: 401/403 are masked to 502 (see `terminal_status`); the
+    /// request log keeps the real upstream status.
+    Stop { downstream_status: u16 },
+}
+
+/// Single source of truth for retry-vs-stop semantics in the legacy flat
+/// loops, built on `classify_http_status` (T00 decision 5) so the legacy path
+/// and the new track can never drift apart.
+///
+/// Callers must gate on a non-2xx status before consulting this — success
+/// responses never reach a retry decision.  Exhausting every channel yields
+/// 502 at the call site, not here.
+pub fn upstream_failover_decision(status: u16) -> FailoverDecision {
+    debug_assert!(
+        !(200..300).contains(&status),
+        "callers must gate on non-2xx before consulting the decision"
+    );
+    match classify_http_status(status) {
+        Some(FailureClass::Retryable) => FailoverDecision::Failover,
+        Some(FailureClass::ChannelAuthTerminal) => FailoverDecision::Stop {
+            downstream_status: terminal_status(FailureClass::ChannelAuthTerminal),
+        },
+        // CallerTerminal / EndpointUnsupported stop with the status verbatim;
+        // the ambiguous 404 (`None`) also stops because the legacy loops can
+        // never prove path-not-found.  The remaining classes are never
+        // produced by `classify_http_status`; stopping verbatim is the safe
+        // default if that ever changes.
+        Some(_) | None => FailoverDecision::Stop {
+            downstream_status: status,
+        },
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Attempt + outcome
 // ---------------------------------------------------------------------------
@@ -1349,5 +1391,41 @@ mod tests {
         assert_eq!(terminal_status(FailureClass::Retryable), 502);
         assert_eq!(terminal_status(FailureClass::UpstreamProtocolError), 502);
         assert_eq!(terminal_status(FailureClass::CommittedStreamError), 502);
+    }
+
+    #[test]
+    fn upstream_failover_decision_matrix() {
+        let stop = |downstream_status: u16| FailoverDecision::Stop { downstream_status };
+        // Caller-terminal: the request itself is invalid — surface verbatim.
+        assert_eq!(upstream_failover_decision(400), stop(400));
+        assert_eq!(upstream_failover_decision(422), stop(422));
+        // Channel credentials failed: masked to 502 so the caller never
+        // mistakes an upstream auth failure for their own key (the request
+        // log keeps the real upstream status).
+        assert_eq!(upstream_failover_decision(401), stop(502));
+        assert_eq!(upstream_failover_decision(403), stop(502));
+        // Ambiguous 404: path-missing is never proven in the legacy loops.
+        assert_eq!(upstream_failover_decision(404), stop(404));
+        // Endpoint unsupported: verbatim, never retried as a generic 5xx.
+        assert_eq!(upstream_failover_decision(405), stop(405));
+        assert_eq!(upstream_failover_decision(501), stop(501));
+        // Transient statuses and the conservative default for everything
+        // unlisted (3xx / 402 / 418 / 425 / 451 …) keep cycling channels.
+        for status in [
+            408, 409, 429, 529, 500, 502, 503, 504, 301, 307, 402, 418, 425, 451,
+        ] {
+            assert_eq!(
+                upstream_failover_decision(status),
+                FailoverDecision::Failover,
+                "status {status} should fail over"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "callers must gate on non-2xx")]
+    fn upstream_failover_decision_rejects_2xx() {
+        let _ = upstream_failover_decision(200);
     }
 }

--- a/src-tauri/src/core/proxy.rs
+++ b/src-tauri/src/core/proxy.rs
@@ -1,5 +1,5 @@
 use crate::adaptor::{get_adaptor, ProxyRequest, TokenUsage};
-use crate::core::attempt::{classify_http_status, FailureClass};
+use crate::core::attempt::{upstream_failover_decision, FailoverDecision};
 use crate::core::dispatcher::Dispatcher;
 use crate::db::models::{Channel, RequestLog};
 use crate::db::repository::Repository;
@@ -9,14 +9,6 @@ use crate::utils;
 use rand::Rng;
 use std::sync::Arc;
 use std::time::Instant;
-
-/// Failover only over statuses the new-track classifier marks retryable
-/// (408/409/429/529/5xx).  Caller-terminal and channel-auth-terminal statuses
-/// stop the loop and surface the upstream response verbatim; an ambiguous 404
-/// also stops, matching the handlers' legacy rule.
-fn upstream_status_is_retryable(status: u16) -> bool {
-    matches!(classify_http_status(status), Some(FailureClass::Retryable))
-}
 
 /// Multi-key load balancing for the legacy proxy path.  Selects a random
 /// enabled key from the channel's extra keys, weighted by `weight`.  The
@@ -271,19 +263,23 @@ pub async fn handle_request(
                         eprintln!("[WARN] create_security_findings failed: {}", e);
                     }
                     last_error = Some(error_message);
-                    if upstream_status_is_retryable(status) {
-                        continue;
+                    // Terminal upstream status: the same request would fail
+                    // on every other channel too, so stop cycling and answer
+                    // with the decision's downstream status (an upstream
+                    // 401/403 is masked to 502 — the log above keeps the
+                    // real status).
+                    match upstream_failover_decision(status) {
+                        FailoverDecision::Failover => continue,
+                        FailoverDecision::Stop { downstream_status } => {
+                            return Ok(ProxyResult {
+                                status: downstream_status,
+                                body: resp_body,
+                                usage: None,
+                                channel,
+                                duration_ms: duration_ms as u64,
+                            });
+                        }
                     }
-                    // Caller-terminal / channel-auth-terminal / ambiguous: the
-                    // same request will fail on every other channel too, so
-                    // surface this upstream response instead of failover.
-                    return Ok(ProxyResult {
-                        status,
-                        body: resp_body,
-                        usage: None,
-                        channel,
-                        duration_ms: duration_ms as u64,
-                    });
                 }
 
                 // Extract and log choices

--- a/src-tauri/src/core/proxy.rs
+++ b/src-tauri/src/core/proxy.rs
@@ -1,4 +1,5 @@
 use crate::adaptor::{get_adaptor, ProxyRequest, TokenUsage};
+use crate::core::attempt::{classify_http_status, FailureClass};
 use crate::core::dispatcher::Dispatcher;
 use crate::db::models::{Channel, RequestLog};
 use crate::db::repository::Repository;
@@ -8,6 +9,14 @@ use crate::utils;
 use rand::Rng;
 use std::sync::Arc;
 use std::time::Instant;
+
+/// Failover only over statuses the new-track classifier marks retryable
+/// (408/409/429/529/5xx).  Caller-terminal and channel-auth-terminal statuses
+/// stop the loop and surface the upstream response verbatim; an ambiguous 404
+/// also stops, matching the handlers' legacy rule.
+fn upstream_status_is_retryable(status: u16) -> bool {
+    matches!(classify_http_status(status), Some(FailureClass::Retryable))
+}
 
 /// Multi-key load balancing for the legacy proxy path.  Selects a random
 /// enabled key from the channel's extra keys, weighted by `weight`.  The
@@ -262,7 +271,19 @@ pub async fn handle_request(
                         eprintln!("[WARN] create_security_findings failed: {}", e);
                     }
                     last_error = Some(error_message);
-                    continue;
+                    if upstream_status_is_retryable(status) {
+                        continue;
+                    }
+                    // Caller-terminal / channel-auth-terminal / ambiguous: the
+                    // same request will fail on every other channel too, so
+                    // surface this upstream response instead of failover.
+                    return Ok(ProxyResult {
+                        status,
+                        body: resp_body,
+                        usage: None,
+                        channel,
+                        duration_ms: duration_ms as u64,
+                    });
                 }
 
                 // Extract and log choices

--- a/src-tauri/src/protocol/legacy/anthropic_decode.rs
+++ b/src-tauri/src/protocol/legacy/anthropic_decode.rs
@@ -70,7 +70,11 @@ pub fn anthropic_to_openai(body: &Value) -> Result<Value, String> {
     // Convert Anthropic tools to OpenAI tools format
     // Anthropic: {"name": "xxx", "description": "xxx", "input_schema": {...}}
     // OpenAI: {"type": "function", "function": {"name": "xxx", "description": "xxx", "parameters": {...}}}
-    // Also handles Anthropic built-in tools (web_search, computer_use, etc.) which are skipped.
+    // Anthropic server-side tools (web_search, computer_use, ...) have no Chat
+    // Completions equivalent and are skipped fail-open so a mixed custom +
+    // built-in request can still use a conversion channel; tool_choice that
+    // forces a skipped built-in still requires a native Anthropic channel.
+    let mut skipped_builtin_names: Vec<String> = Vec::new();
     if let Some(tools) = body.get("tools").and_then(|t| t.as_array()) {
         let mut openai_tools = Vec::new();
         for tool in tools {
@@ -106,10 +110,14 @@ pub fn anthropic_to_openai(body: &Value) -> Result<Value, String> {
                     }));
                 }
                 _ => {
-                    return Err(
-                        "Anthropic built-in tools require a native Anthropic Messages channel"
-                            .to_string(),
-                    )
+                    if !is_anthropic_builtin_tool_type(tool_type) {
+                        return Err(format!(
+                            "unsupported Anthropic tool type '{tool_type}' requires a native Anthropic Messages channel"
+                        ));
+                    }
+                    if let Some(name) = tool.get("name").and_then(|n| n.as_str()) {
+                        skipped_builtin_names.push(name.to_string());
+                    }
                 }
             }
         }
@@ -117,18 +125,40 @@ pub fn anthropic_to_openai(body: &Value) -> Result<Value, String> {
             openai_body["tools"] = Value::Array(openai_tools);
         }
     }
+    // tool_choice is only dropped when it references a toolset that no longer
+    // exists because every tool was a skipped built-in; a request that never
+    // had tools keeps its tool_choice (existing fail-open behavior).
+    let dropped_all_tools = !skipped_builtin_names.is_empty() && openai_body.get("tools").is_none();
+    let keep_tool_choice = !dropped_all_tools;
 
     // Convert tool_choice
     // Anthropic: {"type": "auto"} or {"type": "any"} or {"type": "tool", "name": "xxx"}
     // OpenAI: "auto" or "required" or {"type": "function", "function": {"name": "xxx"}}
+    // OpenAI Chat Completions rejects `tool_choice` without `tools`, so it is
+    // dropped when every tool was a skipped built-in; forcing a skipped
+    // built-in still requires a native Anthropic channel.
     if let Some(tc) = body.get("tool_choice") {
         if let Some(tc_type) = tc.get("type").and_then(|t| t.as_str()) {
             let openai_tc = match tc_type {
                 "auto" => Value::String("auto".to_string()),
-                "any" => Value::String("required".to_string()),
+                "any" => {
+                    if dropped_all_tools {
+                        return Err(
+                            "Anthropic built-in tools require a native Anthropic Messages channel"
+                                .to_string(),
+                        );
+                    }
+                    Value::String("required".to_string())
+                }
                 "tool" => {
                     let name = tc.get("name").and_then(|n| n.as_str()).filter(|s| !s.is_empty())
                         .ok_or_else(|| "Anthropic tool_choice type 'tool' is missing a name".to_string())?;
+                    if skipped_builtin_names.iter().any(|n| n == name) {
+                        return Err(
+                            "Anthropic built-in tools require a native Anthropic Messages channel"
+                                .to_string(),
+                        );
+                    }
                     serde_json::json!({
                         "type": "function",
                         "function": {"name": name}
@@ -136,11 +166,21 @@ pub fn anthropic_to_openai(body: &Value) -> Result<Value, String> {
                 }
                 _ => return Err("unsupported Anthropic tool_choice requires a native Anthropic Messages channel".to_string()),
             };
-            openai_body["tool_choice"] = openai_tc;
+            if keep_tool_choice {
+                openai_body["tool_choice"] = openai_tc;
+            }
         } else if let Some(s) = tc.as_str() {
             let openai_tc = match s {
                 "auto" => Value::String("auto".to_string()),
-                "any" => Value::String("required".to_string()),
+                "any" => {
+                    if dropped_all_tools {
+                        return Err(
+                            "Anthropic built-in tools require a native Anthropic Messages channel"
+                                .to_string(),
+                        );
+                    }
+                    Value::String("required".to_string())
+                }
                 "tool" => return Err("Anthropic tool_choice 'tool' requires a name".to_string()),
                 _ => {
                     return Err(
@@ -149,7 +189,9 @@ pub fn anthropic_to_openai(body: &Value) -> Result<Value, String> {
                     )
                 }
             };
-            openai_body["tool_choice"] = openai_tc;
+            if keep_tool_choice {
+                openai_body["tool_choice"] = openai_tc;
+            }
         } else {
             return Err(
                 "unsupported Anthropic tool_choice requires a native Anthropic Messages channel"
@@ -183,6 +225,25 @@ pub fn anthropic_to_openai(body: &Value) -> Result<Value, String> {
 ///
 /// `None` when the downstream did not ask for thinking (or asked for an
 /// unrecognized type), in which case `reasoning_effort` is left unset.
+/// Anthropic server-side tool families. Versions are encoded as a suffix on
+/// the type (e.g. `web_search_20250305`), so prefix matching is required.
+const ANTHROPIC_BUILTIN_TOOL_TYPES: &[&str] = &[
+    "web_search",
+    "computer_use",
+    "computer",
+    "text_editor",
+    "code_execution",
+    "bash",
+    "code_analysis",
+    "mcp_connector",
+];
+
+fn is_anthropic_builtin_tool_type(tool_type: &str) -> bool {
+    ANTHROPIC_BUILTIN_TOOL_TYPES
+        .iter()
+        .any(|prefix| tool_type == *prefix || tool_type.starts_with(&format!("{prefix}_")))
+}
+
 fn anthropic_thinking_to_reasoning_effort(body: &Value) -> Option<String> {
     let thinking = body.get("thinking")?;
     if !thinking.is_object() {

--- a/src-tauri/src/protocol/legacy/tests/anthropic.rs
+++ b/src-tauri/src/protocol/legacy/tests/anthropic.rs
@@ -220,3 +220,109 @@ fn openai_to_anthropic_maps_reasoning_fail_open() {
     assert_eq!(converted["content"][1]["type"], "text");
     assert_eq!(converted["content"][1]["text"], "answer");
 }
+
+// ---------------------------------------------------------------------------
+// Upstream issue #21: Claude Code sends Anthropic built-in tools (web_search
+// etc.) alongside custom function tools. Built-ins are skipped fail-open so a
+// mixed request can still use an OpenAI Chat conversion channel; forcing a
+// skipped built-in via tool_choice still requires a native channel.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn legacy_builtin_tool_alongside_custom_tool_is_skipped() {
+    let request = serde_json::json!({
+        "model": "claude-sonnet-4-20250514",
+        "max_tokens": 1024,
+        "messages": [{"role":"user", "content":"search the web for rust axum"}],
+        "tools": [
+            {"name": "read_file", "description": "read a file", "input_schema": {"type":"object","properties":{"path":{"type":"string"}}}},
+            {"type": "web_search_20250305", "name": "web_search", "max_uses": 5}
+        ],
+        "tool_choice": {"type": "auto"}
+    });
+    let converted = anthropic_to_openai(&request).unwrap();
+    let tools = converted["tools"].as_array().unwrap();
+    assert_eq!(tools.len(), 1, "custom tool kept, built-in skipped");
+    assert_eq!(tools[0]["function"]["name"], "read_file");
+    assert_eq!(converted["tool_choice"], "auto");
+}
+
+#[test]
+fn legacy_builtin_tool_only_drops_tools_and_tool_choice() {
+    let request = serde_json::json!({
+        "model": "claude-sonnet-4-20250514",
+        "max_tokens": 1024,
+        "messages": [{"role":"user", "content":"hi"}],
+        "tools": [
+            {"type": "web_search_20250305", "name": "web_search"}
+        ],
+        "tool_choice": {"type": "auto"}
+    });
+    let converted = anthropic_to_openai(&request).unwrap();
+    assert!(converted.get("tools").is_none(), "no tools survive");
+    // OpenAI rejects tool_choice without tools, so it must be dropped too.
+    assert!(converted.get("tool_choice").is_none());
+}
+
+#[test]
+fn legacy_tool_choice_forcing_builtin_tool_still_rejected() {
+    let request = serde_json::json!({
+        "model": "claude-sonnet-4-20250514",
+        "max_tokens": 1024,
+        "messages": [{"role":"user", "content":"hi"}],
+        "tools": [
+            {"name": "read_file", "description": "read a file", "input_schema": {"type":"object","properties":{}}},
+            {"type": "web_search_20250305", "name": "web_search"}
+        ],
+        "tool_choice": {"type": "tool", "name": "web_search"}
+    });
+    assert!(anthropic_to_openai(&request).is_err());
+}
+
+#[test]
+fn legacy_tool_choice_any_with_only_builtin_tools_rejected() {
+    let request = serde_json::json!({
+        "model": "claude-sonnet-4-20250514",
+        "max_tokens": 1024,
+        "messages": [{"role":"user", "content":"hi"}],
+        "tools": [
+            {"type": "web_search_20250305", "name": "web_search"}
+        ],
+        "tool_choice": {"type": "any"}
+    });
+    assert!(anthropic_to_openai(&request).is_err());
+}
+
+#[test]
+fn legacy_unknown_tool_type_still_rejected() {
+    let request = serde_json::json!({
+        "model": "claude-sonnet-4-20250514",
+        "max_tokens": 1024,
+        "messages": [{"role":"user", "content":"hi"}],
+        "tools": [
+            {"type": "mystery_tool_20990101", "name": "mystery"}
+        ]
+    });
+    assert!(anthropic_to_openai(&request).is_err());
+}
+
+#[test]
+fn legacy_builtin_tool_families_recognized() {
+    for tool_type in [
+        "web_search_20250305",
+        "computer_20250124",
+        "text_editor_20250429",
+        "code_execution_20250522",
+        "bash_20250124",
+    ] {
+        let request = serde_json::json!({
+            "model": "claude-sonnet-4-20250514",
+            "max_tokens": 1024,
+            "messages": [{"role":"user", "content":"hi"}],
+            "tools": [{"type": tool_type, "name": "t"}]
+        });
+        let converted = anthropic_to_openai(&request)
+            .unwrap_or_else(|e| panic!("{tool_type} should be skipped, got: {e}"));
+        assert!(converted.get("tools").is_none(), "{tool_type}");
+    }
+}

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -556,7 +556,11 @@ pub async fn handle_chat_completions(
         )
         .await
         {
-            Ok(result) => (StatusCode::OK, Json(result.body)).into_response(),
+            Ok(result) => (
+                StatusCode::from_u16(result.status).unwrap_or(StatusCode::OK),
+                Json(result.body),
+            )
+                .into_response(),
             Err((code, msg)) => {
                 let err_body = serde_json::json!({
                     "error": { "message": msg, "type": "upstream_error", "code": code }
@@ -798,6 +802,10 @@ async fn handle_stream(
     };
 
     let mut last_error = None;
+    // Set when an upstream returned a terminal (non-retryable) status before
+    // any bytes were streamed, so the loop stops and the final response keeps
+    // that status instead of a generic 502.
+    let mut last_error_status: Option<StatusCode> = None;
 
     for (attempt, channel) in selected_channels.into_iter().take(max_attempts).enumerate() {
         let config = Dispatcher::channel_to_config(&channel);
@@ -826,7 +834,13 @@ async fn handle_stream(
                 if !status.is_success() {
                     let body_str = resp.text().await.unwrap_or_default();
                     last_error = Some(format!("{}: {}", channel.name, body_str));
-                    continue;
+                    if retryable_upstream_status(status) {
+                        continue;
+                    }
+                    // Terminal upstream failure and nothing has been streamed
+                    // yet — stop cycling channels; the tail returns this status.
+                    last_error_status = Some(status);
+                    break;
                 }
 
                 let start = std::time::Instant::now();
@@ -1118,7 +1132,8 @@ async fn handle_stream(
             "type": "upstream_error"
         }
     });
-    (StatusCode::BAD_GATEWAY, Json(err_body)).into_response()
+    let status = last_error_status.unwrap_or(StatusCode::BAD_GATEWAY);
+    (status, Json(err_body)).into_response()
 }
 
 // ─── Anthropic Messages API: POST /v1/messages ─────────────────────────────
@@ -2463,9 +2478,15 @@ pub async fn handle_responses(
         .await
         {
             Ok(result) => {
-                // Convert OpenAI response to Responses API format
+                // Convert OpenAI response to Responses API format.  A
+                // caller-terminal upstream status keeps its status code; only
+                // the body is re-framed.
                 let responses_resp = protocol::openai_to_responses(&result.body, &model);
-                (StatusCode::OK, Json(responses_resp)).into_response()
+                (
+                    StatusCode::from_u16(result.status).unwrap_or(StatusCode::OK),
+                    Json(responses_resp),
+                )
+                    .into_response()
             }
             Err((code, msg)) => {
                 let err_body = serde_json::json!({
@@ -2632,6 +2653,10 @@ async fn handle_responses_stream(
     };
 
     let mut last_error = None;
+    // Set when an upstream returned a terminal (non-retryable) status before
+    // any bytes were streamed, so the loop stops and the final response keeps
+    // that status instead of a generic 502.
+    let mut last_error_status: Option<StatusCode> = None;
 
     for (attempt, channel) in selected_channels.into_iter().take(max_attempts).enumerate() {
         let config = Dispatcher::channel_to_config(&channel);
@@ -2659,7 +2684,13 @@ async fn handle_responses_stream(
                 if !status.is_success() {
                     let body_str = resp.text().await.unwrap_or_default();
                     last_error = Some(format!("{}: {}", channel.name, body_str));
-                    continue;
+                    if retryable_upstream_status(status) {
+                        continue;
+                    }
+                    // Terminal upstream failure and nothing has been streamed
+                    // yet — stop cycling channels; the tail returns this status.
+                    last_error_status = Some(status);
+                    break;
                 }
 
                 let start = std::time::Instant::now();
@@ -2941,7 +2972,8 @@ async fn handle_responses_stream(
             "type": "upstream_error"
         }
     });
-    (StatusCode::BAD_GATEWAY, Json(err_body)).into_response()
+    let status = last_error_status.unwrap_or(StatusCode::BAD_GATEWAY);
+    (status, Json(err_body)).into_response()
 }
 
 pub async fn handle_completions(State(_shared): State<SharedState>) -> Response {
@@ -3178,7 +3210,16 @@ pub async fn handle_embeddings(
                         eprintln!("[WARN] create_security_findings failed: {}", e);
                     }
                     last_error = Some(error_message);
-                    continue;
+                    if retryable_upstream_status(status) {
+                        continue;
+                    }
+                    // Terminal upstream statuses (400/401/403/422...) would fail
+                    // identically on every channel — surface this response.
+                    return (
+                        StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::BAD_GATEWAY),
+                        Json(resp_body),
+                    )
+                        .into_response();
                 }
 
                 // Extract usage from response

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -1,5 +1,6 @@
 use super::router::SharedState;
 use crate::adaptor::{get_adaptor, ProxyRequest};
+use crate::core::attempt::{upstream_failover_decision, FailoverDecision};
 use crate::core::dispatcher::Dispatcher;
 use crate::core::feature_flags;
 use crate::core::proxy;
@@ -864,13 +865,19 @@ async fn handle_stream(
                 if !status.is_success() {
                     let body_str = resp.text().await.unwrap_or_default();
                     last_error = Some(format!("{}: {}", channel.name, body_str));
-                    if retryable_upstream_status(status) {
-                        continue;
+                    match upstream_failover_decision(status.as_u16()) {
+                        FailoverDecision::Failover => continue,
+                        FailoverDecision::Stop { downstream_status } => {
+                            // Nothing has been streamed yet — stop cycling
+                            // channels; the tail returns this status (an
+                            // upstream 401/403 is masked to 502; last_error
+                            // above keeps the real response text).
+                            last_error_status = Some(
+                                StatusCode::from_u16(downstream_status).unwrap_or(status),
+                            );
+                            break;
+                        }
                     }
-                    // Terminal upstream failure and nothing has been streamed
-                    // yet — stop cycling channels; the tail returns this status.
-                    last_error_status = Some(status);
-                    break;
                 }
 
                 let start = std::time::Instant::now();
@@ -1567,10 +1574,6 @@ fn stored_native_response(error: StoredNativeError) -> Response {
     })
 }
 
-fn retryable_upstream_status(status: StatusCode) -> bool {
-    matches!(status.as_u16(), 408 | 409 | 429 | 529) || status.is_server_error()
-}
-
 fn openai_error_response(
     status: StatusCode,
     message: &str,
@@ -1923,25 +1926,39 @@ pub async fn handle_messages(
                 Ok((response, upstream_model)) => {
                     let status = StatusCode::from_u16(response.status().as_u16())
                         .unwrap_or(StatusCode::BAD_GATEWAY);
-                    if !retryable_upstream_status(status) {
-                        record_anthropic_outcome(
-                            repo.clone(),
-                            &key,
-                            Some(&channel),
-                            &model,
-                            upstream_model,
-                            &sanitized_log_json,
-                            &security_result,
-                            stream,
-                            status.as_u16() as i64,
-                            Some(format!("Native upstream returned HTTP {status}")),
-                            None,
-                        )
-                        .await;
-                        return native_response(response, None);
+                    match upstream_failover_decision(status.as_u16()) {
+                        FailoverDecision::Failover => {
+                            last_error = format!("{}: HTTP {}", channel.name, status);
+                            last_native_error = Some(store_native_error(response).await);
+                        }
+                        FailoverDecision::Stop { downstream_status } => {
+                            record_anthropic_outcome(
+                                repo.clone(),
+                                &key,
+                                Some(&channel),
+                                &model,
+                                upstream_model,
+                                &sanitized_log_json,
+                                &security_result,
+                                stream,
+                                status.as_u16() as i64,
+                                Some(format!("Native upstream returned HTTP {status}")),
+                                None,
+                            )
+                            .await;
+                            // An upstream 401/403 is a channel-credential
+                            // failure — answer 502 instead of passing it
+                            // through (the outcome log keeps the real status).
+                            if downstream_status != status.as_u16() {
+                                return anthropic_error(
+                                    StatusCode::BAD_GATEWAY,
+                                    "api_error",
+                                    "Upstream channel authentication failed",
+                                );
+                            }
+                            return native_response(response, None);
+                        }
                     }
-                    last_error = format!("{}: HTTP {}", channel.name, status);
-                    last_native_error = Some(store_native_error(response).await);
                 }
                 Err(error) => {
                     last_error = format!("{}: {error}", channel.name);
@@ -2064,24 +2081,30 @@ pub async fn handle_messages(
                     .and_then(|value| value.as_str())
                     .unwrap_or("OpenAI Chat Completions upstream rejected the request");
                 last_error = format!("{}: {message}", channel.name);
-                if !retryable_upstream_status(status) {
-                    record_anthropic_outcome(
-                        repo.clone(),
-                        &key,
-                        Some(&channel),
-                        &model,
-                        upstream_model,
-                        &sanitized_log_json,
-                        &security_result,
-                        stream,
-                        status.as_u16() as i64,
-                        Some(last_error.clone()),
-                        None,
-                    )
-                    .await;
-                    return openai_error_response(status, message, &response_headers);
+                match upstream_failover_decision(status.as_u16()) {
+                    FailoverDecision::Failover => {
+                        last_openai_error = Some((status, message.to_string(), response_headers));
+                    }
+                    FailoverDecision::Stop { .. } => {
+                        record_anthropic_outcome(
+                            repo.clone(),
+                            &key,
+                            Some(&channel),
+                            &model,
+                            upstream_model,
+                            &sanitized_log_json,
+                            &security_result,
+                            stream,
+                            status.as_u16() as i64,
+                            Some(last_error.clone()),
+                            None,
+                        )
+                        .await;
+                        // openai_error_response already maps an upstream
+                        // 401/403 to 502 api_error (429 keeps Retry-After).
+                        return openai_error_response(status, message, &response_headers);
+                    }
                 }
-                last_openai_error = Some((status, message.to_string(), response_headers));
             }
             Err(error) => {
                 last_error = format!("{}: {error}", channel.name);
@@ -2333,10 +2356,23 @@ pub async fn handle_messages_count_tokens(
             Ok((response, _upstream_model)) => {
                 let status = StatusCode::from_u16(response.status().as_u16())
                     .unwrap_or(StatusCode::BAD_GATEWAY);
-                if !retryable_upstream_status(status) {
-                    return native_response(response, None);
+                match upstream_failover_decision(status.as_u16()) {
+                    FailoverDecision::Failover => {
+                        last_error = Some(store_native_error(response).await);
+                    }
+                    FailoverDecision::Stop { downstream_status } => {
+                        // Mask a channel-credential failure (401/403) to 502;
+                        // every other terminal status passes through verbatim.
+                        if downstream_status != status.as_u16() {
+                            return anthropic_error(
+                                StatusCode::BAD_GATEWAY,
+                                "api_error",
+                                "Upstream channel authentication failed",
+                            );
+                        }
+                        return native_response(response, None);
+                    }
                 }
-                last_error = Some(store_native_error(response).await);
             }
             Err(_) => continue,
         }
@@ -2737,13 +2773,19 @@ async fn handle_responses_stream(
                 if !status.is_success() {
                     let body_str = resp.text().await.unwrap_or_default();
                     last_error = Some(format!("{}: {}", channel.name, body_str));
-                    if retryable_upstream_status(status) {
-                        continue;
+                    match upstream_failover_decision(status.as_u16()) {
+                        FailoverDecision::Failover => continue,
+                        FailoverDecision::Stop { downstream_status } => {
+                            // Nothing has been streamed yet — stop cycling
+                            // channels; the tail returns this status (an
+                            // upstream 401/403 is masked to 502; last_error
+                            // above keeps the real response text).
+                            last_error_status = Some(
+                                StatusCode::from_u16(downstream_status).unwrap_or(status),
+                            );
+                            break;
+                        }
                     }
-                    // Terminal upstream failure and nothing has been streamed
-                    // yet — stop cycling channels; the tail returns this status.
-                    last_error_status = Some(status);
-                    break;
                 }
 
                 let start = std::time::Instant::now();
@@ -3272,16 +3314,21 @@ pub async fn handle_embeddings(
                         eprintln!("[WARN] create_security_findings failed: {}", e);
                     }
                     last_error = Some(error_message);
-                    if retryable_upstream_status(status) {
-                        continue;
+                    match upstream_failover_decision(status.as_u16()) {
+                        FailoverDecision::Failover => continue,
+                        FailoverDecision::Stop { downstream_status } => {
+                            // Terminal status: the same request would fail
+                            // identically on every channel — surface this
+                            // response (an upstream 401/403 is masked to
+                            // 502; the log above keeps the real status).
+                            return (
+                                StatusCode::from_u16(downstream_status)
+                                    .unwrap_or(StatusCode::BAD_GATEWAY),
+                                Json(resp_body),
+                            )
+                                .into_response();
+                        }
                     }
-                    // Terminal upstream statuses (400/401/403/422...) would fail
-                    // identically on every channel — surface this response.
-                    return (
-                        StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::BAD_GATEWAY),
-                        Json(resp_body),
-                    )
-                        .into_response();
                 }
 
                 // Extract usage from response

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -16,6 +16,14 @@ use axum::{
 use futures_util::StreamExt;
 use rand::SeedableRng;
 use sqlx::sqlite::SqlitePool;
+
+/// A key lookup failure means "invalid key" only when the row is genuinely
+/// absent (or disabled); any other database error is a storage failure and
+/// must surface as 5xx, not as an authentication error.
+fn is_key_lookup_storage_error(err: &sqlx::Error) -> bool {
+    !matches!(err, sqlx::Error::RowNotFound)
+}
+
 /// Run the unified security audit gate against the ORIGINAL downstream
 /// protocol JSON full tree (never a converted Chat JSON).  Returns
 /// `Ok(AuditedRequest)` for audit-allow / redact, or a ready HTTP response
@@ -243,6 +251,25 @@ fn has_request_scoped_auth_candidate(
 }
 
 #[cfg(test)]
+mod key_lookup_classification_tests {
+    use super::is_key_lookup_storage_error;
+
+    #[test]
+    fn row_not_found_is_authentication_failure_not_storage_error() {
+        let err = sqlx::Error::RowNotFound;
+        assert!(!is_key_lookup_storage_error(&err));
+    }
+
+    #[test]
+    fn database_errors_are_storage_failures() {
+        assert!(is_key_lookup_storage_error(&sqlx::Error::PoolTimedOut));
+        assert!(is_key_lookup_storage_error(&sqlx::Error::Io(
+            std::io::Error::new(std::io::ErrorKind::Other, "disk")
+        )));
+    }
+}
+
+#[cfg(test)]
 mod auth_routeplan_rollout_tests {
     use super::{auth_routeplan_rollout_enabled, has_request_scoped_auth_candidate};
     use crate::core::feature_flags::FeatureFlags;
@@ -456,6 +483,9 @@ pub async fn handle_chat_completions(
     let repo = std::sync::Arc::new(Repository::new(shared.state.db.pool.clone()));
     let key_record = match repo.get_api_key_by_key(api_key).await {
         Ok(k) => k,
+        Err(e) if is_key_lookup_storage_error(&e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, "Key lookup failed").into_response()
+        }
         Err(_) => return (StatusCode::UNAUTHORIZED, "Invalid API key").into_response(),
     };
 
@@ -1715,6 +1745,13 @@ pub async fn handle_messages(
     let repo = std::sync::Arc::new(Repository::new(shared.state.db.pool.clone()));
     let key = match repo.get_api_key_by_key(&api_key).await {
         Ok(key) => key,
+        Err(e) if is_key_lookup_storage_error(&e) => {
+            return anthropic_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "api_error",
+                "Key lookup failed",
+            )
+        }
         Err(_) => {
             return anthropic_error(
                 StatusCode::UNAUTHORIZED,
@@ -2180,6 +2217,13 @@ pub async fn handle_messages_count_tokens(
     let repo = std::sync::Arc::new(Repository::new(shared.state.db.pool.clone()));
     let key = match repo.get_api_key_by_key(&api_key).await {
         Ok(key) => key,
+        Err(e) if is_key_lookup_storage_error(&e) => {
+            return anthropic_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "api_error",
+                "Key lookup failed",
+            )
+        }
         Err(_) => {
             return anthropic_error(
                 StatusCode::UNAUTHORIZED,
@@ -2328,6 +2372,15 @@ pub async fn handle_responses(
     let repo = std::sync::Arc::new(Repository::new(shared.state.db.pool.clone()));
     let key_record = match repo.get_api_key_by_key(&api_key).await {
         Ok(k) => k,
+        Err(e) if is_key_lookup_storage_error(&e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": {"message": "Key lookup failed", "type": "server_error"}
+                })),
+            )
+                .into_response()
+        }
         Err(_) => {
             return (
                 StatusCode::UNAUTHORIZED,
@@ -2975,6 +3028,15 @@ pub async fn handle_embeddings(
     let repo = std::sync::Arc::new(Repository::new(shared.state.db.pool.clone()));
     let key_record = match repo.get_api_key_by_key(&api_key).await {
         Ok(k) => k,
+        Err(e) if is_key_lookup_storage_error(&e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": {"message": "Key lookup failed", "type": "server_error"}
+                })),
+            )
+                .into_response()
+        }
         Err(_) => {
             return (
                 StatusCode::UNAUTHORIZED,
@@ -3380,7 +3442,8 @@ fn collect_auth_account_models(
     for account in accounts {
         if let Ok(states) = account.model_states() {
             for state in &states.models {
-                if state.status == "available" && !state.unavailable
+                if state.status == "available"
+                    && !state.unavailable
                     && seen.insert(state.id.clone())
                 {
                     out.push(ConfigModel {
@@ -3484,6 +3547,14 @@ async fn list_models_impl(pool: SqlitePool, headers: &HeaderMap) -> Response {
     let repo = Repository::new(pool);
     let key = match repo.get_api_key_by_key(&api_key).await {
         Ok(key) => key,
+        Err(e) if is_key_lookup_storage_error(&e) => {
+            return models_error(
+                anthropic,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "api_error",
+                "Key lookup failed",
+            )
+        }
         Err(_) => {
             return models_error(
                 anthropic,

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.18.1",
+    "react-router-dom": "^7.18.2",
     "react-syntax-highlighter": "^16.1.1",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",


### PR DESCRIPTION
## 问题（Fixes #48）

上游非 2xx 的重试语义此前有三套实现（legacy 代理、handlers 私有判定、T00 分类器），边缘状态码行为相反：501 在 handlers 被当作可重试 5xx 轮询全部渠道；3xx/402/418 在代理路径换渠道、在 handlers 直接停；上游 401/403 原样透传，调用方会误以为自己的 key 失效（与 #39 同类误报）。

## 根因

PR #46 在代理路径引入了基于 `classify_http_status` 的判定，但 handlers 的旧私有 `retryable_upstream_status`（`408|409|429|529 || is_server_error()`）与 native 路径未同步，三套判定各自演化。

## 修复

- `core/attempt.rs` 新增纯函数决策 API：`FailoverDecision::Failover | Stop { downstream_status }`，以 `classify_http_status`（T00 决策 5）为唯一事实来源，附全分支真值表单测与「2xx 不进入判定」的 `#[should_panic]` 契约测试。
- 删除 `proxy.rs::upstream_status_is_retryable` 与 `handlers.rs::retryable_upstream_status`，七个循环点（legacy 代理、chat 流式、responses 流式、embeddings、native Messages、Messages 经 OpenAI Chat 转换、count_tokens）全部薄委托决策函数，调用点无本地映射。

最终语义：

| 上游状态码 | 行为 | 下游状态码 |
|---|---|---|
| 400 / 422 | 停 | 原样透传 |
| 401 / 403 | 停 | **502 api_error（脱敏）**，日志/审计保留真实状态码与渠道名 |
| 404 | 停（无法证明路径缺失） | 原样透传 |
| 405 / 501 | 停（不再当可重试 5xx） | 原样透传 |
| 408/409/429/529、500–599（除 501） | 换渠道 | 耗尽后 502 |
| 3xx / 402 / 418 / 未列 | 换渠道（保守默认） | 耗尽后 502 |

429 的 `Retry-After` 头与 `rate_limit_error` 错误类型保持不变；流式已 commit 后的错误处理不变。

## 测试

```
$ cargo test attempt --manifest-path src-tauri/Cargo.toml
test result: ok. 20 passed; 0 failed; 0 ignored   # 含新增真值表与 2xx 契约测试

$ cargo test --manifest-path src-tauri/Cargo.toml --no-fail-fast
lib: 662 passed, 1 failed（security_gate_block_zero_upstream）
集成: 5 + 21 + 5 passed
```

唯一失败的 `security_gate_block_zero_upstream` 在本 PR 基底 `9232d6d`（v0.2.3 tip）纯净工作区上同样失败，为存量问题，与本 PR 无关（已用 `git stash` 对照验证）。

合并状态：基于 v0.2.3（fork 点 `9232d6d`），两个 commit 均为独立可评审的语义单元。