### PR TITLE
fix(protocol): Codex 工具调用参数改为一次性下发，修复部分客户端截断

### DIFF
--- a/src-tauri/src/protocol/codec/responses_codec/state.rs
+++ b/src-tauri/src/protocol/codec/responses_codec/state.rs
@@ -207,17 +207,22 @@ impl ResponsesChatState {
                 }
             }
             Some("response.function_call_arguments.delta") => {
+                // 有意不下发工具参数的逐片增量，只更新 call_id/name 等元数据
+                // （merge_tool_event_fields）。完整参数改为在
+                // response.function_call_arguments.done 时一次性发出：
+                // 届时 call.arguments 仍为空，complete_tool_call 计算出的
+                // remaining 就是完整参数字符串。
+                //
+                // 为什么不逐片下发：部分客户端（实测 WaLiCode）不按 index 累积
+                // tool_call 分片，而是以 id 定位后整体覆盖 arguments，导致
+                // 只保留某一个分片而非拼接结果——分片越多坏得越彻底。
+                // 单个 delta 携带完整 arguments 同样符合 OpenAI 协议
+                // （协议未要求必须分片），按 index 正确累积的客户端收到一整块
+                // 也能正常工作，因此这是对两类客户端都安全的做法。
+                // 代价：工具参数失去逐字显示效果，正文（output_text）不受影响。
                 self.role(&mut output);
                 let index = self.tool_index(&event).unwrap_or(0);
                 self.merge_tool_event_fields(index, &event);
-                if let Some(delta) = event.get("delta").and_then(Value::as_str) {
-                    let (call_id, name) = {
-                        let entry = self.tool_calls.entry(index).or_default();
-                        entry.arguments.push_str(delta);
-                        (entry.call_id.clone(), entry.name.clone())
-                    };
-                    output.push(self.chunk(serde_json::json!({"tool_calls":[{"index":index,"id":call_id,"type":"function","function":{"name":name,"arguments":delta}}]}), None));
-                }
             }
             Some("response.function_call_arguments.done") => {
                 self.role(&mut output);

--- a/src-tauri/src/protocol/codec/responses_codec/tests.rs
+++ b/src-tauri/src/protocol/codec/responses_codec/tests.rs
@@ -230,6 +230,64 @@ data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output
 }
 
 #[test]
+fn stream_tool_call_arguments_delivered_whole_not_piecemeal() {
+    // WaLiCode 实测：16 次工具调用全部只收到参数末尾的 "]}"。
+    //
+    // 起初怀疑是「每条 delta 都重复 id/name，客户端把带 id 当新调用而重置」，
+    // 改成仅首个 delta 带身份字段后复测——问题变成只剩*第一个*分片，说明
+    // WaLiCode 根本不做分片累积，而是每次直接用最新收到的 delta.arguments
+    // 覆盖，不管有没有 id。对分片型客户端，唯一安全的做法是不分片：
+    // arguments.delta 只更新 call_id/name 等元数据、不下发内容，完整参数
+    // 在 arguments.done 时一次性发出。
+    //
+    // 这同样符合 OpenAI 协议（协议未要求必须分片），按 index 正确累积的
+    // 客户端收到一整块参数也能正常工作。
+    let context = ConversionContext::new("chatcmpl_1", "m", true);
+    let mut decoder = ResponsesStreamDecoder {
+        state: ResponsesChatState::new(&context),
+    };
+    let output = decoder
+        .feed(
+            br#"data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"weather"}}
+
+data: {"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_1","delta":"{\"city\":"}
+
+data: {"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_1","delta":"\"Shanghai\""}
+
+data: {"type":"response.function_call_arguments.delta","output_index":0,"item_id":"fc_1","delta":"}"}
+
+data: {"type":"response.function_call_arguments.done","output_index":0,"item_id":"fc_1","arguments":"{\"city\":\"Shanghai\"}"}
+
+"#,
+        )
+        .unwrap()
+        .concat();
+
+    // delta 事件本身不应该出现在下游输出里——不下发任何参数内容
+    for line in output.lines() {
+        let Some(rest) = line.strip_prefix("data: ") else { continue };
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(rest) else { continue };
+        if let Some(tcs) = v.pointer("/choices/0/delta/tool_calls").and_then(|t| t.as_array()) {
+            for tc in tcs {
+                if let Some(a) = tc.pointer("/function/arguments").and_then(|a| a.as_str()) {
+                    assert_eq!(
+                        a, r#"{"city":"Shanghai"}"#,
+                        "工具调用只应收到一次、且是完整参数，实际输出:\n{output}"
+                    );
+                }
+            }
+        }
+    }
+    // 完整参数、身份字段各恰好出现一次（唯一一条 tool_calls chunk）
+    assert_eq!(
+        output.matches(r#""id":"call_1""#).count(),
+        1,
+        "id 应恰好出现一次"
+    );
+    assert_eq!(output.matches("Shanghai").count(), 1, "完整参数应恰好发送一次");
+}
+
+#[test]
 fn stream_rejects_invalid_done_function_call_arguments() {
     let context = ConversionContext::new("chatcmpl_1", "m", true);
     let mut decoder = ResponsesStreamDecoder {


### PR DESCRIPTION
Fixes #52 
问题：Responses → Chat 流式转换时，function_call_arguments.delta 的每个 分片都重复携带完整的 id / type / function.name。OpenAI 的流式约定是只有 首个 delta 带这些身份字段，后续仅带 index + arguments。

部分客户端（实测 WaLiCode）不按 index 累积分片，而是每收到一条 delta 就
用其 arguments 整体覆盖，导致只保留某一片而非拼接结果。实测 16 次工具
调用全部失败，客户端只收到参数末尾的 "]}"。

先尝试改为「仅首个 delta 携带身份字段」，格式虽合规但问题依旧——只是从
「只剩最后一片」变成「只剩第一片」，说明这类客户端根本不做累积。

因此改为不分片：function_call_arguments.delta 不再下发 tool_calls chunk （仍调用 merge_tool_event_fields 维护 call_id/name 状态），完整参数在 function_call_arguments.done 时一次性发出。

done 分支无需改动：complete_tool_call() 中 call.arguments 的语义是 「已下发给下游的部分」，删除 delta 分支的 push_str 后它恒为空，
remaining 自然等于完整参数字符串。

这同样符合 OpenAI 协议（协议未强制要求分片），按 index 正确累积的客户端
收到一整块参数也能正常工作，因此对两类客户端都安全。代价是工具参数失去
逐字流式显示效果，正文 response.output_text 不受影响。

新增回归测试 stream_tool_call_arguments_delivered_whole_not_piecemeal： 断言 delta 阶段不产生任何 tool_calls 输出，done 时 id 与完整参数各恰好
出现一次。

验证：cargo test --lib 在本分支为 675 passed / 1 failed，唯一失败 rollout_integration_tests::security_gate_block_zero_upstream 在未打本补丁 的 v0.2.5 上同样为红，与本改动无关。