### PR TITLE
 fix(wiki): 修复 Unicode 文档摄入与搜索导致的进程崩溃

### DIFF
--- a/src-tauri/src/security/scanner.rs
+++ b/src-tauri/src/security/scanner.rs
@@ -1,4 +1,5 @@
 use super::{RiskLevel, SecurityFinding, SecurityScanResult, SecuritySettings};
+use crate::utils::text::truncate_utf8;
 use std::time::{Duration, Instant};
 
 const MAX_FINDINGS: usize = 80;
@@ -255,20 +256,6 @@ fn scan_text(text: &str, phase: &str, location: &str, ctx: &mut ScanContext) {
     }
     scan_tracking_pixel(scan_text, phase, location, ctx);
     scan_fingerprint_terms(scan_text, phase, location, ctx);
-}
-
-/// Truncate to `max` bytes at a UTF-8 char boundary (never panics).
-fn truncate_utf8(text: &str, max: usize) -> &str {
-    if text.len() <= max {
-        text
-    } else {
-        // Find the largest char boundary <= max.
-        let mut end = max;
-        while end > 0 && !text.is_char_boundary(end) {
-            end -= 1;
-        }
-        &text[..end]
-    }
 }
 
 fn scan_credentials(text: &str, phase: &str, location: &str, ctx: &mut ScanContext) {

--- a/src-tauri/src/services/wiki/ingest.rs
+++ b/src-tauri/src/services/wiki/ingest.rs
@@ -5,9 +5,13 @@ use crate::core::proxy;
 use crate::db::repository::Repository;
 use crate::server::event_bridge::EventSink;
 use crate::settings_store::SettingsStore;
+use crate::utils::text::truncate_utf8;
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::sync::Arc;
+
+const MAX_SOURCE_CONTEXT_BYTES: usize = 24_000;
+const SOURCE_CONTEXT_TRUNCATION_MARKER: &str = "\n\n[... content truncated ...]";
 
 /// Ingest a source file: read → parse → generate wiki pages via LLM → write to disk+DB.
 pub async fn ingest_source(
@@ -276,7 +280,7 @@ fn emit_wiki_progress(
     stage: &str,
     progress: u8,
     detail: &str,
-    ) {
+) {
     events.emit(
         "wiki-source-progress",
         serde_json::json!({
@@ -427,22 +431,7 @@ async fn generate_wiki_pages(
     sections: &[ContentSection],
     schema: &str,
 ) -> Result<Vec<GeneratedPage>, String> {
-    // Build a combined context from all sections
-    let combined: String = sections
-        .iter()
-        .map(|s| format!("## {}\n{}", s.heading, s.content))
-        .collect::<Vec<_>>()
-        .join("\n\n");
-
-    // Truncate to fit context window (rough estimate)
-    let max_chars = 24000;
-    let truncated = if combined.len() > max_chars {
-        let mut t = combined[..max_chars].to_string();
-        t.push_str("\n\n[... content truncated ...]");
-        t
-    } else {
-        combined
-    };
+    let truncated = build_source_context(sections);
 
     let system_prompt = format!(
         r#"You are a Wiki maintainer. Read the source document and generate structured wiki pages in Markdown.
@@ -550,6 +539,22 @@ Generate 3-8 pages depending on document complexity. Focus on the most important
 
     // Parse the LLM output into pages
     Ok(parse_generated_pages(raw_text, source_filename))
+}
+
+fn build_source_context(sections: &[ContentSection]) -> String {
+    let combined: String = sections
+        .iter()
+        .map(|s| format!("## {}\n{}", s.heading, s.content))
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    if combined.len() <= MAX_SOURCE_CONTEXT_BYTES {
+        return combined;
+    }
+
+    let mut truncated = truncate_utf8(&combined, MAX_SOURCE_CONTEXT_BYTES).to_string();
+    truncated.push_str(SOURCE_CONTEXT_TRUNCATION_MARKER);
+    truncated
 }
 
 /// Parse LLM-generated pages from the response text.
@@ -998,4 +1003,97 @@ async fn resolve_wikilink_to_path(pool: &sqlx::SqlitePool, project_id: &str, lin
     }
     // Fallback to slug-based normalization
     normalize_wikilink(link)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_context_truncates_cjk_at_utf8_boundary() {
+        let sections = vec![ContentSection {
+            heading: String::new(),
+            content: "中".repeat(9_000),
+        }];
+
+        let context = build_source_context(&sections);
+        let content = context
+            .strip_suffix(SOURCE_CONTEXT_TRUNCATION_MARKER)
+            .unwrap();
+
+        assert!(content.len() <= MAX_SOURCE_CONTEXT_BYTES);
+        assert!(content.is_char_boundary(content.len()));
+        assert!(context.ends_with(SOURCE_CONTEXT_TRUNCATION_MARKER));
+    }
+
+    #[test]
+    fn source_context_truncates_emoji_at_utf8_boundary() {
+        let sections = vec![ContentSection {
+            heading: "Emoji".to_string(),
+            content: "😀".repeat(7_000),
+        }];
+
+        let context = build_source_context(&sections);
+        let content = context
+            .strip_suffix(SOURCE_CONTEXT_TRUNCATION_MARKER)
+            .unwrap();
+
+        assert!(content.len() <= MAX_SOURCE_CONTEXT_BYTES);
+        assert!(content.is_char_boundary(content.len()));
+    }
+
+    #[test]
+    fn source_context_preserves_content_within_limit() {
+        let sections = vec![ContentSection {
+            heading: "Overview".to_string(),
+            content: "WaLiAPI Wiki".to_string(),
+        }];
+
+        assert_eq!(build_source_context(&sections), "## Overview\nWaLiAPI Wiki");
+    }
+
+    #[test]
+    fn source_context_handles_ascii_at_and_above_byte_limit() {
+        let exact = vec![ContentSection {
+            heading: "A".to_string(),
+            content: "x".repeat(MAX_SOURCE_CONTEXT_BYTES - "## A\n".len()),
+        }];
+        let over = vec![ContentSection {
+            heading: "A".to_string(),
+            content: "x".repeat(MAX_SOURCE_CONTEXT_BYTES - "## A\n".len() + 1),
+        }];
+
+        let exact_context = build_source_context(&exact);
+        assert_eq!(exact_context.len(), MAX_SOURCE_CONTEXT_BYTES);
+        assert!(!exact_context.ends_with(SOURCE_CONTEXT_TRUNCATION_MARKER));
+
+        let over_context = build_source_context(&over);
+        let over_content = over_context
+            .strip_suffix(SOURCE_CONTEXT_TRUNCATION_MARKER)
+            .unwrap();
+        assert_eq!(over_content.len(), MAX_SOURCE_CONTEXT_BYTES);
+    }
+
+    #[test]
+    fn source_context_truncates_combined_sections_at_utf8_boundary() {
+        let sections = vec![
+            ContentSection {
+                heading: "Overview".to_string(),
+                content: "a".repeat(12_000),
+            },
+            ContentSection {
+                heading: "中文".to_string(),
+                content: "界".repeat(5_000),
+            },
+        ];
+
+        let context = build_source_context(&sections);
+        let content = context
+            .strip_suffix(SOURCE_CONTEXT_TRUNCATION_MARKER)
+            .unwrap();
+
+        assert!(content.len() <= MAX_SOURCE_CONTEXT_BYTES);
+        assert!(content.is_char_boundary(content.len()));
+        assert!(content.contains("## 中文"));
+    }
 }

--- a/src-tauri/src/services/wiki/repository.rs
+++ b/src-tauri/src/services/wiki/repository.rs
@@ -259,18 +259,7 @@ impl WikiRepository {
                 if let Ok(content) =
                     crate::services::wiki::project::read_page(project_id, &page.path).await
                 {
-                    let content_lower = content.to_lowercase();
-                    let query_lower = query.to_lowercase();
-                    if content_lower.contains(&query_lower) {
-                        // Extract snippet around match
-                        let pos = content_lower.find(&query_lower).unwrap_or(0);
-                        let start = if pos > 60 { pos - 60 } else { 0 };
-                        let end = std::cmp::min(start + 200, content.len());
-                        // Align to char boundaries to avoid splitting multi-byte UTF-8 chars
-                        let start = content.floor_char_boundary(start);
-                        let end = content.ceil_char_boundary(end);
-                        let snippet = format!("...{}...", &content[start..end].replace('\n', " "));
-
+                    if let Some(snippet) = build_search_snippet(&content, query) {
                         results.push(WikiSearchResult {
                             page_id: page.id.clone(),
                             path: page.path.clone(),
@@ -292,12 +281,8 @@ impl WikiRepository {
                 if let Ok(content) =
                     crate::services::wiki::project::read_page(project_id, &r.path).await
                 {
-                    let content_lower = content.to_lowercase();
-                    let query_lower = query.to_lowercase();
-                    if let Some(pos) = content_lower.find(&query_lower) {
-                        let start = if pos > 60 { pos - 60 } else { 0 };
-                        let end = std::cmp::min(start + 200, content.len());
-                        r.snippet = format!("...{}...", &content[start..end].replace('\n', " "));
+                    if let Some(snippet) = build_search_snippet(&content, query) {
+                        r.snippet = snippet;
                     } else {
                         // Use first 200 chars as snippet
                         r.snippet = content.chars().take(200).collect::<String>();
@@ -633,6 +618,37 @@ impl WikiRepository {
     }
 }
 
+fn build_search_snippet(content: &str, query: &str) -> Option<String> {
+    let match_start = find_case_insensitive_match_start(content, query)?;
+    let match_char_index = content[..match_start].chars().count();
+    let snippet_start = match_char_index.saturating_sub(60);
+    let snippet = content
+        .chars()
+        .skip(snippet_start)
+        .take(200)
+        .collect::<String>()
+        .replace('\n', " ");
+    Some(format!("...{}...", snippet))
+}
+
+fn find_case_insensitive_match_start(content: &str, query: &str) -> Option<usize> {
+    let query_lower = query.to_lowercase();
+    let mut content_lower = String::with_capacity(content.len());
+    let mut offsets = Vec::with_capacity(content.chars().count() + 1);
+
+    for (original_offset, ch) in content.char_indices() {
+        offsets.push((content_lower.len(), original_offset));
+        content_lower.extend(ch.to_lowercase());
+    }
+    offsets.push((content_lower.len(), content.len()));
+
+    let match_offset = content_lower.find(&query_lower)?;
+    let offset_index = offsets
+        .partition_point(|(lower_offset, _)| *lower_offset <= match_offset)
+        .saturating_sub(1);
+    Some(offsets[offset_index].1)
+}
+
 #[derive(Debug, Clone, sqlx::FromRow)]
 struct WikiGraphEdgeRow {
     id: String,
@@ -669,3 +685,32 @@ You are a Wiki maintainer. Your job is to read source documents and maintain a s
 - `wiki/concepts/*.md` — concept pages.
 - `wiki/summaries/*.md` — source summaries.
 "#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn search_snippet_handles_cjk_without_splitting_utf8() {
+        let content = format!("{}阻止输出或报警{}", "前".repeat(80), "后".repeat(180));
+        let snippet = build_search_snippet(&content, "输出").unwrap();
+
+        assert!(snippet.contains("阻止输出或报警"));
+        assert!(snippet.is_char_boundary(snippet.len()));
+    }
+
+    #[test]
+    fn search_snippet_maps_unicode_lowercase_expansion_to_original_text() {
+        let content = format!("{}İSTANBUL{}", "前".repeat(80), "后".repeat(180));
+        let snippet = build_search_snippet(&content, "i\u{307}stanbul").unwrap();
+
+        assert!(snippet.contains("İSTANBUL"));
+        assert!(snippet.is_char_boundary(snippet.len()));
+    }
+
+    #[test]
+    fn search_snippet_is_case_insensitive_for_ascii() {
+        let snippet = build_search_snippet("WaLiAPI Wiki Gateway", "wiki").unwrap();
+        assert!(snippet.contains("WaLiAPI Wiki Gateway"));
+    }
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod id;
+pub mod text;
 pub mod time;

--- a/src-tauri/src/utils/text.rs
+++ b/src-tauri/src/utils/text.rs
@@ -1,0 +1,41 @@
+/// 按 UTF-8 字节上限截断字符串，并保证返回值始终落在字符边界上。
+pub fn truncate_utf8(text: &str, max_bytes: usize) -> &str {
+    if text.len() <= max_bytes {
+        return text;
+    }
+
+    let mut end = max_bytes;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    &text[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncates_cjk_at_utf8_boundary() {
+        let text = "界".repeat(100);
+        let truncated = truncate_utf8(&text, 37);
+
+        assert_eq!(truncated.len(), 36);
+        assert!(text.is_char_boundary(truncated.len()));
+    }
+
+    #[test]
+    fn truncates_emoji_at_utf8_boundary() {
+        let text = "a".repeat(15) + "😀尾";
+        let truncated = truncate_utf8(&text, 17);
+
+        assert_eq!(truncated, "a".repeat(15));
+        assert!(text.is_char_boundary(truncated.len()));
+    }
+
+    #[test]
+    fn preserves_text_within_limit() {
+        assert_eq!(truncate_utf8("WaLiAPI", 7), "WaLiAPI");
+        assert_eq!(truncate_utf8("WaLiAPI", 16), "WaLiAPI");
+    }
+}


### PR DESCRIPTION
修复 `ingest_wiki_source` 和 `search_wiki` 在 Unicode 文本上触发 `core::str::slice_error_fail`，并在 release `panic=abort` 配置下导致整个 WaLiAPI 进程退出的问题。
