### PR TITLE
fix(codex): strip prompt_cache_options instead of rejecting the request

### DIFF
--- a/src-tauri/src/auth_provider/codex_backend.rs
+++ b/src-tauri/src/auth_provider/codex_backend.rs
@@ -341,7 +341,12 @@ pub fn validate_backend_request(body: &Value) -> Result<Value, ProviderError> {
         "stream",
         "store",
     ];
-    const STRIPPED: &[&str] = &["max_output_tokens", "metadata"];
+    // `prompt_cache_options` is a caching hint that accompanies
+    // `prompt_cache_key`; it carries no request semantics the backend needs and
+    // the Chat path already discards it (see `responses_codec::encode_messages`
+    // DROPPED). Stripping keeps both downstream protocols behaving the same
+    // instead of rejecting Responses clients that send it (e.g. WaLiCode).
+    const STRIPPED: &[&str] = &["max_output_tokens", "metadata", "prompt_cache_options"];
     for (key, value) in object {
         if !ALLOWED.contains(&key.as_str()) && !STRIPPED.contains(&key.as_str()) && !value.is_null()
         {
@@ -906,6 +911,34 @@ mod tests {
             error,
             ProviderError::UnsupportedFeatures { ref pointer } if pointer == "/unknown_field"
         ));
+    }
+
+    /// Regression: a real WaLiCode `/v1/responses` body (captured from
+    /// `request_logs`) was rejected with 400 at `/prompt_cache_options` before
+    /// any network call. Every other field it sends is allowed or stripped.
+    #[test]
+    fn backend_request_strips_prompt_cache_options() {
+        let body = validate_backend_request(&json!({
+            "model": "gpt-5.4",
+            "input": "hi",
+            "instructions": "you are a coding agent",
+            "max_output_tokens": 32768,
+            "prompt_cache_key": "walicode-responses-v2:1dgr77u:91n97n",
+            "prompt_cache_options": {"mode": "implicit"},
+            "reasoning": {"effort": "medium"},
+            "stream": true,
+            "tools": []
+        }))
+        .unwrap();
+        assert!(body.get("prompt_cache_options").is_none());
+        // The companion key is still forwarded; only the hint is dropped.
+        assert_eq!(
+            body["prompt_cache_key"],
+            "walicode-responses-v2:1dgr77u:91n97n"
+        );
+        assert_eq!(body["reasoning"], json!({"effort": "medium"}));
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["store"], false);
     }
 
     #[test]


### PR DESCRIPTION
Codex 后端的 validate_backend_request 白名单里有 prompt_cache_key，却没有 与之配套的 prompt_cache_options，导致带该字段的 /v1/responses 请求在联网前 就被拒：

    HTTP 400  unsupported provider request field at /prompt_cache_options

实测 WaLiCode 走 Responses 协议时必带这个字段（值为 {"mode":"implicit"}）， 于是整条 Responses 路径不可用，只能退回 Chat 协议。

同一个字段在 Chat 路径上早已被静默丢弃（responses_codec::encode_messages 的 DROPPED 列表），protocol/codec/registry.rs 也把它列为已知字段。三处不一致， 只有 codex_backend 会因此阻断请求。

它是 prompt_cache_key 的缓存提示，不携带后端需要的请求语义，丢弃不改变输出，
因此归入 STRIPPED，与 Chat 路径行为对齐，也与既有的 metadata 同性质。

验证（本机 gateway，codex/auth_account/responses 同一路径，仅此一行为变量）：
  无修复  HTTP 400  unsupported provider request field at /prompt_cache_options
  有修复  HTTP 200  event: response.created

回归测试用的是从 request_logs 捞出的真实 WaLiCode 请求体字段集；已确认撤掉
修复该测试即失败。