### PR TITLE
fix(stream): 流式请求被误记为 499/client_cancelled 且 token 用量恒为 0

### DIFF
--- a/src-tauri/migrations/028_request_log_usage_source.sql
+++ b/src-tauri/migrations/028_request_log_usage_source.sql
@@ -1,0 +1,17 @@
+-- 028: 标注 request_logs 里 token 用量的来源
+--
+-- `repair_stream_cancel_logs` 会一次性回填历史上被误记为 499 / client_cancelled
+-- 且用量恒为 0 的流式请求。回填出来的数字是"按证据恢复 + 本地估算"得到的，
+-- 不是上游实测值，必须能在看板和配额里区分开，否则历史估算会永久冒充实测数据。
+--
+-- 取值语义：
+--   * NULL        — 本列引入之前写入的行，来源未知（不做追溯标注）
+--   * 'upstream'  — 上游真实回传的 usage（预留，实时路径暂未写入）
+--   * 'estimated' — 上游未回传 usage，实时路径本地 BPE 估算（预留）
+--   * 'repaired'  — 由 repair_stream_cancel_logs 回填的行
+--
+-- 纯新增可空列，不改写、不删除任何既有列与既有行；老查询与日志页照常工作。
+
+ALTER TABLE request_logs ADD COLUMN usage_source TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_logs_usage_source ON request_logs(usage_source);

--- a/src-tauri/src/bin/waliapi-web.rs
+++ b/src-tauri/src/bin/waliapi-web.rs
@@ -3,6 +3,7 @@
 //! 用法：
 //!   waliapi-web [--host 0.0.0.0] [--port 8777] [--data-dir /data]   （默认即启动服务）
 //!   waliapi-web start [...同上参数...]
+//!   waliapi-web repair-stream-logs [--data-dir <目录>] [--apply] [--limit <行>]
 //!
 //! 环境变量：WALIAPI_SERVER_HOST / WALIAPI_SERVER_PORT / WALIAPI_DATA_DIR / XDG_DATA_HOME
 
@@ -15,6 +16,7 @@ fn print_usage() {
 
 用法:
   waliapi-web [start] [--host <地址>] [--port <端口>] [--data-dir <目录>]
+  waliapi-web repair-stream-logs [--data-dir <目录>] [--apply] [--limit <行>]
 
 说明:
   不带任何参数直接启动服务（start 为可选子命令，语义相同）。
@@ -24,8 +26,110 @@ fn print_usage() {
   --port       监听端口（默认读取 WALIAPI_SERVER_PORT 或设置，缺省 8777）
   --data-dir   数据目录（默认读取 WALIAPI_DATA_DIR / XDG_DATA_HOME，再缺省为平台应用数据目录）
   -h, --help   显示帮助
+
+子命令 repair-stream-logs:
+  一次性修复历史上被误记为 499 / client_cancelled 且 token 用量为 0 的流式日志。
+  默认 dry-run 只报告不改库，加 --apply 才写入。
+    --apply         真正写库（缺省为 dry-run）
+    --limit <行>    每批处理行数（缺省 50，命令内部自动分批直到处理完）
+    --status-only   只改判状态（499→200），不补 token。只做消息前缀比对，秒级完成
+    --usage-only    只补 token 用量与响应内容，保留 499 状态。需跑 BPE，大库分钟级
+  缺省两者都做。--status-only 与 --usage-only 互斥。
+
+  ⚠ 请先停止正在使用同一数据目录的实例再执行。WaLiAPI 的 SQLite 以默认
+    journal_mode=delete（回滚日志）打开，写事务提交需要 EXCLUSIVE 锁；本命令
+    会连续发起数百个写事务，与仍在服务的网关（每个请求至少一次读 + 一次写）
+    争锁，两侧都会遇到 SQLITE_BUSY 停顿。首次执行还会触发 schema 迁移，
+    迁移前的 VACUUM INTO 备份需要整库一致性快照，在 GB 级库上尤其不适合与
+    在线写入并行。
 "
     );
+}
+
+/// `repair-stream-logs` 子命令：打开数据目录 → 跑迁移 → 分批修复直到收敛。
+async fn run_repair_cli(
+    rest: &[String],
+    apply: bool,
+    limit: i64,
+    reclassify: bool,
+    backfill_usage: bool,
+) -> Result<(), String> {
+    let data_dir = resolve_data_dir(
+        rest.iter()
+            .position(|a| a == "--data-dir")
+            .and_then(|i| rest.get(i + 1).cloned()),
+    );
+    println!("数据目录: {}", data_dir.display());
+    let db = waliapi_lib::db::Database::new_with_path(&data_dir).await;
+    let pool = db.pool.clone();
+
+    let mut total_scanned = 0i64;
+    let mut total_reclassified = 0i64;
+    let mut total_kept = 0i64;
+    let mut total_prompt = 0i64;
+    let mut total_completion = 0i64;
+    let mut rounds = 0i64;
+    loop {
+        let report = waliapi_lib::commands::log_repair::repair_pool(
+            &pool,
+            waliapi_lib::commands::log_repair::RepairInput {
+                apply: Some(apply),
+                limit: Some(limit),
+                reclassify: Some(reclassify),
+                backfill_usage: Some(backfill_usage),
+            },
+        )
+        .await?;
+        rounds += 1;
+        total_scanned += report.scanned;
+        total_reclassified += report.reclassified;
+        total_kept += report.kept_cancelled;
+        total_prompt += report.prompt_tokens_added;
+        total_completion += report.completion_tokens_added;
+        println!(
+            "[第 {rounds} 批] 扫描={} 改判200={} 保持499={} prompt+={} completion+={} \
+             恢复响应={} 剩余={}",
+            report.scanned,
+            report.reclassified,
+            report.kept_cancelled,
+            report.prompt_tokens_added,
+            report.completion_tokens_added,
+            report.response_choices_restored,
+            report.remaining
+        );
+        for sample in report.samples.iter().take(3) {
+            println!(
+                "    seq={} delivered={} prompt={}({}) completion={} resp_chars={}",
+                sample.seq,
+                sample.delivered,
+                sample.prompt_tokens,
+                serde_json::to_string(&sample.prompt_method).unwrap_or_default(),
+                sample.completion_tokens,
+                sample.restored_response_chars
+            );
+        }
+        // dry-run 不写库，remaining 永远不会收敛；只跑一批给人看影响面，
+        // 否则这里会死循环。apply 才按批推进直到处理完。
+        if !apply || report.scanned == 0 || report.remaining == 0 {
+            break;
+        }
+    }
+
+    println!(
+        "\n{}：共扫描 {} 行（{} 批），改判 200 共 {} 行，保持 499 共 {} 行，\n补记 prompt {} tokens、completion {} tokens。",
+        if apply { "已应用" } else { "dry-run（未写库）" },
+        total_scanned,
+        rounds,
+        total_reclassified,
+        total_kept,
+        total_prompt,
+        total_completion
+    );
+    if !apply {
+        println!("确认无误后加 --apply 真正写入。");
+    }
+    pool.close().await;
+    Ok(())
 }
 
 fn parse_args(args: &[String]) -> Result<WebServerConfig, String> {
@@ -76,6 +180,16 @@ async fn main() {
     let log_dir = data_log_dir.unwrap_or_else(|| exe_log_dir.clone());
     std::fs::create_dir_all(&log_dir).ok();
 
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let first = args.first().map(String::as_str);
+    // 维护子命令要给人读结论，不能被 sqlx 的 DEBUG 语句淹掉；服务模式日志级别保持不变。
+    let maintenance = first == Some("repair-stream-logs");
+    let max_level = if maintenance {
+        tracing::level_filters::LevelFilter::WARN
+    } else {
+        tracing::level_filters::LevelFilter::DEBUG
+    };
+
     // 按天滚动日志文件（如 waliapi.log.2026-08-25），最多保留 7 个文件
     let file_appender = tracing_appender::rolling::Builder::new()
         .rotation(tracing_appender::rolling::Rotation::DAILY)
@@ -87,23 +201,68 @@ async fn main() {
     // 同时输出到 stdout（docker logs 可见）和日志文件。
     // 文件写入失败不影响 stdout，保证容器日志始终可见。
     let stdout_layer = tracing_subscriber::fmt::layer()
-        .with_writer(std::io::stdout);
+        .with_writer(std::io::stdout)
+        .with_filter(max_level);
     let file_layer = file_appender.map(|w| {
-        tracing_subscriber::fmt::layer().with_writer(w)
+        tracing_subscriber::fmt::layer()
+            .with_writer(w)
+            .with_filter(max_level)
     });
     tracing_subscriber::registry()
         .with(stdout_layer)
         .with(file_layer)
         .init();
 
-    let args: Vec<String> = std::env::args().skip(1).collect();
     // 帮助优先于参数路由：-h/--help（含 start 子命令后）打印用法并正常退出
-    let first = args.first().map(String::as_str);
     let help_requested = matches!(first, Some("-h") | Some("--help"))
         || (first == Some("start")
             && matches!(args.get(1).map(String::as_str), Some("-h") | Some("--help")));
     if help_requested {
         print_usage();
+        return;
+    }
+    // repair-stream-logs 是离线维护子命令：不开服务、不需要管理员会话，跑完即退出
+    if first == Some("repair-stream-logs") {
+        let rest = &args[1..];
+        let apply = rest.iter().any(|a| a == "--apply");
+        let limit = match rest.iter().position(|a| a == "--limit") {
+            Some(idx) => match rest.get(idx + 1).map(|raw| raw.trim().parse::<i64>()) {
+                Some(Ok(v)) if v > 0 => Ok(v),
+                Some(Ok(_)) => Err("--limit 必须为正整数".to_string()),
+                Some(Err(e)) => Err(format!("--limit 无效: {e}")),
+                None => Err("--limit 缺少参数值".to_string()),
+            },
+            None => Ok(50),
+        };
+        let limit = match limit {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("参数错误: {e}\n");
+                print_usage();
+                std::process::exit(2);
+            }
+        };
+        let scope = match (
+            rest.iter().any(|a| a == "--status-only"),
+            rest.iter().any(|a| a == "--usage-only"),
+        ) {
+            (true, true) => Err("--status-only 与 --usage-only 互斥".to_string()),
+            (true, false) => Ok((true, false)),
+            (false, true) => Ok((false, true)),
+            (false, false) => Ok((true, true)),
+        };
+        let (reclassify, backfill_usage) = match scope {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("参数错误: {e}\n");
+                print_usage();
+                std::process::exit(2);
+            }
+        };
+        if let Err(e) = run_repair_cli(rest, apply, limit, reclassify, backfill_usage).await {
+            eprintln!("修复失败: {e}");
+            std::process::exit(1);
+        }
         return;
     }
     // 不带参数、直接带选项（waliapi-web --port 9000）、或显式 start 子命令，均启动服务

--- a/src-tauri/src/commands/log_repair.rs
+++ b/src-tauri/src/commands/log_repair.rs
@@ -1,0 +1,1076 @@
+//! 历史 499 日志的一次性修复命令。
+//!
+//! # 背景
+//!
+//! 0.2.8 之前，流式请求的成功日志写在 `async_stream::stream!` 生成器**最后一次
+//! `yield` 之后**，只有消费者再轮询一次才会执行。Agent 类客户端（Codex / Claude
+//! Code / Node undici）拿到终止帧 `[DONE]` 就立刻关连接，hyper 停止轮询并 drop
+//! 掉 body，`StreamLogFinalizer::drop` 兜底路径于是把一条完整成功的流写成
+//! `499 / client_cancelled / 0 token / 空响应`。
+//!
+//! 前向缺陷已由 `endpoint_executor::driver` 修复；**已经落库的历史行**需要本命令
+//! 单独恢复。
+//!
+//! # 为什么可以逐行判定，而不是按 duration 猜
+//!
+//! Agent 的对话历史是累积的：若第 N 轮真的产出了被下游采用的回复，那么同会话
+//! 第 N+1 轮请求的 `messages` 里必然多出第 N 轮那条 assistant 消息。这是内容级
+//! 证据，不是启发式打分。据此既能判定"本轮其实成功了"，又能顺带把本轮的响应正文
+//! 和 completion tokens 一起恢复出来。
+//!
+//! 参照行的 `messages` 必须与目标行**前缀逐条相等**才采信（否则说明换了会话，
+//! 或客户端压缩过历史），判定偏保守：拿不到证据的行保持 499。
+//!
+//! # 安全边界
+//!
+//! - 默认 dry-run，只报告不写库；`apply=true` 才落库。
+//! - 单次最多处理 `limit` 行，可反复调用直到 `remaining == 0`，避免长任务卡住一次请求。
+//! - 只碰 `usage_source IS NULL` 的行，天然幂等，重复执行不会二次改写。
+//! - **不改 `quota_used`**：配额语义是否要同步是独立决策，留给使用者。
+//! - 回填出的数字一律标 `usage_source='repaired'`，与上游实测值可区分。
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sqlx::SqlitePool;
+
+use crate::endpoint_executor::estimate_usage::{count_tokens, estimate_usage};
+use crate::AppState;
+
+/// 采信插值所需的字节比窗口。超出即认为参照行不属于同一对话状态。
+///
+/// 本机 434 对"两行都有上游真实 prompt_tokens"的相邻样本留一验证：
+/// 比值落在 1.00–1.02 时中位误差 **0.01%**、P90 0.13%；1.05–1.15 恶化到 2.9%；
+/// ≥1.5 恶化到 25%。故窗口收紧在 0.9–1.1。
+///
+/// **已知局限（实测）**：以后继行为锚点时，本层在本机只命中 **0.8%**（7/873）——
+/// 因为 499 行往往连续成串（回溯链中位 44 行、P90 123 行），后继本身通常也是
+/// prompt_tokens=0 的 499 行，没有可锚的真实值。剩下 99.2% 全部落到 BPE，
+/// 这就是全量回填在 1.7 GB 库上要跑约 23 分钟的原因。改用前驱行为锚点可把命中
+/// 提到 91.9%，但链式插值会 telescoping 成 `prompt(锚点) × chars(N)/chars(锚点)`，
+/// 等价于直接用远锚点，严格窗口下覆盖率只回升到 17.3% —— 精度受益、耗时不受益。
+/// 真正能同时改善两者的是增量法（只对每轮新增的几 KB 跑 BPE 再累加），
+/// 属后续优化，本 PR 未做。
+const INTERP_MIN_RATIO: f64 = 0.9;
+const INTERP_MAX_RATIO: f64 = 1.1;
+
+/// 默认单次处理行数。
+const DEFAULT_LIMIT: i64 = 50;
+
+/// dry-run 报告里最多给出多少条明细样例。
+const SAMPLE_LIMIT: usize = 10;
+
+/// `request_logs.usage_source` 的取值：本命令回填的行。
+const USAGE_SOURCE_REPAIRED: &str = "repaired";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptMethod {
+    /// 同会话邻近真实行按字节比插值（实测中位误差 0.01%）
+    Interpolated,
+    /// 本地 BPE 估算（`cl100k_base`，对非 OpenAI 系模型自述 ±10–20% 偏差）
+    Estimated,
+    /// 本次范围不含用量回填，未做计算
+    Skipped,
+}
+
+/// 对单条历史行算出的修复计划。
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RepairPlan {
+    /// 有内容证据证明本轮回复被下游采用 → 可以改判 200
+    pub delivered: bool,
+    pub prompt_tokens: i64,
+    pub completion_tokens: i64,
+    pub prompt_method: PromptMethod,
+    /// 从下一轮请求里恢复出的本轮回复（证据成立时才有）
+    pub response_choices: Option<String>,
+}
+
+/// 一条待修复的历史行。
+#[derive(Debug, Clone, sqlx::FromRow)]
+struct Candidate {
+    id: String,
+    seq: i64,
+    model: String,
+    request_body: String,
+    body_chars: i64,
+}
+
+/// 同会话的参照行（目标行 seq 之后紧邻的一行）。
+///
+/// `plan_repair` 的公开入参类型，故必须 pub。
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct Successor {
+    request_body: String,
+    body_chars: i64,
+    prompt_tokens: i64,
+}
+
+/// 修复范围。状态改判与用量回填是两件独立的事：
+/// 前者只要比对消息前缀（秒级），后者要对 request_body 跑 BPE（大库上分钟级），
+/// 且精度来源不同，所以必须能分开选。
+///
+/// ⚠ 两个 scope **不能先后各跑一次**：候选条件是 `usage_source IS NULL`，
+/// 先跑 `reclassify` 会把行打上 `repaired` 标记，第二次跑 `backfill_usage`
+/// 就再也扫不到这些行了。要么一次跑完（缺省），要么只跑其中一种。
+#[derive(Debug, Clone, Copy)]
+pub struct RepairScope {
+    /// 有内容证据的行 499 → 200，并清掉 client_cancelled / error_message
+    pub reclassify: bool,
+    /// 补记 prompt / completion / total tokens 并恢复 response_choices
+    pub backfill_usage: bool,
+}
+
+impl Default for RepairScope {
+    fn default() -> Self {
+        Self {
+            reclassify: true,
+            backfill_usage: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RepairInput {
+    /// false（默认）= 只报告不写库
+    pub apply: Option<bool>,
+    /// 单次最多处理多少行
+    pub limit: Option<i64>,
+    /// 是否执行状态改判，缺省 true
+    pub reclassify: Option<bool>,
+    /// 是否执行用量回填，缺省 true
+    pub backfill_usage: Option<bool>,
+}
+
+impl RepairInput {
+    /// 两个开关同时关闭会让本命令什么都不做（只会打 usage_source 标记），
+    /// 那是误用而不是意图，显式拦掉。
+    fn scope(&self) -> Result<RepairScope, String> {
+        let scope = RepairScope {
+            reclassify: self.reclassify.unwrap_or(true),
+            backfill_usage: self.backfill_usage.unwrap_or(true),
+        };
+        if !scope.reclassify && !scope.backfill_usage {
+            return Err(
+                "reclassify 与 backfill_usage 不能同时为 false，那样不会改动任何数据".to_string(),
+            );
+        }
+        Ok(scope)
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RepairSample {
+    pub seq: i64,
+    pub model: String,
+    pub delivered: bool,
+    pub prompt_tokens: i64,
+    pub completion_tokens: i64,
+    pub prompt_method: PromptMethod,
+    pub restored_response_chars: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RepairReport {
+    pub dry_run: bool,
+    /// 本次生效的修复范围（让读报告的人知道数字是否真的写进了库）
+    pub reclassify: bool,
+    pub backfill_usage: bool,
+    pub scanned: i64,
+    /// 有内容证据证明其实成功交付的行数（是否真改状态取决于 `reclassify`）
+    pub reclassified: i64,
+    /// 无证据、保持 499 的行数
+    pub kept_cancelled: i64,
+    pub prompt_tokens_added: i64,
+    pub completion_tokens_added: i64,
+    pub response_choices_restored: i64,
+    /// request_body 无法解析、只打标记不改数值的行数
+    pub skipped_unparsable: i64,
+    /// 仍待处理的行数（apply 模式下收敛到 0 表示全部处理完）
+    pub remaining: i64,
+    pub samples: Vec<RepairSample>,
+}
+
+fn messages_of(value: &Value) -> Option<&Vec<Value>> {
+    value.get("messages").and_then(Value::as_array)
+}
+
+fn is_assistant(message: &Value) -> bool {
+    message.get("role").and_then(Value::as_str) == Some("assistant")
+}
+
+/// 取 successor 相对 target 多出来的 assistant 消息，即本轮的实际回复。
+///
+/// 返回 `None` 表示不构成证据：successor 不比 target 长、前缀不一致（换了会话或
+/// 历史被压缩）、或多出来的部分里没有 assistant 消息。
+fn recovered_assistant_turns(target: &[Value], successor: &[Value]) -> Option<Vec<Value>> {
+    if successor.len() <= target.len() {
+        return None;
+    }
+    // 前缀必须逐条相等：zip 到较短的 target 为止，正好覆盖 target 全部消息。
+    if !successor.iter().zip(target.iter()).all(|(s, t)| s == t) {
+        return None;
+    }
+    let turns: Vec<Value> = successor[target.len()..]
+        .iter()
+        .filter(|m| is_assistant(m))
+        .cloned()
+        .collect();
+    if turns.is_empty() {
+        None
+    } else {
+        Some(turns)
+    }
+}
+
+/// 把恢复出的 assistant 消息合并成日志详情页使用的 `response_choices` 形状，
+/// 与 `StreamPumpCore::build_response_choices` 产出的结构保持一致。
+fn build_response_choices(turns: &[Value]) -> Option<String> {
+    let mut content = String::new();
+    let mut reasoning = String::new();
+    let mut tool_calls: Vec<Value> = Vec::new();
+
+    for turn in turns {
+        if let Some(text) = turn.get("content").and_then(Value::as_str) {
+            if !text.is_empty() {
+                if !content.is_empty() {
+                    content.push('\n');
+                }
+                content.push_str(text);
+            }
+        }
+        if let Some(text) = turn
+            .get("reasoning_content")
+            .and_then(Value::as_str)
+            .filter(|t| !t.is_empty())
+        {
+            if !reasoning.is_empty() {
+                reasoning.push('\n');
+            }
+            reasoning.push_str(text);
+        }
+        if let Some(calls) = turn.get("tool_calls").and_then(Value::as_array) {
+            for (idx, call) in calls.iter().enumerate() {
+                let mut call = call.clone();
+                call["index"] = json!(tool_calls.len() + idx);
+                tool_calls.push(call);
+            }
+        }
+    }
+
+    if content.is_empty() && reasoning.is_empty() && tool_calls.is_empty() {
+        return None;
+    }
+
+    let mut message = json!({ "role": "assistant" });
+    if !content.is_empty() {
+        message["content"] = json!(&content);
+    }
+    if !reasoning.is_empty() {
+        message["reasoning_content"] = json!(&reasoning);
+    }
+    if !tool_calls.is_empty() {
+        message["tool_calls"] = json!(tool_calls);
+    }
+    let choices = vec![json!({
+        "index": 0,
+        "message": message,
+        "finish_reason": "stop",
+    })];
+    serde_json::to_string(&choices).ok()
+}
+
+/// 恢复出的回复一共多少 token（正文 + 思考 + 工具调用参数）。
+fn recovered_tokens(turns: &[Value]) -> i64 {
+    let mut text = String::new();
+    for turn in turns {
+        if let Some(t) = turn.get("content").and_then(Value::as_str) {
+            text.push_str(t);
+        }
+        if let Some(t) = turn.get("reasoning_content").and_then(Value::as_str) {
+            text.push_str(t);
+        }
+        if let Some(calls) = turn.get("tool_calls").and_then(Value::as_array) {
+            for call in calls {
+                if let Some(args) = call.pointer("/function/arguments").and_then(Value::as_str) {
+                    text.push_str(args);
+                }
+            }
+        }
+    }
+    count_tokens(&text)
+}
+
+/// 纯函数：对一条历史行 + 其同会话参照行算出修复计划。
+///
+/// `successor` 为 `None` 表示找不到参照行（会话末尾 / 该组没有后续请求）。
+///
+/// `with_usage=false` 时**完全跳过 token 计算**（插值和 BPE 都不做）。这不是省
+/// 几行代码的问题：BPE 要跑完整 request_body（本机 714 MB / 约 23 分钟），而只要
+/// 改判状态的话，证据判定靠的是消息前缀比对，两者成本差两个数量级。
+pub fn plan_repair(
+    target_body: &str,
+    target_chars: i64,
+    model: &str,
+    successor: Option<&Successor>,
+    with_usage: bool,
+) -> Option<RepairPlan> {
+    let target: Value = serde_json::from_str(target_body).ok()?;
+    let target_msgs = messages_of(&target)?;
+
+    let mut delivered = false;
+    let mut turns: Vec<Value> = Vec::new();
+
+    if let Some(succ) = successor {
+        if let Ok(succ_json) = serde_json::from_str::<Value>(&succ.request_body) {
+            if let Some(succ_msgs) = messages_of(&succ_json) {
+                if let Some(recovered) = recovered_assistant_turns(target_msgs, succ_msgs) {
+                    delivered = true;
+                    turns = recovered;
+                }
+            }
+        }
+    }
+
+    if !with_usage {
+        return Some(RepairPlan {
+            delivered,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            prompt_method: PromptMethod::Skipped,
+            response_choices: None,
+        });
+    }
+
+    // prompt：优先同会话邻近真实行按字节比插值，窗口外退到本地 BPE 估算。
+    let interpolated = successor.and_then(|succ| {
+        if succ.prompt_tokens <= 0 || succ.body_chars <= 0 {
+            return None;
+        }
+        let ratio = target_chars as f64 / succ.body_chars as f64;
+        if (INTERP_MIN_RATIO..=INTERP_MAX_RATIO).contains(&ratio) {
+            Some((succ.prompt_tokens as f64 * ratio).round() as i64)
+        } else {
+            None
+        }
+    });
+    let (prompt_tokens, prompt_method) = match interpolated {
+        Some(tokens) => (tokens, PromptMethod::Interpolated),
+        None => (
+            estimate_usage(&target, None, model).0,
+            PromptMethod::Estimated,
+        ),
+    };
+
+    let completion_tokens = if turns.is_empty() {
+        0
+    } else {
+        recovered_tokens(&turns)
+    };
+    let response_choices = if turns.is_empty() {
+        None
+    } else {
+        build_response_choices(&turns)
+    };
+
+    Some(RepairPlan {
+        delivered,
+        prompt_tokens,
+        completion_tokens,
+        prompt_method,
+        response_choices,
+    })
+}
+
+const CANDIDATE_WHERE: &str = "status_code = 499 AND client_cancelled = 1 AND total_tokens = 0 \
+                               AND usage_source IS NULL AND request_body IS NOT NULL";
+
+async fn fetch_candidates(pool: &SqlitePool, limit: i64) -> Result<Vec<Candidate>, String> {
+    sqlx::query_as::<_, Candidate>(&format!(
+        "SELECT id, seq, model, request_body, length(request_body) AS body_chars \
+         FROM request_logs WHERE {CANDIDATE_WHERE} ORDER BY seq ASC LIMIT ?"
+    ))
+    .bind(limit)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| format!("读取待修复日志失败: {e}"))
+}
+
+async fn count_pending(pool: &SqlitePool) -> Result<i64, String> {
+    sqlx::query_scalar::<_, i64>(&format!(
+        "SELECT COUNT(*) FROM request_logs WHERE {CANDIDATE_WHERE}"
+    ))
+    .fetch_one(pool)
+    .await
+    .map_err(|e| format!("统计待修复日志失败: {e}"))
+}
+
+/// 取同 (api_key_id, model, channel_id) 分组内、seq 紧邻的下一行作为参照。
+async fn fetch_successor(
+    pool: &SqlitePool,
+    candidate: &Candidate,
+) -> Result<Option<Successor>, String> {
+    let group: Option<(Option<String>, Option<String>)> =
+        sqlx::query_as("SELECT api_key_id, channel_id FROM request_logs WHERE id = ?")
+            .bind(&candidate.id)
+            .fetch_optional(pool)
+            .await
+            .map_err(|e| format!("读取分组键失败: {e}"))?;
+    let Some((Some(api_key_id), Some(channel_id))) = group else {
+        return Ok(None);
+    };
+    let successor = sqlx::query_as::<_, Successor>(
+        "SELECT request_body, length(request_body) AS body_chars, prompt_tokens \
+         FROM request_logs \
+         WHERE seq > ? AND api_key_id IS ? AND channel_id IS ? AND model = ? \
+           AND request_body IS NOT NULL \
+         ORDER BY seq ASC LIMIT 1",
+    )
+    .bind(candidate.seq)
+    .bind(&api_key_id)
+    .bind(&channel_id)
+    .bind(&candidate.model)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| format!("读取参照行失败: {e}"))?;
+    Ok(successor)
+}
+
+/// 无法解析的行：数值一律不动，只打 `usage_source` 让扫描收敛。
+async fn mark_processed(pool: &SqlitePool, candidate: &Candidate) -> Result<(), String> {
+    sqlx::query("UPDATE request_logs SET usage_source = ? WHERE id = ?")
+        .bind(USAGE_SOURCE_REPAIRED)
+        .bind(&candidate.id)
+        .execute(pool)
+        .await
+        .map_err(|e| format!("标记已处理失败: {e}"))?;
+    Ok(())
+}
+
+/// 按 scope 拼 UPDATE。SET 子句全部来自固定字面量，不含任何外部输入。
+/// 绑定顺序必须与拼出来的占位符顺序严格一致。
+async fn apply_plan(
+    pool: &SqlitePool,
+    candidate: &Candidate,
+    plan: &RepairPlan,
+    scope: RepairScope,
+) -> Result<(), String> {
+    let mut sets: Vec<&str> = Vec::new();
+    let do_status = scope.reclassify && plan.delivered;
+    if do_status {
+        sets.extend([
+            "status_code = 200",
+            "client_cancelled = 0",
+            "error_message = NULL",
+        ]);
+    }
+    if scope.backfill_usage {
+        // 无证据的行也补 prompt：上游确实消耗过它。completion / response_choices
+        // 在没有证据时本来就是 0 / NULL，写回去等价于不动。
+        sets.extend([
+            "prompt_tokens = ?",
+            "completion_tokens = ?",
+            "total_tokens = ?",
+            "response_choices = ?",
+        ]);
+    }
+    sets.push("usage_source = ?");
+
+    let sql = format!("UPDATE request_logs SET {} WHERE id = ?", sets.join(", "));
+    let mut query = sqlx::query(&sql);
+    if scope.backfill_usage {
+        query = query
+            .bind(plan.prompt_tokens)
+            .bind(plan.completion_tokens)
+            .bind(plan.prompt_tokens + plan.completion_tokens)
+            .bind(&plan.response_choices);
+    }
+    query
+        .bind(USAGE_SOURCE_REPAIRED)
+        .bind(&candidate.id)
+        .execute(pool)
+        .await
+        .map_err(|e| format!("写入修复结果失败: {e}"))?;
+    Ok(())
+}
+
+/// 执行一轮修复。直接接收连接池而不是 `AppState`，让集成测试可以用内存库跑通
+/// 整条"扫描 → 判定 → 落库"链路。
+pub async fn repair_pool(pool: &SqlitePool, input: RepairInput) -> Result<RepairReport, String> {
+    let apply = input.apply.unwrap_or(false);
+    let limit = input.limit.unwrap_or(DEFAULT_LIMIT).max(1);
+    let scope = input.scope()?;
+
+    let pending_before = count_pending(pool).await?;
+    let candidates = fetch_candidates(pool, limit).await?;
+
+    let mut report = RepairReport {
+        dry_run: !apply,
+        reclassify: scope.reclassify,
+        backfill_usage: scope.backfill_usage,
+        scanned: 0,
+        reclassified: 0,
+        kept_cancelled: 0,
+        prompt_tokens_added: 0,
+        completion_tokens_added: 0,
+        response_choices_restored: 0,
+        skipped_unparsable: 0,
+        remaining: pending_before,
+        samples: Vec::new(),
+    };
+
+    for candidate in candidates {
+        let successor = fetch_successor(pool, &candidate).await?;
+        let Some(plan) = plan_repair(
+            &candidate.request_body,
+            candidate.body_chars,
+            &candidate.model,
+            successor.as_ref(),
+            scope.backfill_usage,
+        ) else {
+            // request_body 不是合法 JSON 或没有 messages：数值不动，
+            // 但必须打上 usage_source，否则 `remaining` 永远收敛不到 0、调用方会死循环。
+            report.scanned += 1;
+            report.skipped_unparsable += 1;
+            if apply {
+                mark_processed(pool, &candidate).await?;
+            }
+            continue;
+        };
+
+        report.scanned += 1;
+        if plan.delivered {
+            report.reclassified += 1;
+        } else {
+            report.kept_cancelled += 1;
+        }
+        if scope.backfill_usage {
+            report.prompt_tokens_added += plan.prompt_tokens;
+            report.completion_tokens_added += plan.completion_tokens;
+            if plan.response_choices.is_some() {
+                report.response_choices_restored += 1;
+            }
+        }
+        if report.samples.len() < SAMPLE_LIMIT {
+            report.samples.push(RepairSample {
+                seq: candidate.seq,
+                model: candidate.model.clone(),
+                delivered: plan.delivered,
+                prompt_tokens: plan.prompt_tokens,
+                completion_tokens: plan.completion_tokens,
+                prompt_method: plan.prompt_method,
+                restored_response_chars: plan
+                    .response_choices
+                    .as_ref()
+                    .map(|s| s.chars().count())
+                    .unwrap_or(0),
+            });
+        }
+        if apply {
+            apply_plan(pool, &candidate, &plan, scope).await?;
+        }
+    }
+
+    report.remaining = count_pending(pool).await?;
+    Ok(report)
+}
+
+#[tauri::command]
+pub async fn repair_stream_cancel_logs(
+    input: RepairInput,
+    state: tauri::State<'_, std::sync::Arc<AppState>>,
+) -> Result<RepairReport, String> {
+    repair_pool(&state.db.pool, input).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn body(messages: Vec<Value>) -> String {
+        json!({ "model": "m", "messages": messages }).to_string()
+    }
+
+    fn user(text: &str) -> Value {
+        json!({ "role": "user", "content": text })
+    }
+
+    fn assistant(text: &str) -> Value {
+        json!({ "role": "assistant", "content": text })
+    }
+
+    fn succ(request_body: String, body_chars: i64, prompt_tokens: i64) -> Successor {
+        Successor {
+            request_body,
+            body_chars,
+            prompt_tokens,
+        }
+    }
+
+    #[test]
+    fn successor_with_new_assistant_turn_proves_delivery() {
+        let target = body(vec![user("hi")]);
+        let next = body(vec![user("hi"), assistant("hello there")]);
+        let plan = plan_repair(&target, 100, "m", Some(&succ(next, 100, 1000)), true).unwrap();
+        assert!(plan.delivered);
+        assert_eq!(plan.completion_tokens, count_tokens("hello there"));
+        let choices = plan.response_choices.unwrap();
+        assert!(choices.contains("hello there"), "{choices}");
+        assert!(choices.contains("\"finish_reason\":\"stop\""));
+    }
+
+    #[test]
+    fn prefix_mismatch_is_not_evidence() {
+        // 换了会话：下一行的第一条消息都不一样
+        let target = body(vec![user("hi")]);
+        let next = body(vec![user("totally different"), assistant("x")]);
+        let plan = plan_repair(&target, 100, "m", Some(&succ(next, 120, 1000)), true).unwrap();
+        assert!(!plan.delivered);
+        assert_eq!(plan.completion_tokens, 0);
+        assert!(plan.response_choices.is_none());
+    }
+
+    #[test]
+    fn shorter_or_equal_successor_is_not_evidence() {
+        let target = body(vec![user("a"), assistant("b"), user("c")]);
+        let next = body(vec![user("a"), assistant("b")]);
+        let plan = plan_repair(&target, 100, "m", Some(&succ(next, 90, 1000)), true).unwrap();
+        assert!(!plan.delivered);
+    }
+
+    #[test]
+    fn growth_without_assistant_turn_is_not_evidence() {
+        // 只多了 tool 结果，本轮没有 assistant 回复
+        let target = body(vec![user("hi")]);
+        let next = body(vec![
+            user("hi"),
+            json!({"role": "tool", "content": "result"}),
+        ]);
+        let plan = plan_repair(&target, 100, "m", Some(&succ(next, 110, 1000)), true).unwrap();
+        assert!(!plan.delivered);
+        assert!(plan.response_choices.is_none());
+    }
+
+    #[test]
+    fn prompt_interpolated_only_inside_byte_ratio_window() {
+        let target = body(vec![user("hi")]);
+        let next = body(vec![user("hi"), assistant("ok")]);
+        // 比值 100/105 ≈ 0.95 → 落在窗口内，走插值
+        let plan = plan_repair(
+            &target,
+            100,
+            "m",
+            Some(&succ(next.clone(), 105, 1000)),
+            true,
+        )
+        .unwrap();
+        assert_eq!(plan.prompt_method, PromptMethod::Interpolated);
+        assert_eq!(
+            plan.prompt_tokens,
+            (1000.0f64 * (100.0f64 / 105.0f64)).round() as i64
+        );
+        // 比值 100/500 = 0.2 → 窗口外，退到估算
+        let far = plan_repair(&target, 100, "m", Some(&succ(next, 500, 1000)), true).unwrap();
+        assert_eq!(far.prompt_method, PromptMethod::Estimated);
+        assert_ne!(far.prompt_tokens, plan.prompt_tokens);
+    }
+
+    #[test]
+    fn no_successor_still_estimates_prompt() {
+        let target = body(vec![user("hi there how are you doing today")]);
+        let plan = plan_repair(&target, 100, "m", None, true).unwrap();
+        assert!(!plan.delivered);
+        assert_eq!(plan.prompt_method, PromptMethod::Estimated);
+        assert!(plan.prompt_tokens > 0, "prompt 必须估出来，不能记 0");
+    }
+
+    #[test]
+    fn unparsable_body_yields_no_plan() {
+        assert!(plan_repair("not json", 10, "m", None, true).is_none());
+        assert!(plan_repair(r#"{"model":"m"}"#, 10, "m", None, true).is_none());
+    }
+
+    #[test]
+    fn tool_call_turns_are_merged_and_reindexed() {
+        let target = body(vec![user("hi")]);
+        let next = body(vec![
+            user("hi"),
+            json!({"role":"assistant","content":null,"tool_calls":[
+                {"id":"c1","type":"function","index":0,"function":{"name":"f","arguments":"{}"}}]}),
+            json!({"role":"tool","tool_call_id":"c1","content":"r"}),
+            json!({"role":"assistant","content":"done","tool_calls":[
+                {"id":"c2","type":"function","index":0,"function":{"name":"g","arguments":"{}"}}]}),
+        ]);
+        let plan = plan_repair(&target, 100, "m", Some(&succ(next, 105, 1000)), true).unwrap();
+        assert!(plan.delivered);
+        let choices = plan.response_choices.unwrap();
+        assert!(choices.contains("done"), "{choices}");
+        assert!(
+            choices.contains("\"c1\"") && choices.contains("\"c2\""),
+            "{choices}"
+        );
+        // 两条 tool_call 的 index 必须重排成 0/1，不能都留 0
+        assert!(choices.contains("\"index\":1"), "{choices}");
+        assert!(plan.completion_tokens > 0);
+    }
+
+    #[tokio::test]
+    async fn candidate_query_skips_already_repaired_rows() {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+
+        // 用 async fn 而不是返回 future 的闭包：闭包会把 `Option<&str>` 的
+        // 生命周期和 async block 的返回类型对不上（E0623 类错误）。
+        async fn insert(pool: &SqlitePool, seq: i64, usage_source: Option<&str>) {
+            sqlx::query(
+                "INSERT INTO request_logs (id, seq, model, mode, status_code, prompt_tokens, \
+                 completion_tokens, total_tokens, duration_ms, is_stream, is_retry, \
+                 created_at, request_body, risk_level, risk_score, security_action, \
+                 sanitized, client_cancelled, stream_committed, usage_source) \
+                 VALUES (?, ?, 'm', 'chat', 499, 0, 0, 0, 1, 1, 0, \
+                         '2026-09-04T00:00:00.000Z', ?, 'clean', 0, 'allow', 0, 1, 1, ?)",
+            )
+            .bind(format!("id-{seq}"))
+            .bind(seq)
+            .bind(json!({"model":"m","messages":[{"role":"user","content":"hi"}]}).to_string())
+            .bind(usage_source)
+            .execute(pool)
+            .await
+            .unwrap();
+        }
+        insert(&pool, 1, None).await;
+        insert(&pool, 2, Some("repaired")).await;
+
+        assert_eq!(count_pending(&pool).await.unwrap(), 1);
+        let cands = fetch_candidates(&pool, 10).await.unwrap();
+        assert_eq!(cands.len(), 1);
+        assert_eq!(cands[0].seq, 1);
+        pool.close().await;
+    }
+
+    /// 端到端跑通"扫描 → 证据判定 → 落库 → 幂等"整条链路（内存库 + 真实迁移）。
+    /// scope 开关必须真的生效：status-only 不改 token，usage-only 不改状态。
+    #[tokio::test]
+    async fn scope_flags_are_respected() {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+
+        async fn seed(pool: &SqlitePool) {
+            sqlx::query(
+                "INSERT INTO request_logs (id, seq, api_key_id, channel_id, model, mode, \
+                 status_code, prompt_tokens, completion_tokens, total_tokens, duration_ms, \
+                 is_stream, is_retry, created_at, request_body, error_message, risk_level, \
+                 risk_score, security_action, sanitized, client_cancelled, stream_committed) \
+                 VALUES ('a', 1, 'k', 'c', 'm', 'chat', 499, 0, 0, 0, 1, 1, 0, \
+                         '2026-09-04T00:00:00.000Z', ?, 'client_cancelled', 'clean', 0, \
+                         'allow', 0, 1, 1)",
+            )
+            .bind(json!({"messages":[{"role":"user","content":"hi"}]}).to_string())
+            .execute(pool)
+            .await
+            .unwrap();
+            sqlx::query(
+                "INSERT INTO request_logs (id, seq, api_key_id, channel_id, model, mode, \
+                 status_code, prompt_tokens, completion_tokens, total_tokens, duration_ms, \
+                 is_stream, is_retry, created_at, request_body, risk_level, risk_score, \
+                 security_action, sanitized, client_cancelled, stream_committed) \
+                 VALUES ('b', 2, 'k', 'c', 'm', 'chat', 200, 1000, 5, 1005, 1, 1, 0, \
+                         '2026-09-04T00:01:00.000Z', ?, 'clean', 0, 'allow', 0, 0, 1)",
+            )
+            .bind(
+                json!({"messages":[{"role":"user","content":"hi"},
+                                   {"role":"assistant","content":"hello there"}]})
+                .to_string(),
+            )
+            .execute(pool)
+            .await
+            .unwrap();
+        }
+
+        // ── status-only：改判 200，但 token 必须保持 0（说明 BPE 根本没跑）──
+        seed(&pool).await;
+        let r = repair_pool(
+            &pool,
+            RepairInput {
+                apply: Some(true),
+                limit: Some(10),
+                reclassify: Some(true),
+                backfill_usage: Some(false),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(r.reclassified, 1);
+        assert_eq!(
+            r.prompt_tokens_added, 0,
+            "status-only 不该产生任何 token 数字"
+        );
+        assert_eq!(r.response_choices_restored, 0);
+        let row: (i64, i64, i64, Option<String>) = sqlx::query_as(
+            "SELECT status_code, prompt_tokens, total_tokens, response_choices FROM request_logs WHERE id='a'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0, 200, "状态应改判");
+        assert_eq!((row.1, row.2), (0, 0), "token 不应被写");
+        assert!(row.3.is_none(), "response_choices 不应被写");
+        let cancelled: i64 =
+            sqlx::query_scalar("SELECT client_cancelled FROM request_logs WHERE id='a'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(cancelled, 0);
+        pool.close().await;
+
+        // ── usage-only：补 token，但状态必须保持 499 ──
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        seed(&pool).await;
+        let r = repair_pool(
+            &pool,
+            RepairInput {
+                apply: Some(true),
+                limit: Some(10),
+                reclassify: Some(false),
+                backfill_usage: Some(true),
+            },
+        )
+        .await
+        .unwrap();
+        assert!(r.prompt_tokens_added > 0, "usage-only 应补上 prompt");
+        let row: (i64, i64, Option<String>) = sqlx::query_as(
+            "SELECT status_code, prompt_tokens, error_message FROM request_logs WHERE id='a'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0, 499, "usage-only 不该改状态");
+        assert!(row.1 > 0);
+        assert_eq!(
+            row.2.as_deref(),
+            Some("client_cancelled"),
+            "error_message 应保留"
+        );
+        pool.close().await;
+    }
+
+    /// 两个开关同时关闭是误用，必须显式报错而不是静默"处理"掉所有行。
+    #[tokio::test]
+    async fn empty_scope_is_rejected() {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        let e = repair_pool(
+            &pool,
+            RepairInput {
+                apply: Some(true),
+                limit: Some(10),
+                reclassify: Some(false),
+                backfill_usage: Some(false),
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(e.contains("不能同时为 false"), "{e}");
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn repair_pool_reclassifies_proven_rows_and_is_idempotent() {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+
+        async fn insert(
+            pool: &SqlitePool,
+            seq: i64,
+            status: i64,
+            prompt: i64,
+            total: i64,
+            body: Value,
+        ) {
+            sqlx::query(
+                "INSERT INTO request_logs (id, seq, api_key_id, channel_id, model, mode, \
+                 status_code, prompt_tokens, completion_tokens, total_tokens, duration_ms, \
+                 is_stream, is_retry, created_at, request_body, error_message, risk_level, \
+                 risk_score, security_action, sanitized, client_cancelled, stream_committed) \
+                 VALUES (?, ?, 'key-1', 'ch-1', 'm', 'chat', ?, ?, 0, ?, 1, 1, 0, \
+                         '2026-09-04T00:00:00.000Z', ?, ?, 'clean', 0, 'allow', 0, ?, 1)",
+            )
+            .bind(format!("id-{seq}"))
+            .bind(seq)
+            .bind(status)
+            .bind(prompt)
+            .bind(total)
+            .bind(body.to_string())
+            .bind((status == 499).then_some("client_cancelled"))
+            .bind(if status == 499 { 1 } else { 0 })
+            .execute(pool)
+            .await
+            .unwrap();
+        }
+
+        // seq 1：被误记的 499；seq 2：同会话下一轮，历史里多出了 seq 1 那轮的回复
+        insert(
+            &pool,
+            1,
+            499,
+            0,
+            0,
+            json!({"messages":[{"role":"user","content":"hi"}]}),
+        )
+        .await;
+        insert(
+            &pool,
+            2,
+            200,
+            1000,
+            1010,
+            json!({"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"hello there"}]}),
+        )
+        .await;
+        // seq 3：499，下一轮（seq 4）不是它的延续（历史前缀对不上）→ 无证据，
+        // 保持 499，但上游确实消耗过的 prompt 仍要补记
+        insert(
+            &pool,
+            3,
+            499,
+            0,
+            0,
+            json!({"messages":[{"role":"user","content":"other session"}]}),
+        )
+        .await;
+        insert(
+            &pool,
+            4,
+            200,
+            900,
+            905,
+            json!({"messages":[{"role":"user","content":"completely unrelated"}]}),
+        )
+        .await;
+
+        // ── dry-run：不得改动任何行 ──
+        let dry = repair_pool(
+            &pool,
+            RepairInput {
+                apply: Some(false),
+                limit: Some(10),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert!(dry.dry_run);
+        assert_eq!(dry.scanned, 2, "两条 499 都应被扫到");
+        assert_eq!(dry.reclassified, 1, "只有有证据的那条判定为成功交付");
+        assert_eq!(dry.kept_cancelled, 1);
+        assert_eq!(dry.response_choices_restored, 1);
+        assert!(dry.prompt_tokens_added > 0);
+        let still_499: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM request_logs WHERE status_code=499")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(still_499, 2, "dry-run 不能改状态");
+        let marked: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM request_logs WHERE usage_source IS NOT NULL")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(marked, 0, "dry-run 不能打标记");
+
+        // ── apply ──
+        let run = repair_pool(
+            &pool,
+            RepairInput {
+                apply: Some(true),
+                limit: Some(10),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert!(!run.dry_run);
+        assert_eq!(run.reclassified, 1);
+        assert_eq!(run.remaining, 0, "apply 之后必须收敛到 0");
+
+        let repaired: (i64, i64, i64, i64, Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT status_code, prompt_tokens, completion_tokens, client_cancelled, \
+             error_message, usage_source FROM request_logs WHERE seq = 1",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(repaired.0, 200, "有证据的行应改判 200");
+        assert_eq!(repaired.3, 0, "client_cancelled 必须清零");
+        assert_eq!(repaired.4, None, "error_message 必须清空");
+        assert_eq!(repaired.5.as_deref(), Some("repaired"), "必须留痕");
+        // 参照行 prompt=1000、字节比落在窗口内 → 插值；completion 由恢复出的回复算出
+        assert!(repaired.1 > 0, "prompt 必须补上");
+        assert!(repaired.2 > 0, "completion 必须由恢复出的回复算出");
+
+        let choices: Option<String> =
+            sqlx::query_scalar("SELECT response_choices FROM request_logs WHERE seq = 1")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        let choices = choices.expect("response_choices 应被恢复");
+        assert!(choices.contains("hello there"), "{choices}");
+
+        // 无证据的 seq 3：保持 499，但 prompt 补记、同样留痕
+        let kept: (i64, i64, Option<String>) = sqlx::query_as(
+            "SELECT status_code, prompt_tokens, usage_source FROM request_logs WHERE seq = 3",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(kept.0, 499, "无证据的行不能改判成功");
+        assert!(kept.1 > 0, "上游确实消耗了 prompt，必须记上");
+        assert_eq!(kept.2.as_deref(), Some("repaired"));
+
+        // 参照行本身不受影响
+        let untouched: (i64, i64, Option<String>) = sqlx::query_as(
+            "SELECT prompt_tokens, total_tokens, usage_source FROM request_logs WHERE seq = 2",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(untouched.0, 1000);
+        assert_eq!(untouched.2, None, "非 499 行不该被碰");
+
+        // ── 幂等：再跑一次什么都不做 ──
+        let again = repair_pool(
+            &pool,
+            RepairInput {
+                apply: Some(true),
+                limit: Some(10),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(again.scanned, 0);
+        assert_eq!(again.remaining, 0);
+
+        pool.close().await;
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod channel;
 pub mod import_export;
 pub mod knowledge_base;
 pub mod log;
+pub mod log_repair;
 pub mod security;
 pub mod server;
 pub mod services;

--- a/src-tauri/src/endpoint_executor/driver.rs
+++ b/src-tauri/src/endpoint_executor/driver.rs
@@ -1195,9 +1195,64 @@ struct StreamLogFinalizer {
     upstream_type: String,
     started: Instant,
     completed: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// 生成器随流推进发布到这里的进度。客户端中途断开时 `Drop` 只能看到这份
+    /// 快照，用它把断开前已经产生的 token 用量补记进 499 行（此前恒为 0）。
+    progress: std::sync::Arc<std::sync::Mutex<Option<StreamCancelProgress>>>,
+}
+
+/// 客户端断开前已经观测到的流式进度，用于 499 行的用量补记。
+#[derive(Clone, Default)]
+struct StreamCancelProgress {
+    /// 上游已回传的 usage（prompt, completion, total, cached）。
+    usage: (i64, i64, i64, i64),
+    /// 已下发给下游的正文；上游没回传 usage 时用它做本地估算。
+    content: String,
 }
 
 impl StreamLogFinalizer {
+    /// 把当前进度发布给 finalizer。只在真正要向下游 yield 字节时调用，因此
+    /// 「有进度」等价于「响应已经开始交付」。
+    fn publish_progress(&self, pump: &StreamPumpCore) {
+        let usage = pump.usage();
+        let content = pump.accumulated_content().to_string();
+        if let Ok(mut slot) = self.progress.lock() {
+            let p = slot.get_or_insert_with(StreamCancelProgress::default);
+            p.usage = usage;
+            p.content = content;
+        }
+    }
+
+    /// 客户端断开：状态仍是 499 + client_cancelled，但用量按断开前已观测到的数据
+    /// 补记（上游回传优先，否则用已下发正文本地估算）。一个字节都没发出去时保持全 0
+    /// —— 那次请求上游可能根本没开始生成。
+    async fn write_cancelled(&self, progress: Option<StreamCancelProgress>) {
+        let mut usage = (0i64, 0i64, 0i64, 0i64);
+        if let Some(p) = progress.as_ref() {
+            usage = p.usage;
+            if usage.0 == 0 && usage.1 == 0 && usage.2 == 0 {
+                let req_body: serde_json::Value = serde_json::from_str(&self.sanitized_log_body)
+                    .unwrap_or(serde_json::Value::Null);
+                let (prompt, completion, total) = super::estimate_usage::estimate_usage(
+                    &req_body,
+                    Some(p.content.as_str()),
+                    &self.model,
+                );
+                usage = (prompt, completion, total, 0);
+            }
+        }
+        self.write(
+            true,
+            false,
+            Some("client_cancelled"),
+            usage.0,
+            usage.1,
+            usage.2,
+            usage.3,
+            None,
+        )
+        .await;
+    }
+
     async fn write(
         &self,
         client_cancelled: bool,
@@ -1307,9 +1362,9 @@ impl Drop for StreamLogFinalizer {
             self.completed
                 .store(true, std::sync::atomic::Ordering::SeqCst);
             let f = self.clone();
+            let progress = f.progress.lock().ok().and_then(|g| g.clone());
             tokio::spawn(async move {
-                f.write(true, false, Some("client_cancelled"), 0, 0, 0, 0, None)
-                    .await;
+                f.write_cancelled(progress).await;
             });
         }
     }
@@ -1362,12 +1417,15 @@ fn stream_response_body(
         upstream_type,
         started: Instant::now(),
         completed: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        progress: std::sync::Arc::new(std::sync::Mutex::new(None)),
     };
     let completed = finalizer.completed.clone();
 
     async_stream::stream! {
         let mut had_error = false;
         let mut error_message: Option<String> = None;
+        // 终止帧 / 错误帧交给下游之前就已经落库时为 true，函数末尾不再重复写日志。
+        let mut finalized = false;
 
         let upstream_bytes = upstream.body;
         tokio::pin!(upstream_bytes);
@@ -1379,6 +1437,19 @@ fn stream_response_body(
         match pump.start() {
             Ok(first) => {
                 if !first.is_empty() {
+                    if !finalized && downstream_terminal_frame(&mode_for_error, &first) {
+                        finalized = true;
+                        write_stream_log(
+                            &finalizer,
+                            &completed,
+                            false,
+                            None,
+                            StreamLogSnapshot::take(&pump),
+                        )
+                        .await;
+                    } else {
+                        finalizer.publish_progress(&pump);
+                    }
                     yield Ok::<_, std::io::Error>(bytes::Bytes::from(first));
                 }
             }
@@ -1393,6 +1464,19 @@ fn stream_response_body(
                 UpstreamItem::Chunk(Some(Ok(bytes))) => match pump.push(&bytes) {
                     Ok(out) => {
                         if !out.is_empty() {
+                            if !finalized && downstream_terminal_frame(&mode_for_error, &out) {
+                                finalized = true;
+                                write_stream_log(
+                                    &finalizer,
+                                    &completed,
+                                    false,
+                                    None,
+                                    StreamLogSnapshot::take(&pump),
+                                )
+                                .await;
+                            } else {
+                                finalizer.publish_progress(&pump);
+                            }
                             yield Ok::<_, std::io::Error>(bytes::Bytes::from(out));
                         }
                     }
@@ -1433,6 +1517,19 @@ fn stream_response_body(
             match pump.finish() {
                 Ok(out) => {
                     if !out.is_empty() {
+                        if !finalized && downstream_terminal_frame(&mode_for_error, &out) {
+                            finalized = true;
+                            write_stream_log(
+                                &finalizer,
+                                &completed,
+                                false,
+                                None,
+                                StreamLogSnapshot::take(&pump),
+                            )
+                            .await;
+                        } else {
+                            finalizer.publish_progress(&pump);
+                        }
                         yield Ok::<_, std::io::Error>(bytes::Bytes::from(out));
                     }
                 }
@@ -1446,39 +1543,140 @@ fn stream_response_body(
         // A downstream error before/after commit must produce a protocol
         // error event (never a retry, never a fake success).
         if had_error {
+            // 与终止帧同理：错误帧发出去后客户端也可能立刻关闭连接，日志必须先落库，
+            // 否则这条 502 会被 Drop 里的 client_cancelled 覆盖成 499。
+            if !finalized {
+                finalized = true;
+                write_stream_log(
+                    &finalizer,
+                    &completed,
+                    true,
+                    error_message.as_deref(),
+                    StreamLogSnapshot::take(&pump),
+                )
+                .await;
+            }
             let msg = error_message.clone().unwrap_or_else(|| "stream error".to_string());
             let ev = format_stream_error(&mode_for_error, &msg);
             yield Ok::<_, std::io::Error>(bytes::Bytes::from(ev));
         }
 
-        let (mut usage_prompt, mut usage_completion, mut usage_total, usage_cached) = pump.usage();
-
-        // Fallback: estimate tokens locally when upstream didn't return usage.
-        // Only estimate for successful streams (no error).
-        if usage_total == 0 && usage_prompt == 0 && usage_completion == 0 && !had_error {
-            let req_body: serde_json::Value = serde_json::from_str(&finalizer.sanitized_log_body).unwrap_or(serde_json::Value::Null);
-            let resp_text = pump.accumulated_content();
-            let (p, c, t) = super::estimate_usage::estimate_usage(&req_body, Some(resp_text), &finalizer.model);
-            usage_prompt = p;
-            usage_completion = c;
-            usage_total = t;
-            if usage_total > 0 {
-                eprintln!("[INFO] stream token usage estimated (upstream didn't return usage): prompt={}, completion={}, total={}", usage_prompt, usage_completion, usage_total);
-            }
-        }
-
-        // Mark the request completed so the Drop finalizer does NOT write a
-        // duplicate client_cancelled row, then write the normal log inline.
-        completed.store(true, std::sync::atomic::Ordering::SeqCst);
-        let response_choices = if !had_error {
-            pump.build_response_choices()
-        } else {
-            None
-        };
-        finalizer
-            .write(false, had_error, error_message.as_deref(), usage_prompt, usage_completion, usage_total, usage_cached, response_choices)
+        // 兜底：上游自然结束、终止帧没被单独识别出来（例如只发到 finish_reason 就 EOF）
+        // 时仍在这里写日志。已经落过库的请求不再重复写。
+        if !finalized {
+            write_stream_log(
+                &finalizer,
+                &completed,
+                had_error,
+                error_message.as_deref(),
+                StreamLogSnapshot::take(&pump),
+            )
             .await;
+        }
     }
+}
+
+/// 落库所需的 pump 侧快照。
+///
+/// 必须在 `await` 之前同步取好：`stream_response_body` 是 `async_stream` 生成器，
+/// 把 `&mut pump` 带过 `await` 会让生成器自引用。调用方只交出这个 owned 结构体，
+/// 跨 `await` 存活的只有 `&finalizer` / `&completed`（与改动前的收尾代码同形）。
+struct StreamLogSnapshot {
+    usage: (i64, i64, i64, i64),
+    response_choices: Option<String>,
+    accumulated_content: String,
+}
+
+impl StreamLogSnapshot {
+    fn take(pump: &StreamPumpCore) -> Self {
+        Self {
+            usage: pump.usage(),
+            response_choices: pump.build_response_choices(),
+            accumulated_content: pump.accumulated_content().to_string(),
+        }
+    }
+}
+
+/// 把一次流式请求的结果写成一条审计日志（成功，或已提交之后的流错误）。
+///
+/// 关键约束：**必须在终止帧交给下游之前调用**。终止帧一旦送达，客户端（Codex /
+/// Claude Code / Node undici 等 Agent）就会立刻关闭连接，hyper 不再轮询本流，
+/// 生成器直接被 drop；此时若日志还没写，`StreamLogFinalizer::drop` 会把一条完整
+/// 成功的流误记成 `499 / client_cancelled / 0 token / 空响应`。
+async fn write_stream_log(
+    finalizer: &StreamLogFinalizer,
+    completed: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    had_error: bool,
+    error_message: Option<&str>,
+    snapshot: StreamLogSnapshot,
+) {
+    let (mut usage_prompt, mut usage_completion, mut usage_total, usage_cached) = snapshot.usage;
+
+    // Fallback: estimate tokens locally when upstream didn't return usage.
+    // Only estimate for successful streams (no error).
+    if usage_total == 0 && usage_prompt == 0 && usage_completion == 0 && !had_error {
+        let req_body: serde_json::Value =
+            serde_json::from_str(&finalizer.sanitized_log_body).unwrap_or(serde_json::Value::Null);
+        let (p, c, t) = super::estimate_usage::estimate_usage(
+            &req_body,
+            Some(snapshot.accumulated_content.as_str()),
+            &finalizer.model,
+        );
+        usage_prompt = p;
+        usage_completion = c;
+        usage_total = t;
+        if usage_total > 0 {
+            eprintln!("[INFO] stream token usage estimated (upstream didn't return usage): prompt={}, completion={}, total={}", usage_prompt, usage_completion, usage_total);
+        }
+    }
+
+    // Mark the request completed so the Drop finalizer does NOT write a
+    // duplicate client_cancelled row, then write the log.
+    completed.store(true, std::sync::atomic::Ordering::SeqCst);
+    let response_choices = if had_error {
+        None
+    } else {
+        snapshot.response_choices
+    };
+    finalizer
+        .write(
+            false,
+            had_error,
+            error_message,
+            usage_prompt,
+            usage_completion,
+            usage_total,
+            usage_cached,
+            response_choices,
+        )
+        .await;
+}
+
+/// 判断这段下游字节里是否已经出现该协议的终止帧。
+///
+/// 出现即代表响应体已完整交给下游，之后下游怎么关连接都不影响本次请求的成功性。
+/// 逐行精确匹配而不是子串搜索：SSE 的 JSON 载荷里换行一定是 `\n` 转义，正文内容
+/// 不可能伪造出一个行首的终止帧。
+fn downstream_terminal_frame(mode: &str, out: &[u8]) -> bool {
+    let Ok(text) = std::str::from_utf8(out) else {
+        return false;
+    };
+    // 与 `format_stream_error` 使用同一套下游协议判定。
+    let terminal_event = match mode {
+        "anthropic" | "anthropic_count_tokens" => Some("message_stop"),
+        "responses" => Some("response.completed"),
+        _ => None,
+    };
+    text.lines().any(|line| {
+        let line = line.trim_end_matches('\r');
+        if let Some(name) = terminal_event {
+            line.strip_prefix("event:")
+                .is_some_and(|value| value.trim() == name)
+        } else {
+            line.strip_prefix("data:")
+                .is_some_and(|payload| payload.trim() == "[DONE]")
+        }
+    })
 }
 
 /// Walk an error's `source()` chain to its root and return it as a string.

--- a/src-tauri/src/endpoint_executor/estimate_usage.rs
+++ b/src-tauri/src/endpoint_executor/estimate_usage.rs
@@ -128,7 +128,7 @@ fn input_to_text(input: &Value) -> String {
 ///
 /// Falls back to a rough character-based estimate if the tokenizer fails
 /// to initialize (should never happen, but be defensive).
-fn count_tokens(text: &str) -> i64 {
+pub(crate) fn count_tokens(text: &str) -> i64 {
     if text.is_empty() {
         return 0;
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -281,6 +281,7 @@ pub fn run() {
             commands::log::delete_logs_before,
             commands::log::delete_all_logs,
             commands::log::get_log_stats,
+            commands::log_repair::repair_stream_cancel_logs,
             commands::stats::get_dashboard_stats,
             commands::stats::get_model_stats,
             commands::stats::get_token_trend,

--- a/src-tauri/src/rollout_integration_tests.rs
+++ b/src-tauri/src/rollout_integration_tests.rs
@@ -1844,6 +1844,188 @@ async fn stream_client_cancel_records_client_cancelled_log() {
     );
 }
 
+/// 499 误报回归：客户端**完整收完**流（含终止帧 `data: [DONE]`）后立刻断开连接。
+///
+/// Agent 类客户端（Node/undici、Codex、Claude Code…）拿到终止帧就 `res.destroy()`，
+/// 不会继续读到 HTTP chunked 的结束块。hyper 于是停止轮询 body，流式生成器在跑到
+/// 「写成功日志」那段代码之前就被 drop，`StreamLogFinalizer::drop` 把这条完全成功的
+/// 流记成 499 + client_cancelled + 0 token + 空响应。
+///
+/// 下面用「读到终止帧就停止轮询并 drop」精确模拟该时机（等价于 hyper 收到客户端 FIN
+/// 之后的行为，实测已在真机上验证：同一模型同一 key，读完即断 → 499，读到 EOF → 200）。
+#[tokio::test]
+async fn stream_client_close_after_terminal_frame_is_logged_as_success() {
+    use futures_util::StreamExt;
+
+    // 上游：[DONE] 之后再延迟 300ms 才发结束块，保证客户端断开时生成器还停在
+    // `upstream.next()` 上等 EOF，而不是已经自然收尾。
+    let sse = MockResponse::sse(vec![
+        b"data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\n".as_slice(),
+        b"data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2,\"total_tokens\":7}}\n\n".as_slice(),
+        b"data: [DONE]\n\n".as_slice(),
+    ])
+    .with_delay(300);
+    let mock = MockUpstream::start(move |_| sse.clone()).await;
+    let base = format!("http://{}", mock.addr);
+    let pool = fresh_db().await;
+    let key = api_key();
+    insert_api_key(&pool, &key).await;
+    let ch = channel(
+        "n1",
+        "openai",
+        "openai",
+        &base,
+        &["chat_completions"],
+        &["m"],
+        1,
+        "{}",
+    );
+    insert_channel(&pool, &ch).await;
+
+    let body = json!({"model":"m","messages":[{"role":"user","content":"hi"}],"stream":true});
+    let audit = audited(
+        DownstreamProtocol::ChatCompletions,
+        "/v1/chat/completions",
+        "m",
+        body.clone(),
+        true,
+    );
+    let plan = plan_for(
+        &pool,
+        &key,
+        EndpointKind::ChatCompletions,
+        "m",
+        &flags(true, true, true),
+        &body,
+    )
+    .await
+    .expect("plan");
+    let resp = run_stream(&pool, &key, &audit, plan, "chat").await;
+
+    // 读到终止帧就停：终止帧已经交付，之后连接怎么关都不该影响这条日志。
+    let mut stream = resp.into_body().into_data_stream();
+    let mut got: Vec<u8> = Vec::new();
+    while let Some(Ok(bytes)) = stream.next().await {
+        got.extend_from_slice(&bytes);
+        if String::from_utf8_lossy(&got).contains("data: [DONE]") {
+            break;
+        }
+    }
+    assert!(
+        String::from_utf8_lossy(&got).contains("data: [DONE]"),
+        "必须收到终止帧，实际: {}",
+        String::from_utf8_lossy(&got)
+    );
+    drop(stream);
+
+    // 等 Drop finalizer / 正常收尾落库。
+    tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+
+    let repo = Repository::new(pool.clone());
+    let logs = repo.get_logs(10, 0).await.unwrap();
+    assert_eq!(logs.len(), 1, "一次请求只应落一条日志，实际: {logs:?}");
+    let log = &logs[0];
+    assert_eq!(
+        log.status_code, 200,
+        "完整送达的流不能记成 {}（error={:?}）",
+        log.status_code, log.error_message
+    );
+    assert_eq!(log.client_cancelled, Some(0), "不能标记为客户端取消");
+    assert_eq!(log.total_tokens, 7, "token 用量必须落库");
+    assert!(
+        log.response_choices.as_deref().unwrap_or("").contains("hi"),
+        "响应内容必须落库"
+    );
+}
+
+/// 真·中途取消：状态仍然是 499 + client_cancelled=1（语义不变），但断开前已经产生的
+/// token 用量必须补记进日志。此前 `StreamLogFinalizer::drop` 硬编码 `0,0,0,0`，凡是
+/// 提前断开的请求在用量统计里一律算 0，看板与配额全部偏低。
+#[tokio::test]
+async fn stream_client_cancel_backfills_token_usage() {
+    use futures_util::StreamExt;
+
+    // 多数供应商只在最后一帧回传 usage：客户端在第一段正文之后就断开，上游 usage 还
+    // 没到，此时必须用已下发的正文本地估算，而不是记 0。
+    let sse = MockResponse::sse(vec![
+        b"data: {\"choices\":[{\"delta\":{\"content\":\"first chunk of a fairly long answer\"}}]}\n\n".as_slice(),
+        b"data: {\"choices\":[{\"delta\":{\"content\":\"second chunk of the answer\"}}]}\n\n".as_slice(),
+        b"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":7,\"total_tokens\":18}}\n\n".as_slice(),
+        b"data: [DONE]\n\n".as_slice(),
+    ])
+    .with_delay(200);
+    let mock = MockUpstream::start(move |_| sse.clone()).await;
+    let base = format!("http://{}", mock.addr);
+    let pool = fresh_db().await;
+    let key = api_key();
+    insert_api_key(&pool, &key).await;
+    let ch = channel(
+        "n1",
+        "openai",
+        "openai",
+        &base,
+        &["chat_completions"],
+        &["m"],
+        1,
+        "{}",
+    );
+    insert_channel(&pool, &ch).await;
+
+    let body = json!({"model":"m","messages":[{"role":"user","content":"hi"}],"stream":true});
+    let audit = audited(
+        DownstreamProtocol::ChatCompletions,
+        "/v1/chat/completions",
+        "m",
+        body.clone(),
+        true,
+    );
+    let plan = plan_for(
+        &pool,
+        &key,
+        EndpointKind::ChatCompletions,
+        "m",
+        &flags(true, true, true),
+        &body,
+    )
+    .await
+    .expect("plan");
+    let resp = run_stream(&pool, &key, &audit, plan, "chat").await;
+
+    // 只读走第一段内容就结束任务：body 被 drop，等价于客户端中途断开。
+    let handle = tokio::spawn(async move {
+        let mut stream = resp.into_body().into_data_stream();
+        let _ = stream.next().await;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(120)).await;
+    handle.abort();
+    let _ = handle.await;
+    tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+
+    let repo = Repository::new(pool.clone());
+    let logs = repo.get_logs(10, 0).await.unwrap();
+    let cancelled: Vec<_> = logs
+        .iter()
+        .filter(|l| l.status_code == 499 && l.client_cancelled == Some(1))
+        .collect();
+    assert_eq!(cancelled.len(), 1, "取消日志必须恰好一条，实际: {logs:?}");
+    assert_eq!(
+        cancelled[0].error_message.as_deref(),
+        Some("client_cancelled")
+    );
+    assert!(
+        cancelled[0].total_tokens > 0,
+        "断开前已产生的用量必须补记，实际 prompt={} completion={} total={}",
+        cancelled[0].prompt_tokens,
+        cancelled[0].completion_tokens,
+        cancelled[0].total_tokens
+    );
+    assert!(
+        cancelled[0].completion_tokens > 0,
+        "已下发的正文必须折算出 completion tokens"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // SECURITY & PERMISSIONS (all must produce ZERO upstream calls)
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/server/admin_routes.rs
+++ b/src-tauri/src/server/admin_routes.rs
@@ -448,6 +448,14 @@ async fn dispatch(shared: &SharedState, cmd: &str, args: Value) -> Result<Value,
             to_json(commands::log::delete_logs_before(arg(&args, "beforeDate")?, state).await)
         }
         "delete_all_logs" => to_json(commands::log::delete_all_logs(state).await),
+        // 历史 499 日志一次性修复：默认 dry-run，input.apply=true 才写库。
+        // input 缺省为 {}，让不带参数直接调用也能拿到报告。
+        "repair_stream_cancel_logs" => {
+            let input = args.get("input").cloned().unwrap_or_else(|| json!({}));
+            let input: commands::log_repair::RepairInput =
+                serde_json::from_value(input).map_err(|e| format!("参数 input 无效: {e}"))?;
+            to_json(commands::log_repair::repair_stream_cancel_logs(input, state).await)
+        }
 
         // ── Auth 账号 ──
         "auth_accounts_list" => to_json(commands::auth::auth_accounts_list(state).await),


### PR DESCRIPTION
## 问题

桌面端审计日志里大量 `499` + `client_cancelled`，响应内容为空、token 用量为 0，
但流式输出对下游 Agent 完全正常 —— 思维链和正文都能拿到。

本机实测：873 条 499 里 **870 条来自同一个 Agent 类 API key**；同一模型、同一渠道在
另外两个 key 下拿到的是 200。可见与上游供应商无关，也与下游无关。

## 根因

`stream_response_body` 的成功日志写在 `async_stream::stream!` 生成器**最后一次
`yield` 之后**，只有消费者再轮询一次才会执行到。Agent 类客户端（Codex / Claude Code /
Node undici 等）拿到终止帧 `[DONE]` 就立刻关闭连接，hyper 检测到对端关闭后不再轮询、
直接 drop 掉 body，于是 `StreamLogFinalizer::drop` 的兜底路径接管落库，而那条路径是
硬编码的：

```rust
f.write(true /* client_cancelled */, false, Some("client_cancelled"),
        0, 0, 0, 0 /* token 全 0 */, None /* 响应内容空 */)
```

三个症状（499 / token=0 / 响应空）全部由此解释。全仓库 `499` 只有这一处写入点。

**差分实测**（同一份 DB 副本、同一 key、同一模型，唯一变量 = 客户端何时关连接）：

| 客户端行为 | 修复前 | 修复后 |
|:---|:---|:---|
| 读满 `[DONE]` 立刻 close | 499 / 0 tokens / 无响应 | **200 / 113 tokens / 有响应** |
| 读到 EOF | 200 / 113 tokens | 200 / 112 tokens |
| 终止帧之前断开（真取消） | 499 / **0 tokens** | 499 / **39 tokens（补记）** |

## 提交一：前向修复（`endpoint_executor/driver.rs`）

1. `downstream_terminal_frame()` 按**下游协议**逐行精确识别终止帧
   （chat `data: [DONE]` / anthropic `event: message_stop` / responses
   `event: response.completed`）。逐行匹配而非子串搜索：SSE 的 JSON 载荷里换行一定是
   `\n` 转义，正文伪造不出行首终止帧。
2. 在 `start` / `push` / `finish` 三个产出点于 `yield` **之前**检测终止帧，命中即先把
   200 + 真实 usage + 响应内容落库，`finalized` 标记防止尾部重复写。
3. 流错误帧同理先落 502 再 `yield` —— 原来 502 也会被随后的客户端断开覆盖成 499。
4. 落库逻辑抽成 `StreamLogSnapshot` + `write_stream_log()`。快照必须在 `await` 之前
   同步取好：把 `&mut pump` 带过 `await` 会让 `async_stream` 生成器自引用；跨 await
   存活的只有 `&finalizer` / `&completed`，与改动前的收尾代码同形。
5. 真·中途取消仍记 `499 + client_cancelled=1`（语义不变），但通过 `StreamCancelProgress`
   共享进度槽补记断开前已观测到的用量：上游 usage 优先，否则用已下发正文本地估算；
   一个字节都没 yield 过则保持全 0（那次请求上游可能尚未开始生成）。

回归测试两条：
- `stream_client_close_after_terminal_frame_is_logged_as_success`
  —— 回退本补丁后确实失败，报 `完整送达的流不能记成 499（error=Some("client_cancelled")）`
- `stream_client_cancel_backfills_token_usage`

## 提交二：历史数据修复命令

前一条只修未来，已落库的行需要单独恢复。

**判定不用启发式打分，用内容级证据**：Agent 的对话历史是累积的，若第 N 轮真的产出了
被下游采用的回复，同会话第 N+1 轮请求的 `messages` 里必然多出第 N 轮那条 assistant
消息。据此既能证明"本轮其实成功了"，又能顺带把本轮的响应正文和 completion tokens
一起恢复出来。参照行的 `messages` 必须与目标行**前缀逐条相等**才采信（否则说明换了
会话或客户端压缩过历史），判定偏保守：拿不到证据的行保持 499。

prompt tokens 分两层恢复：邻近真实行按 `request_body` 字节比插值，窗口外退到
`estimate_usage` 本地 BPE。

### 入口与可达性

```
waliapi-web repair-stream-logs [--data-dir <目录>] [--apply] [--limit <行>]
                               [--status-only | --usage-only]
```
以及 Tauri command `repair_stream_cancel_logs`（`/admin/api/invoke` 同名 cmd）。

两点已核实，说明桌面用户真的能自助使用：
- **`waliapi-web.exe` 随 Windows 安装包发布**（Tauri 生成的 `wix/x64/main.wxs` 与
  `nsis/x64/installer.nsi` 均包含该二进制），无需额外下载；
- **不带 `--data-dir` 时命中桌面端同一个库**：`resolve_data_dir` 的 Windows 分支返回
  `%APPDATA%\<APP_IDENTIFIER>`，与 `app.path().app_data_dir()` 一致。

刻意**不做成 migration**：migration 会在每个用户启动时自动跑、静默改写他们的历史数据，
而且 SQL 里跑不了 tiktoken。

### 状态改判与用量回填是两个独立开关

两者成本与精度来源完全不同：

| | 做什么 | 本机 1.73 GB 库 / 873 行实测 |
|:---|:---|:---|
| `--status-only` | 只做消息前缀比对，改判 499→200 | **79.9 秒**（857 行改判，token 全部保持 0） |
| 缺省 / `--usage-only` | 还要对 request_body 跑 BPE | 约 23 分钟 |

开关是真正跳过计算、不是只跳过写入（`plan_repair` 收到 `with_usage=false` 时完全不
调用 tokenizer）。两个开关同时关闭会显式报错。

### 安全边界

- **默认 dry-run**，只报告不改库；`--apply` 才写入。dry-run 只扫一批即退出
  （不写库时 `remaining` 不会收敛，否则会死循环）。
- 只处理 `usage_source IS NULL` 的行 → 天然幂等，且**任何时刻 Ctrl+C 都安全**：
  已处理的行带标记不会被重扫，未处理的仍是候选，重跑即续。
- **不动 `api_keys.quota_used`**：配额语义是否同步是独立决策，留给使用者。
- 回填值一律标 `usage_source='repaired'`，与上游实测值可区分，避免历史估算永久
  冒充实测数据。
- 帮助文本要求先停实例：SQLite 以默认 `journal_mode=delete`（回滚日志）打开，写事务
  提交需要 EXCLUSIVE 锁，而网关每请求至少一次读 + 一次写。风险性质是**可恢复而非危险**
  —— 最坏情况是个别日志行写入失败或回填中途退出，重跑即续，不会损坏库。

### 已知局限（已写进代码注释，避免后人误信）

插值层在本机实际只命中 **0.8%**（7/873）：499 行往往连续成串（回溯链中位 44 行、
P90 123 行），后继本身通常也是 `prompt_tokens=0` 的 499 行，没有可锚的真实值。
剩下 99.2% 落到 BPE —— 这正是 23 分钟的来源。

改用前驱行为锚点可把命中提到 91.9%，且精度更高（434 对"两行都有上游真实
prompt_tokens"的相邻样本留一验证：中位误差 **0.01%**、P90 0.41%、94.5% 误差 ≤1%）。
但链式插值会 telescoping 成 `prompt(锚点) × chars(N)/chars(锚点)`，等价于直接用远
锚点，严格窗口下覆盖率只回升到 17.3% —— **精度受益、耗时不受益**。真正能同时改善
两者的是增量法（只对每轮新增的几 KB 跑 BPE 再累加），属后续优化，本 PR 未做。

## 验证

**单元/集成测试**
- `cargo test --no-fail-fast`：**765 passed / 2 failed**
  （`security_gate_block_zero_upstream`、`codex_login::export_is_nested_private_...`
  —— 已确认 `git diff main v0.2.8 -- src/security/ src/auth_provider/` 为空，
  这两个测试的代码与 main 逐字一致，属 v0.2.8 继承失败，与本 PR 无关）
- 新增 14 个测试：2 个流式回归 + 12 个修复命令测试
  （含内存库 + 真实迁移跑通"扫描 → 证据判定 → 落库 → 幂等"全链路、dry-run 不得改动
  任何行的断言、两个 scope 各自只改自己那部分的断言、双关开关显式报错）
- `cargo fmt --check`：仓库基线 114 处 pre-existing 差异，本分支仍是 114 处，**净增 0**
- `cargo clippy --all-targets`：`log_repair.rs` / `waliapi-web.rs` **零命中**，
  lib 告警数 211 与基线持平

**真实生产库端到端**（1.73 GB、873 条历史 499）
- `--apply` 全量：15 批 / 873 行 / `remaining=0`，**改判 857 条为 200、16 条无证据
  保持 499、0 条疑似真取消**，补记 prompt 147,027,054 + completion 587,507 tokens，
  857 行恢复 `response_choices`
- 回写后 live 库 `499` 计数 **873 → 16**，`quota_used` 三个 key 全部未被改动
- 回写后新产生的流式请求持续记为 `200` + 真实 token + `client_cancelled=0`
- 另做了一次等价性核对：直接对目标库跑本命令的结果，与"先修副本、再按 id 回写"的结果
  在 873 行 × 8 个字段上**逐字节一致（差异 0）**，说明命令输出稳定可复现

## 已知取舍

- 日志写在终止帧交给 hyper **之前**，实测 3 条 SQLite 写入约 20–30ms，即 `[DONE]`
  到客户端会晚这么多。取舍是"宁可少报一条取消，也不把成功流误报成失败"。
- 若客户端恰在写库之后、终止帧真正送达之前死掉 → 记成 200 但客户端没收到终止帧。
- 终止帧之后才到达的 usage 帧（极少数供应商）不计入。
- 已 rebase 到 `v0.2.8`（`3aff3e1`），与上游对 `stream_response_body` 的重写
  （`UpstreamItem` / `next_upstream_item` / `idle_timeout`）合并，v0.2.8 新增的
  `buffer_first_record` 诊断与 idle timeout 测试全部保留。`tests/request_log.rs` 的
  `reasoning_effort` 字段 v0.2.8 已自行修好，本 PR 不再涉及。

## 本 PR 有意未做（可作后续）

- **修复命令没有 UI 入口**：`src/` 与 `web/src/` 里对 `repair_stream_cancel_logs` 的
  引用为 0 处。命令行已覆盖绝大多数场景；若希望完全不停机的用户能自助，值得在日志页
  加一个按钮调用进程内 command（约 40 行前端，复用现有后端）。
- `estimate_usage` 只统计 `delta.content`，不含 `reasoning_content`；非流式路径的
  `extract_response_text()` 同样不取 Anthropic 的 `thinking` 块。但上游真实回传的
  `completion_tokens` 本身**是包含** reasoning tokens 的（OpenAI 把
  `completion_tokens_details.reasoning_tokens` 作为其子集，Anthropic 的 thinking 也
  计入 `output_tokens`）—— 这是估算路径与实测路径口径不一致、估算路径少算，属 bug
  而非口径变更。未一并修是因为它会同时改变既有 200 行的数字，需要维护者定夺。
- 那条 `[INFO] stream token usage estimated` 用的是 `eprintln!`，桌面端无控制台，
  这行日志在桌面版里根本看不到（本机日志目录搜索 0 命中），是可观测性缺口。
- 实时路径尚未写入 `usage_source`（目前只有回填命令会写 `repaired`）。列已预留
  `upstream` / `estimated` / `interpolated` 语义，补上需要把来源信息透到落库处。

## 版本号 / CHANGELOG

未改 `package.json` / `Cargo.toml` / `tauri.conf.json` / `Cargo.lock` 版本号，也未改
`CHANGELOG.md`，按仓库惯例留给维护者在发版时统一处理。