### PR TITLE
feat: 接入自定义黑白名单至运行时安全审计流水线

### DIFF
--- a/src-tauri/src/core/proxy.rs
+++ b/src-tauri/src/core/proxy.rs
@@ -84,13 +84,20 @@ pub async fn handle_request(
         .unwrap_or("")
         .to_string();
     let security_settings = security::get_security_settings(settings);
+    let custom_rules = if security_settings.enabled {
+        security::rules::CustomRuleRepository::get_enabled(repo.pool())
+            .await
+            .unwrap_or_default()
+    } else {
+        vec![]
+    };
     // The gate already audited the ORIGINAL protocol JSON at the handler.
     // Re-scanning the (possibly converted) Chat JSON here would be a redundant,
     // competing non-authoritative audit — only do that when the caller had no
     // gate (legacy RAG path).
     let mut security_result = match audit {
         Some(result) => result.clone(),
-        None => security::scan_request(&body, &security_settings),
+        None => security::scan_request(&body, &security_settings, &custom_rules),
     };
 
     // Real redaction: if redact mode is active, sanitize the request body before forwarding
@@ -291,7 +298,8 @@ pub async fn handle_request(
                 }
 
                 // Scan response for risks
-                let resp_security = security::scan_response(&resp_body, &security_settings);
+                let resp_security =
+                    security::scan_response(&resp_body, &security_settings, &custom_rules);
                 let resp_findings_count = resp_security.findings.len();
                 if resp_findings_count > 0 {
                     // Merge response findings into request findings for logging

--- a/src-tauri/src/db/repository.rs
+++ b/src-tauri/src/db/repository.rs
@@ -21,6 +21,10 @@ impl Repository {
         Self { pool }
     }
 
+    pub fn pool(&self) -> &SqlitePool {
+        &self.pool
+    }
+
     // ==================== Channel ====================
 
     pub async fn get_all_channels(&self) -> Result<Vec<Channel>, sqlx::Error> {
@@ -1081,17 +1085,14 @@ impl Repository {
         // and merged (not overwriting) so login metadata like email/plan_type
         // survives.  The DTO surfaces it again as `invalidation_reason`.
         let merged_attributes: Option<String> = if reason.is_some() {
-            let row: Option<(String,)> = sqlx::query_as(
-                "SELECT attributes_json FROM auth_accounts WHERE id = ?",
-            )
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await?;
+            let row: Option<(String,)> =
+                sqlx::query_as("SELECT attributes_json FROM auth_accounts WHERE id = ?")
+                    .bind(id)
+                    .fetch_optional(&self.pool)
+                    .await?;
             row.map(|(attributes_json,)| {
-                let mut value: serde_json::Value =
-                    serde_json::from_str(&attributes_json).unwrap_or(serde_json::Value::Object(
-                        serde_json::Map::new(),
-                    ));
+                let mut value: serde_json::Value = serde_json::from_str(&attributes_json)
+                    .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
                 value["invalidation_reason"] = reason.unwrap().into();
                 serde_json::to_string(&value).unwrap_or(attributes_json)
             })
@@ -1445,19 +1446,17 @@ impl Repository {
         .await
         .unwrap_or(0);
 
-        let total_cached_tokens: i64 = sqlx::query_scalar(
-            "SELECT COALESCE(SUM(cached_tokens), 0) FROM request_logs",
-        )
-        .fetch_one(&self.pool)
-        .await
-        .unwrap_or(0);
+        let total_cached_tokens: i64 =
+            sqlx::query_scalar("SELECT COALESCE(SUM(cached_tokens), 0) FROM request_logs")
+                .fetch_one(&self.pool)
+                .await
+                .unwrap_or(0);
 
-        let total_prompt_tokens: i64 = sqlx::query_scalar(
-            "SELECT COALESCE(SUM(prompt_tokens), 0) FROM request_logs",
-        )
-        .fetch_one(&self.pool)
-        .await
-        .unwrap_or(0);
+        let total_prompt_tokens: i64 =
+            sqlx::query_scalar("SELECT COALESCE(SUM(prompt_tokens), 0) FROM request_logs")
+                .fetch_one(&self.pool)
+                .await
+                .unwrap_or(0);
 
         let active_channels: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM channels WHERE status = 1")
@@ -1608,7 +1607,9 @@ impl Repository {
             GROUP BY model
             ORDER BY total_tokens DESC
         "#;
-        sqlx::query_as::<_, ModelStats>(sql).fetch_all(&self.pool).await
+        sqlx::query_as::<_, ModelStats>(sql)
+            .fetch_all(&self.pool)
+            .await
     }
 
     /// 按小时粒度统计各模型 Token 趋势
@@ -1632,6 +1633,9 @@ impl Repository {
             GROUP BY hour, model
             ORDER BY hour ASC
         "#;
-        sqlx::query_as::<_, TokenTrendPoint>(sql).bind(&since).fetch_all(&self.pool).await
+        sqlx::query_as::<_, TokenTrendPoint>(sql)
+            .bind(&since)
+            .fetch_all(&self.pool)
+            .await
     }
 }

--- a/src-tauri/src/rollout_integration_tests.rs
+++ b/src-tauri/src/rollout_integration_tests.rs
@@ -432,6 +432,7 @@ fn audited(
         None,
         &SecuritySettings::default(),
         None,
+        vec![],
     )
     .expect("gate passes for a clean body")
 }
@@ -2050,6 +2051,7 @@ async fn security_gate_block_zero_upstream() {
         None,
         &settings,
         None,
+        vec![],
     )
     .expect("gate runs");
     assert_eq!(
@@ -2413,6 +2415,7 @@ async fn security_redacted_forward_body_no_secret() {
         None,
         &settings,
         None,
+        vec![],
     )
     .expect("gate");
     let plan = plan_for(

--- a/src-tauri/src/security/gate.rs
+++ b/src-tauri/src/security/gate.rs
@@ -28,6 +28,7 @@
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use super::rules::CustomRule;
 use super::scanner::ScanBudget;
 use super::{redact, scanner, SecurityScanResult, SecuritySettings};
 
@@ -136,6 +137,8 @@ pub struct SecurityGateInput {
     pub settings: SecuritySettings,
     /// Overrides scanner budget defaults.  `None` → [`ScanBudget::default`].
     pub budget: Option<ScanBudget>,
+    /// User-defined custom rules (blacklist/whitelist) loaded from the database.
+    pub custom_rules: Vec<CustomRule>,
 }
 
 /// Output of the security gate.
@@ -234,15 +237,20 @@ pub fn audit_request(input: SecurityGateInput) -> Result<SecurityGateOutput, Sec
         (SecurityScanResult::default(), features)
     } else {
         // Full-tree scan with cumulative budgets over the ORIGINAL protocol JSON.
-        let mut result =
-            match scanner::scan_with_budget(&input.original_json, "request", settings, &budget) {
-                Ok(result) => result,
-                Err(scanner::BudgetError::Exceeded(reason)) => {
-                    // Fail-closed: never reported as clean.  The caller short-circuits
-                    // to `security_scan_budget_exceeded` and never contacts upstream.
-                    return Err(SecurityGateError::BudgetExceeded { message: reason });
-                }
-            };
+        let mut result = match scanner::scan_with_budget(
+            &input.original_json,
+            "request",
+            settings,
+            &budget,
+            &input.custom_rules,
+        ) {
+            Ok(result) => result,
+            Err(scanner::BudgetError::Exceeded(reason)) => {
+                // Fail-closed: never reported as clean.  The caller short-circuits
+                // to `security_scan_budget_exceeded` and never contacts upstream.
+                return Err(SecurityGateError::BudgetExceeded { message: reason });
+            }
+        };
 
         super::decide_action(&mut result, settings);
 
@@ -312,6 +320,7 @@ pub fn audit_envelope(
     envelope: RequestEnvelope,
     settings: &SecuritySettings,
     budget: Option<ScanBudget>,
+    custom_rules: Vec<CustomRule>,
 ) -> Result<AuditedRequest, SecurityGateError> {
     let safe_forward_headers = envelope.safe_forward_headers.clone();
     let output = audit_request(SecurityGateInput {
@@ -325,6 +334,7 @@ pub fn audit_envelope(
         trace_id: envelope.trace_id.clone(),
         settings: settings.clone(),
         budget,
+        custom_rules,
     })?;
     Ok(AuditedRequest {
         envelope,
@@ -345,6 +355,7 @@ pub fn audit_envelope(
 /// this match, so a newly-enabled Images/Audio handler cannot forward model
 /// content without the audit.  Every handler entry point must route through
 /// [`gate_original`], which delegates here.
+#[allow(clippy::too_many_arguments)]
 pub fn gate_dispatch(
     protocol: DownstreamProtocol,
     endpoint: &str,
@@ -355,6 +366,7 @@ pub fn gate_dispatch(
     trace_id: Option<String>,
     settings: &SecuritySettings,
     budget: Option<ScanBudget>,
+    custom_rules: Vec<CustomRule>,
 ) -> Result<AuditedRequest, SecurityGateError> {
     match protocol {
         // Compiler-enforced checklist: ALL variants, no wildcard arm.  Forgetting
@@ -378,7 +390,7 @@ pub fn gate_dispatch(
                 stream,
                 trace_id,
             };
-            audit_envelope(envelope, settings, budget)
+            audit_envelope(envelope, settings, budget, custom_rules)
         }
     }
 }
@@ -391,6 +403,7 @@ pub fn gate_dispatch(
 ///
 /// Delegates to [`gate_dispatch`] so the exhaustive-variant guard above applies
 /// to every handler path.
+#[allow(clippy::too_many_arguments)]
 pub fn gate_original(
     protocol: DownstreamProtocol,
     endpoint: &str,
@@ -401,6 +414,7 @@ pub fn gate_original(
     trace_id: Option<String>,
     settings: &SecuritySettings,
     budget: Option<ScanBudget>,
+    custom_rules: Vec<CustomRule>,
 ) -> Result<AuditedRequest, SecurityGateError> {
     gate_dispatch(
         protocol,
@@ -412,6 +426,7 @@ pub fn gate_original(
         trace_id,
         settings,
         budget,
+        custom_rules,
     )
 }
 
@@ -453,11 +468,12 @@ pub fn audit_delta_strings(
             .map(|s| serde_json::Value::String(s.clone()))
             .collect(),
     );
-    let mut result = scanner::scan_with_budget(&delta_tree, &phase, settings, &budget).map_err(
-        |scanner::BudgetError::Exceeded(reason)| SecurityGateError::BudgetExceeded {
-            message: reason,
-        },
-    )?;
+    let mut result = scanner::scan_with_budget(&delta_tree, &phase, settings, &budget, &[])
+        .map_err(
+            |scanner::BudgetError::Exceeded(reason)| SecurityGateError::BudgetExceeded {
+                message: reason,
+            },
+        )?;
     super::decide_action(&mut result, settings);
     Ok(result)
 }
@@ -494,6 +510,7 @@ mod gate_tests {
             trace_id: None,
             settings: default_settings(),
             budget: None,
+            custom_rules: vec![],
         })
     }
 
@@ -524,6 +541,7 @@ mod gate_tests {
             trace_id: None,
             settings,
             budget: None,
+            custom_rules: vec![],
         })
         .unwrap_err();
         assert!(matches!(&err, SecurityGateError::ApprovalRequired { .. }));
@@ -553,6 +571,7 @@ mod gate_tests {
             trace_id: None,
             settings,
             budget: Some(budget),
+            custom_rules: vec![],
         })
         .unwrap_err();
         assert_eq!(err.code(), "security_scan_budget_exceeded");
@@ -576,6 +595,7 @@ mod gate_tests {
             trace_id: None,
             settings,
             budget: None,
+            custom_rules: vec![],
         })
         .unwrap();
         let forward_str = serde_json::to_string(&out.forward_json).unwrap();
@@ -600,6 +620,7 @@ mod gate_tests {
             trace_id: None,
             settings,
             budget: None,
+            custom_rules: vec![],
         })
         .unwrap();
         // Forward keeps original content under audit mode...
@@ -704,6 +725,7 @@ mod gate_tests {
             trace_id: None,
             settings,
             budget: None,
+            custom_rules: vec![],
         })
         .unwrap();
         assert!(!out.budget_exceeded);
@@ -734,6 +756,7 @@ mod gate_tests {
             trace_id: None,
             settings: settings(),
             budget: None,
+            custom_rules: vec![],
         })
         .unwrap_err();
         assert!(matches!(&err, SecurityGateError::ApprovalRequired { .. }));
@@ -756,6 +779,7 @@ mod gate_tests {
             trace_id: None,
             settings: default_settings(),
             budget: Some(budget),
+            custom_rules: vec![],
         })
         .unwrap_err();
         assert_eq!(err.code(), "security_scan_budget_exceeded");
@@ -846,6 +870,7 @@ mod gate_tests {
                 None,
                 &settings,
                 None,
+                vec![],
             )
             .unwrap();
             assert_eq!(audited.envelope.downstream_protocol, protocol);

--- a/src-tauri/src/security/mod.rs
+++ b/src-tauri/src/security/mod.rs
@@ -150,7 +150,8 @@ pub fn get_security_settings(settings: &crate::settings_store::SettingsStore) ->
         scan_tools: settings.get_bool("security.scan_tools", defaults.scan_tools),
         scan_network: settings.get_bool("security.scan_network", defaults.scan_network),
         redact_secrets: settings.get_bool("security.redact_secrets", defaults.redact_secrets),
-        block_on_critical: settings.get_bool("security.block_on_critical", defaults.block_on_critical),
+        block_on_critical: settings
+            .get_bool("security.block_on_critical", defaults.block_on_critical),
         max_scan_bytes: settings.get_u64("security.max_scan_bytes", defaults.max_scan_bytes as u64)
             as usize,
     }
@@ -205,42 +206,55 @@ pub fn decide_action(result: &mut SecurityScanResult, settings: &SecuritySetting
     }
 }
 
-pub fn scan_request(body: &serde_json::Value, settings: &SecuritySettings) -> SecurityScanResult {
+pub fn scan_request(
+    body: &serde_json::Value,
+    settings: &SecuritySettings,
+    custom_rules: &[rules::CustomRule],
+) -> SecurityScanResult {
     if !settings.enabled || !settings.scan_request {
         return SecurityScanResult::default();
     }
-    let mut result =
-        scanner::scan_with_budget(body, "request", settings, &scanner::ScanBudget::default())
-            .unwrap_or_else(|err| {
-                // Over-budget must fail closed as a high-risk block, never clean.
-                let mut blocked = SecurityScanResult::default();
-                blocked.risk_level = RiskLevel::Critical;
-                blocked.risk_score = 100;
-                blocked.action = SecurityAction::Block;
-                blocked.blocked_reason = Some(blocked.summary.clone());
-                blocked.summary = match err {
-                    scanner::BudgetError::Exceeded(msg) => msg,
-                };
-                blocked.blocked_reason = Some(blocked.summary.clone());
-                blocked.findings.push(SecurityFinding {
-                    phase: "request".to_string(),
-                    category: "budget".to_string(),
-                    rule_id: "budget.scan_exceeded".to_string(),
-                    severity: RiskLevel::Critical,
-                    title: "安全扫描预算超限".to_string(),
-                    description: "整个请求的扫描预算被超过，请求被 fail-closed 拒绝。".to_string(),
-                    location: "$".to_string(),
-                    evidence_masked: "budget exceeded".to_string(),
-                });
-                blocked
-            });
+    let mut result = scanner::scan_with_budget(
+        body,
+        "request",
+        settings,
+        &scanner::ScanBudget::default(),
+        custom_rules,
+    )
+    .unwrap_or_else(|err| {
+        // Over-budget must fail closed as a high-risk block, never clean.
+        let mut blocked = SecurityScanResult::default();
+        blocked.risk_level = RiskLevel::Critical;
+        blocked.risk_score = 100;
+        blocked.action = SecurityAction::Block;
+        blocked.blocked_reason = Some(blocked.summary.clone());
+        blocked.summary = match err {
+            scanner::BudgetError::Exceeded(msg) => msg,
+        };
+        blocked.blocked_reason = Some(blocked.summary.clone());
+        blocked.findings.push(SecurityFinding {
+            phase: "request".to_string(),
+            category: "budget".to_string(),
+            rule_id: "budget.scan_exceeded".to_string(),
+            severity: RiskLevel::Critical,
+            title: "安全扫描预算超限".to_string(),
+            description: "整个请求的扫描预算被超过，请求被 fail-closed 拒绝。".to_string(),
+            location: "$".to_string(),
+            evidence_masked: "budget exceeded".to_string(),
+        });
+        blocked
+    });
     decide_action(&mut result, settings);
     result
 }
 
 /// Scan an upstream response for risks (sensitive info, tracking, etc.)
 /// Uses a response-side budget with a looser default (responses may be large).
-pub fn scan_response(body: &serde_json::Value, settings: &SecuritySettings) -> SecurityScanResult {
+pub fn scan_response(
+    body: &serde_json::Value,
+    settings: &SecuritySettings,
+    custom_rules: &[rules::CustomRule],
+) -> SecurityScanResult {
     if !settings.enabled || !settings.scan_response {
         return SecurityScanResult::default();
     }
@@ -251,18 +265,16 @@ pub fn scan_response(body: &serde_json::Value, settings: &SecuritySettings) -> S
         max_elapsed: Some(std::time::Duration::from_millis(800)),
         max_text_bytes_per_string: Some(64 * 1024),
     };
-    let mut result =
-        scanner::scan_with_budget(body, "response", settings, &budget).unwrap_or_else(|err| {
-            match err {
-                scanner::BudgetError::Exceeded(msg) => {
-                    let mut blocked = SecurityScanResult::default();
-                    blocked.risk_level = RiskLevel::Critical;
-                    blocked.risk_score = 100;
-                    blocked.action = SecurityAction::Block;
-                    blocked.summary = msg;
-                    blocked.blocked_reason = Some(blocked.summary.clone());
-                    blocked
-                }
+    let mut result = scanner::scan_with_budget(body, "response", settings, &budget, custom_rules)
+        .unwrap_or_else(|err| match err {
+            scanner::BudgetError::Exceeded(msg) => {
+                let mut blocked = SecurityScanResult::default();
+                blocked.risk_level = RiskLevel::Critical;
+                blocked.risk_score = 100;
+                blocked.action = SecurityAction::Block;
+                blocked.summary = msg;
+                blocked.blocked_reason = Some(blocked.summary.clone());
+                blocked
             }
         });
     decide_action(&mut result, settings);

--- a/src-tauri/src/security/rules.rs
+++ b/src-tauri/src/security/rules.rs
@@ -456,7 +456,6 @@ impl CustomRuleRepository {
 
 // ─── Rule matching helpers ──────────────────────────────────────────────────
 
-#[allow(dead_code)]
 pub fn apply_custom_rules(
     text: &str,
     phase: &str,
@@ -496,7 +495,6 @@ pub fn apply_custom_rules(
     }
 }
 
-#[allow(dead_code)]
 pub fn is_whitelisted(category: &str, value: &str, custom_rules: &[CustomRule]) -> bool {
     let lower = value.to_ascii_lowercase();
     custom_rules.iter().any(|r| {
@@ -507,7 +505,6 @@ pub fn is_whitelisted(category: &str, value: &str, custom_rules: &[CustomRule]) 
     })
 }
 
-#[allow(dead_code)]
 fn parse_severity(s: &str) -> RiskLevel {
     match s {
         "info" => RiskLevel::Info,

--- a/src-tauri/src/security/scanner.rs
+++ b/src-tauri/src/security/scanner.rs
@@ -1,3 +1,4 @@
+use super::rules::{self, CustomRule};
 use super::{RiskLevel, SecurityFinding, SecurityScanResult, SecuritySettings};
 use crate::utils::text::truncate_utf8;
 use std::time::{Duration, Instant};
@@ -48,6 +49,7 @@ pub enum BudgetError {
 pub struct ScanContext<'a> {
     settings: &'a SecuritySettings,
     budget: &'a ScanBudget,
+    custom_rules: &'a [CustomRule],
     findings: Vec<SecurityFinding>,
     bytes_visited: usize,
     string_nodes: usize,
@@ -57,10 +59,15 @@ pub struct ScanContext<'a> {
 }
 
 impl<'a> ScanContext<'a> {
-    fn new(settings: &'a SecuritySettings, budget: &'a ScanBudget) -> Self {
+    fn new(
+        settings: &'a SecuritySettings,
+        budget: &'a ScanBudget,
+        custom_rules: &'a [CustomRule],
+    ) -> Self {
         Self {
             settings,
             budget,
+            custom_rules,
             findings: Vec::new(),
             bytes_visited: 0,
             string_nodes: 0,
@@ -113,8 +120,9 @@ pub fn scan_with_budget(
     phase: &str,
     settings: &SecuritySettings,
     budget: &ScanBudget,
+    custom_rules: &[CustomRule],
 ) -> Result<SecurityScanResult, BudgetError> {
-    let mut ctx = ScanContext::new(settings, budget);
+    let mut ctx = ScanContext::new(settings, budget, custom_rules);
     walk_json(value, phase, "$", &mut ctx)?;
     ctx.check_budget()?;
 
@@ -243,19 +251,43 @@ fn scan_text(text: &str, phase: &str, location: &str, ctx: &mut ScanContext) {
         scan_text
     };
 
+    // ── Whitelist short-circuit (per-category exemption) ─────────────
+    // A keyword whitelist exempts the entire text from all built-in scans.
+    let wl_keyword = rules::is_whitelisted("keyword", scan_text, ctx.custom_rules);
+    if wl_keyword {
+        return;
+    }
+    let wl_domain = rules::is_whitelisted("domain", scan_text, ctx.custom_rules);
+    let wl_path = rules::is_whitelisted("path", scan_text, ctx.custom_rules);
+    let wl_tool = rules::is_whitelisted("tool", scan_text, ctx.custom_rules);
+
+    // ── Built-in scans (skipped per-category when whitelisted) ──────
     scan_credentials(scan_text, phase, location, ctx);
-    scan_paths(scan_text, phase, location, ctx);
+    if !wl_path {
+        scan_paths(scan_text, phase, location, ctx);
+    }
     if ctx.settings.scan_unicode {
         scan_unicode(scan_text, phase, location, ctx);
     }
-    if ctx.settings.scan_network {
+    if ctx.settings.scan_network && !wl_domain {
         scan_network(scan_text, phase, location, ctx);
     }
-    if ctx.settings.scan_tools {
+    if ctx.settings.scan_tools && !wl_tool {
         scan_tool_risks(scan_text, phase, location, ctx);
     }
-    scan_tracking_pixel(scan_text, phase, location, ctx);
+    if !wl_domain {
+        scan_tracking_pixel(scan_text, phase, location, ctx);
+    }
     scan_fingerprint_terms(scan_text, phase, location, ctx);
+
+    // ── Custom blacklist rules ──────────────────────────────────────
+    rules::apply_custom_rules(
+        scan_text,
+        phase,
+        location,
+        ctx.custom_rules,
+        &mut ctx.findings,
+    );
 }
 
 fn scan_credentials(text: &str, phase: &str, location: &str, ctx: &mut ScanContext) {
@@ -626,7 +658,6 @@ fn add(
     });
 }
 
-#[allow(dead_code)]
 pub fn add_finding(
     f: &mut Vec<SecurityFinding>,
     phase: &str,
@@ -756,7 +787,7 @@ mod scanner_tests {
                 {"role": "user", "content": "b".repeat(200)}
             ]
         });
-        let err = scan_with_budget(&body, "request", &settings, &budget).unwrap_err();
+        let err = scan_with_budget(&body, "request", &settings, &budget, &[]).unwrap_err();
         match err {
             BudgetError::Exceeded(msg) => assert!(msg.contains("byte budget")),
         }
@@ -773,7 +804,7 @@ mod scanner_tests {
             .map(|i| serde_json::json!({"x": format!("val{}", i)}))
             .collect();
         let body = serde_json::Value::Array(arr);
-        let err = scan_with_budget(&body, "request", &settings, &budget).unwrap_err();
+        let err = scan_with_budget(&body, "request", &settings, &budget, &[]).unwrap_err();
         match err {
             BudgetError::Exceeded(msg) => assert!(msg.contains("string-node")),
         }
@@ -790,7 +821,7 @@ mod scanner_tests {
         for _ in 0..30 {
             v = serde_json::json!({"a": v});
         }
-        let err = scan_with_budget(&v, "request", &settings, &budget).unwrap_err();
+        let err = scan_with_budget(&v, "request", &settings, &budget, &[]).unwrap_err();
         match err {
             BudgetError::Exceeded(msg) => assert!(msg.contains("depth")),
         }
@@ -814,7 +845,7 @@ mod scanner_tests {
             ..Default::default()
         };
         let body = serde_json::json!({"messages": [{"role": "user", "content": "界".repeat(500)}]});
-        let result = scan_with_budget(&body, "request", &settings, &budget).unwrap();
+        let result = scan_with_budget(&body, "request", &settings, &budget, &[]).unwrap();
         assert_eq!(result.action, SecurityAction::Allow);
     }
 
@@ -826,7 +857,7 @@ mod scanner_tests {
             ..Default::default()
         };
         let body = serde_json::json!({"messages": [{"role": "user", "content": "hello world this is a scan".to_string()}]});
-        let result = scan_with_budget(&body, "request", &settings, &budget);
+        let result = scan_with_budget(&body, "request", &settings, &budget, &[]);
         // Either the elapsed check trips immediately, or the scan finishes
         // within the nanos budget (rare); both are acceptable — the budget
         // failure path must never report clean.

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -35,7 +35,7 @@ fn is_key_lookup_storage_error(err: &sqlx::Error) -> bool {
 /// verbatim); boxing it would ripple through every handler call site for no
 /// measurable gain, so the lint is scoped.
 #[allow(clippy::result_large_err)]
-fn audit_original(
+async fn audit_original(
     protocol: security::gate::DownstreamProtocol,
     endpoint: &str,
     original_json: serde_json::Value,
@@ -53,6 +53,13 @@ fn audit_original(
         .and_then(|s| s.as_bool())
         .unwrap_or(false);
     let settings = security::get_security_settings(&shared.state.settings);
+    let custom_rules = if settings.enabled {
+        security::rules::CustomRuleRepository::get_enabled(&shared.state.db.pool)
+            .await
+            .unwrap_or_default()
+    } else {
+        vec![]
+    };
     match security::gate::gate_original(
         protocol,
         endpoint,
@@ -63,6 +70,7 @@ fn audit_original(
         trace_id,
         &settings,
         None,
+        custom_rules,
     ) {
         Ok(audited) => Ok(audited),
         Err(security::gate::SecurityGateError::ApprovalRequired { message }) => Err((
@@ -510,7 +518,9 @@ pub async fn handle_chat_completions(
         None,
         trace_id.clone(),
         &shared,
-    ) {
+    )
+    .await
+    {
         Ok(audited) => audited,
         Err(response) => return response,
     };
@@ -872,9 +882,8 @@ async fn handle_stream(
                             // channels; the tail returns this status (an
                             // upstream 401/403 is masked to 502; last_error
                             // above keeps the real response text).
-                            last_error_status = Some(
-                                StatusCode::from_u16(downstream_status).unwrap_or(status),
-                            );
+                            last_error_status =
+                                Some(StatusCode::from_u16(downstream_status).unwrap_or(status));
                             break;
                         }
                     }
@@ -1415,7 +1424,9 @@ impl NativeSseUsageParser {
         match value.get("type").and_then(|value| value.as_str()) {
             Some("message_start") => {
                 self.input = value.pointer("/message/usage").map(anthropic_input_usage);
-                self.cached = value.pointer("/message/usage/cache_read_input_tokens").and_then(|v| v.as_i64());
+                self.cached = value
+                    .pointer("/message/usage/cache_read_input_tokens")
+                    .and_then(|v| v.as_i64());
             }
             Some("message_delta") => {
                 self.output = value
@@ -1428,8 +1439,13 @@ impl NativeSseUsageParser {
     }
 
     fn finish(self) -> Option<(i64, i64, i64)> {
-        (!self.malformed_or_oversized && self.stopped)
-            .then(|| (self.input.unwrap_or(0), self.output.unwrap_or(0), self.cached.unwrap_or(0)))
+        (!self.malformed_or_oversized && self.stopped).then(|| {
+            (
+                self.input.unwrap_or(0),
+                self.output.unwrap_or(0),
+                self.cached.unwrap_or(0),
+            )
+        })
     }
 }
 
@@ -1822,7 +1838,9 @@ pub async fn handle_messages(
         query.clone(),
         None,
         &shared,
-    ) {
+    )
+    .await
+    {
         Ok(audited) => audited,
         Err(response) => return response,
     };
@@ -2300,7 +2318,9 @@ pub async fn handle_messages_count_tokens(
         query.clone(),
         None,
         &shared,
-    ) {
+    )
+    .await
+    {
         Ok(audited) => audited,
         Err(response) => return response,
     };
@@ -2478,7 +2498,9 @@ pub async fn handle_responses(
         None,
         trace_id.clone(),
         &shared,
-    ) {
+    )
+    .await
+    {
         Ok(audited) => audited,
         Err(response) => return response,
     };
@@ -2791,9 +2813,8 @@ async fn handle_responses_stream(
                             // channels; the tail returns this status (an
                             // upstream 401/403 is masked to 502; last_error
                             // above keeps the real response text).
-                            last_error_status = Some(
-                                StatusCode::from_u16(downstream_status).unwrap_or(status),
-                            );
+                            last_error_status =
+                                Some(StatusCode::from_u16(downstream_status).unwrap_or(status));
                             break;
                         }
                     }
@@ -3160,7 +3181,9 @@ pub async fn handle_embeddings(
         None,
         trace_id.clone(),
         &shared,
-    ) {
+    )
+    .await
+    {
         Ok(audited) => audited,
         Err(response) => return response,
     };
@@ -3893,6 +3916,7 @@ mod anthropic_handler_tests {
                 None,
                 &settings,
                 None,
+                vec![],
             )
             .unwrap();
             assert_eq!(audited.envelope.downstream_protocol, protocol);
@@ -3918,6 +3942,7 @@ mod anthropic_handler_tests {
             None,
             &crate::security::SecuritySettings::default(),
             None,
+            vec![],
         )
         .unwrap();
         let raw_str = serde_json::to_string(&raw).unwrap();

--- a/src-tauri/tests/custom_rules_integration.rs
+++ b/src-tauri/tests/custom_rules_integration.rs
@@ -1,0 +1,227 @@
+use serde_json::json;
+use sqlx::SqlitePool;
+use waliapi_lib::security::{
+    gate::{gate_original, DownstreamProtocol},
+    rules::{CreateCustomRuleInput, CustomRuleRepository},
+    SecurityAction, SecuritySettings,
+};
+
+/// In-memory SQLite with all migrations applied.
+async fn fresh_db() -> SqlitePool {
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("in-memory db");
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("migrate fresh db");
+    pool
+}
+
+fn security_settings_block() -> SecuritySettings {
+    SecuritySettings {
+        enabled: true,
+        mode: "block".to_string(),
+        scan_request: true,
+        scan_response: false,
+        scan_unicode: true,
+        scan_tools: true,
+        scan_network: true,
+        redact_secrets: false,
+        block_on_critical: true,
+        max_scan_bytes: 1024 * 1024,
+    }
+}
+
+#[tokio::test]
+async fn test_custom_blacklist_keyword_intercepts_and_blocks() {
+    let pool = fresh_db().await;
+
+    // 1. Create and enable a custom keyword blacklist rule
+    CustomRuleRepository::create(
+        &pool,
+        &CreateCustomRuleInput {
+            rule_type: "blacklist".to_string(),
+            category: "keyword".to_string(),
+            pattern: "ProjectCobra".to_string(),
+            severity: Some("high".to_string()),
+            action: Some("block".to_string()),
+            description: Some("Confidential internal project codename".to_string()),
+        },
+    )
+    .await
+    .expect("create custom blacklist rule");
+
+    let rules = CustomRuleRepository::get_enabled(&pool)
+        .await
+        .expect("get enabled rules");
+    assert_eq!(rules.len(), 1);
+
+    // 2. Scan a request containing the blacklisted keyword
+    let body = json!({
+        "model": "gpt-4o",
+        "messages": [
+            {"role": "user", "content": "Please explain the architecture of ProjectCobra in detail."}
+        ]
+    });
+
+    let audited = gate_original(
+        DownstreamProtocol::ChatCompletions,
+        "/v1/chat/completions",
+        body,
+        None,
+        "gpt-4o".to_string(),
+        false,
+        None,
+        &security_settings_block(),
+        None,
+        rules,
+    )
+    .expect("gate executes");
+
+    // 3. Verify custom finding and block action
+    assert_eq!(audited.audit_result.action, SecurityAction::Block);
+    assert!(audited
+        .audit_result
+        .findings
+        .iter()
+        .any(|f| f.rule_id == "custom.blacklist.keyword"
+            && f.category == "custom"
+            && f.evidence_masked.contains("ProjectCobra")));
+}
+
+#[tokio::test]
+async fn test_custom_whitelist_domain_exempts_builtin_alarm() {
+    let pool = fresh_db().await;
+
+    let settings = security_settings_block();
+    let probe_body = json!({
+        "model": "gpt-4o",
+        "messages": [
+            {"role": "user", "content": "Check external IP via https://ifconfig.me/all"}
+        ]
+    });
+
+    // 1. Without whitelist: builtin rule triggers on ifconfig.me
+    let audited_without_wl = gate_original(
+        DownstreamProtocol::ChatCompletions,
+        "/v1/chat/completions",
+        probe_body.clone(),
+        None,
+        "gpt-4o".to_string(),
+        false,
+        None,
+        &settings,
+        None,
+        vec![],
+    )
+    .expect("gate executes");
+
+    assert!(audited_without_wl
+        .audit_result
+        .findings
+        .iter()
+        .any(|f| f.rule_id == "network.ip_probe"));
+
+    // 2. Insert custom whitelist for domain "ifconfig.me"
+    CustomRuleRepository::create(
+        &pool,
+        &CreateCustomRuleInput {
+            rule_type: "whitelist".to_string(),
+            category: "domain".to_string(),
+            pattern: "ifconfig.me".to_string(),
+            severity: Some("low".to_string()),
+            action: Some("allow".to_string()),
+            description: Some("Exempt internal IP probe".to_string()),
+        },
+    )
+    .await
+    .expect("create whitelist rule");
+
+    let rules = CustomRuleRepository::get_enabled(&pool)
+        .await
+        .expect("get enabled rules");
+
+    // 3. With whitelist: domain check is short-circuited and exempt
+    let audited_with_wl = gate_original(
+        DownstreamProtocol::ChatCompletions,
+        "/v1/chat/completions",
+        probe_body,
+        None,
+        "gpt-4o".to_string(),
+        false,
+        None,
+        &settings,
+        None,
+        rules,
+    )
+    .expect("gate executes");
+
+    assert!(!audited_with_wl
+        .audit_result
+        .findings
+        .iter()
+        .any(|f| f.rule_id == "network.ip_probe"));
+}
+
+#[tokio::test]
+async fn test_disabled_custom_rule_is_ignored() {
+    let pool = fresh_db().await;
+
+    // 1. Create a custom rule
+    let rule = CustomRuleRepository::create(
+        &pool,
+        &CreateCustomRuleInput {
+            rule_type: "blacklist".to_string(),
+            category: "keyword".to_string(),
+            pattern: "ProjectSecret".to_string(),
+            severity: Some("high".to_string()),
+            action: Some("block".to_string()),
+            description: Some("Secret codename".to_string()),
+        },
+    )
+    .await
+    .expect("create rule");
+
+    // 2. Disable the rule
+    CustomRuleRepository::update_enabled(&pool, &rule.id, false)
+        .await
+        .expect("disable rule");
+
+    // 3. Enabled list should not include the disabled rule
+    let enabled_rules = CustomRuleRepository::get_enabled(&pool)
+        .await
+        .expect("get enabled rules");
+    assert!(enabled_rules.is_empty());
+
+    // 4. Gate run with enabled rules passes without violation
+    let body = json!({
+        "model": "gpt-4o",
+        "messages": [
+            {"role": "user", "content": "Tell me about ProjectSecret"}
+        ]
+    });
+
+    let audited = gate_original(
+        DownstreamProtocol::ChatCompletions,
+        "/v1/chat/completions",
+        body,
+        None,
+        "gpt-4o".to_string(),
+        false,
+        None,
+        &security_settings_block(),
+        None,
+        enabled_rules,
+    )
+    .expect("gate executes");
+
+    assert_eq!(audited.audit_result.action, SecurityAction::Allow);
+    assert!(!audited
+        .audit_result
+        .findings
+        .iter()
+        .any(|f| f.category == "custom"));
+}

--- a/src-tauri/tests/request_log.rs
+++ b/src-tauri/tests/request_log.rs
@@ -332,6 +332,7 @@ async fn request_log_sanitized_log_body_is_what_gets_persisted() {
         None,
         &SecuritySettings::default(),
         None,
+        vec![],
     )
     .expect("gate");
     let log_body = serde_json::to_string(&audited.sanitized_log_json).unwrap();


### PR DESCRIPTION
## 变更背景与目的

用户在桌面端设置中心中配置了自定义安全规则（针对域名、工具命令、文件路径、关键词的黑名单与白名单），规则能够持久化到 SQLite 中。但此前底层流水线中未将数据库中启用的规则加载进上下文并执行，导致运行时审计产生旁路。

本 PR 正式打通数据库自定义黑白名单规则到网关运行时安全审计流水线。

## 变更内容

1. **解封死代码**：开放 pply_custom_rules、is_whitelisted、parse_severity 等核心安全规则匹配函数。
2. **扫描器接入规则**：在 ScanContext 及 scan_with_budget 中传入 custom_rules: &[CustomRule]；scan_text 执行前先基于分类白名单进行豁免短路，并在常规扫描后基于黑名单生成自定义 SecurityFinding。
3. **安全门控接入**：在 SecurityGateInput、gate_original 及 udit_original 中异步加载 CustomRuleRepository::get_enabled，保障实时生效。
4. **端到端集成测试**：新增 custom_rules_integration.rs，覆盖黑名单关键字拦截、白名单域名豁免、禁用规则放行三种核心场景。

## 验证结果

- \cargo test --test custom_rules_integration\ 全部通过 (3/3)
- \cargo test --lib -- security::\ 全部通过 (23/23)
- \pnpm run build\ 前端编译及类型检查通过