### PR TITLE
fix: allow large Codex response created SSE frame

### DIFF
--- a/src-tauri/src/auth_provider/codex_backend.rs
+++ b/src-tauri/src/auth_provider/codex_backend.rs
@@ -123,10 +123,28 @@ impl CodexProvider {
             header::CONTENT_TYPE,
             header::HeaderValue::from_static("application/json"),
         );
+        headers.insert(
+            header::ACCEPT,
+            header::HeaderValue::from_static("text/event-stream"),
+        );
+        headers.insert(
+            header::USER_AGENT,
+            header::HeaderValue::from_static(CODEX_USER_AGENT),
+        );
+        headers.insert(
+            header::HeaderName::from_static("originator"),
+            header::HeaderValue::from_static(CODEX_ORIGINATOR),
+        );
+        headers.insert(
+            header::HeaderName::from_static("chatgpt-account-id"),
+            header::HeaderValue::from_str(&account.account_id)
+                .map_err(|_| ProviderError::InvalidPayload)?,
+        );
 
         // Only a small non-auth whitelist survives the account boundary.  In
         // particular caller Authorization and x-openai-actor-authorization are
-        // never relayed to a subscription account.
+        // never relayed to a subscription account. Accept/User-Agent may
+        // override the defaults for JSON-only probes such as model listing.
         for name in [header::ACCEPT, header::USER_AGENT] {
             if let Some(value) = caller_headers.get(&name) {
                 headers.insert(name, value.clone());
@@ -226,15 +244,6 @@ impl Provider for CodexProvider {
         headers.insert(
             header::USER_AGENT,
             header::HeaderValue::from_static(CODEX_USER_AGENT),
-        );
-        headers.insert(
-            header::HeaderName::from_static("originator"),
-            header::HeaderValue::from_static(CODEX_ORIGINATOR),
-        );
-        headers.insert(
-            header::HeaderName::from_static("chatgpt-account-id"),
-            header::HeaderValue::from_str(&account.account_id)
-                .map_err(|_| ProviderError::InvalidPayload)?,
         );
         let response = self
             .client

--- a/src-tauri/src/endpoint_executor/driver.rs
+++ b/src-tauri/src/endpoint_executor/driver.rs
@@ -1078,6 +1078,7 @@ pub(crate) async fn route_stream_plan_with_auth_service(
 
 /// Bounded, single-line preview of raw upstream bytes for diagnostics.
 const FIRST_RECORD_SNIPPET_BYTES: usize = 240;
+const MAX_FIRST_RECORD_BYTES: usize = 4 * 1024 * 1024;
 
 fn upstream_snippet(bytes: &[u8], max_bytes: usize) -> String {
     let truncated = if bytes.len() > max_bytes {
@@ -1123,7 +1124,7 @@ async fn buffer_first_record(
     };
     loop {
         // Bound the first-frame buffer (a malicious upstream must not OOM us).
-        if buffer.len() > 256 * 1024 {
+        if buffer.len() > MAX_FIRST_RECORD_BYTES {
             return Err(format!(
                 "received {} bytes with no SSE record terminator{ct_note}; preview: \"{}\"",
                 buffer.len(),
@@ -1783,6 +1784,34 @@ mod tests {
         let diagnostic = buffer_first_record(&mut upstream).await.unwrap_err();
         assert!(diagnostic.contains("failed validation"), "{diagnostic}");
         assert!(diagnostic.contains("not valid json"), "{diagnostic}");
+    }
+
+    /// ChatGPT Codex can emit a very large first `response.created` event
+    /// because the response object echoes request metadata/tools.  The commit
+    /// barrier must wait for the real SSE terminator instead of treating a
+    /// >256 KiB but otherwise valid first record as a protocol failure.
+    #[tokio::test]
+    async fn buffer_first_record_accepts_large_codex_created_event() {
+        let large_metadata = "x".repeat(300 * 1024);
+        let record = format!(
+            "event: response.created\ndata: {}\n\n",
+            serde_json::json!({
+                "type": "response.created",
+                "response": {
+                    "id": "resp_test",
+                    "object": "response",
+                    "status": "in_progress",
+                    "metadata": { "large": large_metadata }
+                },
+                "sequence_number": 0
+            })
+        );
+        let mut upstream = upstream_from_chunks(vec![record.as_bytes()]);
+
+        let (first_frame, carry) = buffer_first_record(&mut upstream).await.unwrap();
+
+        assert_eq!(first_frame, record.as_bytes());
+        assert!(carry.is_empty());
     }
 
     /// Non-SSE content-type must be called out in the diagnostic.


### PR DESCRIPTION
## Summary
- preserve Codex-specific response headers on proxied auth-provider requests
- increase the first SSE record buffering limit so large `response.created` events from ChatGPT/Codex are accepted
- add a focused regression test for the large first SSE frame case

## Problem
Codex requests to `/v1/responses` could fail with `upstream stream ended before a valid first SSE record` when the upstream emitted a large `response.created` SSE event. The previous first-record guard was 256 KiB, but Codex account/model metadata can make the initial event larger than that before the SSE record terminator is observed.

## Verification
- `cargo test --manifest-path src-tauri/Cargo.toml endpoint_executor::driver::tests::buffer_first_record_accepts_large_codex_created_event --lib`
- `cargo test --manifest-path src-tauri/Cargo.toml auth_provider::codex_backend --lib`
- `git diff --check`
- built Docker image `waliapi:v0.2.8-p01` for `linux/amd64` and smoke-tested `/health`
