### PR TITLE
feat(auth): Auth 账号额度改为剩余展示

### DIFF
--- a/src/components/auth/QuotaBlock.tsx
+++ b/src/components/auth/QuotaBlock.tsx
@@ -1,5 +1,6 @@
 import { Clock3 } from "lucide-react";
 import type { AuthQuotaLimit, AuthQuotaWindow } from "../../types";
+import { quotaDisplayState } from "./quotaDisplay";
 
 // `window_minutes` is in minutes: 5h = 300, 7d = 10080, 30d = 43200.
 const MINUTES_5H = 5 * 60;
@@ -42,18 +43,18 @@ function windowLabel(window: AuthQuotaWindow) {
 }
 
 function QuotaWindow({ limit, window }: { limit: AuthQuotaLimit; window: AuthQuotaWindow }) {
-  const used = Math.max(0, Math.min(100, window.used_percent ?? 0));
-  const exhausted = used >= 100;
-  const barColor = exhausted ? "bg-destructive" : used >= 70 ? "bg-warning" : "bg-success";
+  const { remaining, tone } = quotaDisplayState(window.used_percent);
+  const exhausted = tone === "destructive";
+  const barColor = tone === "destructive" ? "bg-destructive" : tone === "warning" ? "bg-warning" : "bg-success";
   const reset = resetLabel(window.reset_at);
   return (
     <div className="rounded-xl border border-border bg-muted/45 p-3">
       <div className="flex items-center justify-between gap-3 text-xs">
         <span className="flex items-center gap-1.5 font-medium"><Clock3 size={13} className="text-muted-foreground" />限额 · {limit.limit_name || windowLabel(window)}</span>
-        <span className={exhausted ? "font-semibold text-destructive" : "font-semibold text-muted-foreground"}>{used.toFixed(0)}% 已用</span>
+        <span className={exhausted ? "font-semibold text-destructive" : "font-semibold text-muted-foreground"}>{remaining == null ? "剩余 --" : `剩余 ${remaining.toFixed(0)}%`}</span>
       </div>
       <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-card">
-        <div className={`h-full rounded-full ${barColor}`} style={{ width: `${used}%` }} />
+        <div className={`h-full rounded-full ${barColor}`} style={{ width: `${remaining ?? 0}%` }} />
       </div>
       {reset && <p className="mt-2 text-[11px] text-muted-foreground">重置 {reset} · {limit.limit_id}</p>}
     </div>

--- a/src/components/auth/quotaDisplay.test.mjs
+++ b/src/components/auth/quotaDisplay.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { quotaDisplayState } from "./quotaDisplay.ts";
+
+test("converts used quota into the remaining balance and matching tone", () => {
+  assert.deepEqual(quotaDisplayState(25), { remaining: 75, tone: "success" });
+  assert.deepEqual(quotaDisplayState(73), { remaining: 27, tone: "warning" });
+  assert.deepEqual(quotaDisplayState(100), { remaining: 0, tone: "destructive" });
+});
+
+test("clamps out-of-range used quota before calculating the balance", () => {
+  assert.deepEqual(quotaDisplayState(-20), { remaining: 100, tone: "success" });
+  assert.deepEqual(quotaDisplayState(150), { remaining: 0, tone: "destructive" });
+});
+
+test("keeps the remaining balance unknown when used quota is absent", () => {
+  assert.deepEqual(quotaDisplayState(null), { remaining: null, tone: "unknown" });
+});

--- a/src/components/auth/quotaDisplay.ts
+++ b/src/components/auth/quotaDisplay.ts
@@ -1,0 +1,10 @@
+export type QuotaTone = "success" | "warning" | "destructive" | "unknown";
+
+export function quotaDisplayState(usedPercent: number | null): { remaining: number | null; tone: QuotaTone } {
+  if (usedPercent == null) return { remaining: null, tone: "unknown" };
+
+  const used = Math.max(0, Math.min(100, usedPercent));
+  const remaining = 100 - used;
+  const tone = remaining === 0 ? "destructive" : remaining <= 30 ? "warning" : "success";
+  return { remaining, tone };
+}


### PR DESCRIPTION
## 改动说明

- 将 Auth 账号额度从“已用百分比”改为“剩余百分比”
- 进度条宽度与颜色同步表达剩余额度
- 对越界用量进行 0–100 截断
- 用量缺失时显示“剩余 --”，避免误判为满额
- 保持后端 used_percent、路由熔断和重置时间逻辑不变

## 验证

- `node --experimental-strip-types --test src/components/auth/quotaDisplay.test.mjs`
- `pnpm build`
- `pnpm --filter waliapi-web build`
- 本地 Web 页面人工验收通过