### PR TITLE
fix(usage): 连接测试请求头不得写入中文占位密钥

### DIFF
--- a/src/pages/UsagePage.tsx
+++ b/src/pages/UsagePage.tsx
@@ -133,13 +133,18 @@ export function UsagePage() {
   const [keyValue, setKeyValue] = useState("");
   const [keyValueLoading, setKeyValueLoading] = useState(false);
   useEffect(() => { setKeyValue(""); }, [selKey]);
-  const loadKeyValue = async () => {
-    if (!selKey || keyValue || keyValueLoading) return;
+  const loadKeyValue = async (): Promise<string> => {
+    if (!selKey) return "";
+    if (keyValue) return keyValue;
+    if (keyValueLoading) return "";
     setKeyValueLoading(true);
     try {
-      setKeyValue(await apiKeyApi.getFull(selKey));
+      const full = await apiKeyApi.getFull(selKey);
+      setKeyValue(full);
+      return full;
     } catch (e) {
       console.error("Failed to load full key:", e);
+      return "";
     } finally {
       setKeyValueLoading(false);
     }
@@ -411,15 +416,25 @@ public class AnthropicTest {
     setTestState("running"); setTestResult(""); setTestLatency(null);
     const startTime = performance.now();
     try {
+      // FIX：测试请求头必须用真实密钥。占位文案含中文全角括号，塞进 header 会触发
+      // 浏览器 "String contains non ISO-8859-1 code point" 直接抛错；未载入时先取回。
+      let realKey = keyValue;
+      if (!realKey) realKey = await loadKeyValue();
+      if (!realKey) {
+        setTestState("error");
+        setTestResult("未能载入完整密钥：请先在左侧点击「载入密钥」，确认密钥有效后再测试。");
+        return;
+      }
+
       const isAnthropic = activeProtocol === "anthropic";
       const isResponses = activeProtocol === "responses";
       const url = endpoints[activeProtocol];
       const headers: Record<string, string> = { "Content-Type": "application/json" };
       if (isAnthropic) {
-        headers["x-api-key"] = selKey;
+        headers["x-api-key"] = realKey;
         headers["anthropic-version"] = "2023-06-01";
       } else {
-        headers["Authorization"] = `Bearer ${keyForSamples}`;
+        headers["Authorization"] = `Bearer ${realKey}`;
       }
       let body: string;
       if (isAnthropic) {
@@ -629,8 +644,8 @@ public class AnthropicTest {
                 {/* FIX-13：按需载入完整密钥后才能复制/生成真实示例 */}
                 <button
                   onClick={async () => {
-                    await loadKeyValue();
-                    if (keyValue) { await copy(keyValue, "key"); }
+                    const full = await loadKeyValue();
+                    if (full) { await copy(full, "key"); }
                   }}
                   disabled={!selKey}
                   className="action-secondary px-3 py-2.5 disabled:opacity-50"


### PR DESCRIPTION
## 问题

「LLM 使用」页点击「发送测试请求」时，若尚未点击「载入密钥」，会抛出：

```
Request failed: Failed to execute 'fetch' on 'Window': Failed to read the
'headers' property from 'RequestInit': String contains non ISO-8859-1 code point.
```

同时页面展示：

```
Causes:
1. Server not running
2. Invalid key
3. Upstream channel error
```

这段 `Causes` 是 catch 分支里的固定兜底文案，并非真实诊断，容易把排查引向服务端/上游渠道。

## 根因

测试请求直接使用了 `keyForSamples`，在密钥未载入时它的值是占位文案：

```js
const keyForSamples = keyValue || "sk-waliapi-****（点击「载入密钥」后填充）";
```

该文案含中文全角字符，而 HTTP 头值必须为 ISO-8859-1，浏览器在构造 `Request` 时即拒绝，请求根本没有发出——所以下面三项 Causes 都不成立。

## 修复

- `loadKeyValue` 改为返回取到的完整密钥，供调用方直接使用，避免读取尚未刷新的 `keyValue` 状态
- `handleTest` 先确保拿到真实密钥再发请求；取回失败时给出明确提示，不再发出含非法字符的请求
- **顺带修复**：Anthropic 协议分支此前用掩码 `selKey`（`sk-****`）作为 `x-api-key`，导致该协议下即使载入密钥也永远使用掩码值；现已统一改用真实密钥
- 复制按钮同样改用 `loadKeyValue` 的返回值

## 验证

- `pnpm exec tsc --noEmit -p tsconfig.json` 通过
- 在「LLM 使用」页直接点击「发送测试请求」（不预先载入密钥）：不再出现 `non ISO-8859-1` 报错，请求正常发出或返回网关真实错误

## 影响范围

仅 `src/pages/UsagePage.tsx`，无后端改动、无依赖变更。