### PR TITLE
fix(auth): 修复 Sub2API 批量导入账号未显示

### DIFF
--- a/src-tauri/src/auth_provider/codex_login.rs
+++ b/src-tauri/src/auth_provider/codex_login.rs
@@ -752,13 +752,25 @@ fn sub2api_codex_accounts(
         };
         // sub2api stores the ChatGPT account id as `chatgpt_account_id`
         // (openai_oauth_service.go); normalize it to the `account_id` key the
-        // shared token extractor expects.  An explicit `account_id` wins.
+        // shared token extractor expects.  Preference order (first non-empty
+        // wins): explicit `account_id`, `chatgpt_account_id`, then
+        // `chatgpt_user_id`.  Registrar-created exports carry a full token set
+        // but no account id — only a stable `user-…` id — and must not be
+        // silently dropped (surfacing as a hard import failure).
         let mut normalized = credentials.clone();
-        if !normalized.contains_key("account_id") {
-            if let Some(id) = normalized.get("chatgpt_account_id") {
-                normalized.insert("account_id".to_owned(), id.clone());
-            }
-        }
+        let account_id = ["account_id", "chatgpt_account_id", "chatgpt_user_id"]
+            .iter()
+            .find_map(|key| {
+                normalized
+                    .get(*key)
+                    .and_then(Value::as_str)
+                    .filter(|value| !value.trim().is_empty())
+                    .map(str::to_owned)
+            });
+        let Some(account_id) = account_id else {
+            continue;
+        };
+        normalized.insert("account_id".to_owned(), Value::String(account_id));
         let Ok(payload) = codex_payload_from_tokens(&Value::Object(normalized)) else {
             continue;
         };
@@ -1575,6 +1587,44 @@ mod tests {
             accounts[0].label.as_deref(),
             Some("jennifersimon497104t@outlook.com_40刀")
         );
+    }
+
+    #[test]
+    fn sub2api_registrar_export_falls_back_to_chatgpt_user_id() {
+        // Registrar-created exports carry a full token set but an EMPTY
+        // `chatgpt_account_id` and no `account_id` — only `chatgpt_user_id`
+        // is populated.  Regression: every account used to be skipped, which
+        // surfaced as a hard "导入失败" for an otherwise valid file.
+        let fixture = json!({
+            "type": "sub2api-data", "version": 1,
+            "accounts": [
+                {
+                    "name": "mccarnskauer55@outlook.com----U2G6----Gf0@AU2g!",
+                    "platform": "openai", "type": "oauth",
+                    "credentials": {
+                        "access_token": ACCESS, "refresh_token": REFRESH,
+                        "id_token": ID,
+                        "chatgpt_account_id": "",
+                        "chatgpt_user_id": "user-AAFxzpZD5jVl2krLAqE9fIqC"
+                    }
+                },
+                {
+                    "name": "no-account-id-at-all",
+                    "platform": "openai", "type": "oauth",
+                    "credentials": {
+                        "access_token": ACCESS, "refresh_token": REFRESH,
+                        "id_token": ID
+                    }
+                }
+            ]
+        });
+        let accounts = sub2api_codex_accounts(&fixture).unwrap();
+        assert_eq!(accounts.len(), 1, "id-less entry must still be skipped");
+        assert_eq!(
+            accounts[0].payload.as_value()["account_id"],
+            "user-AAFxzpZD5jVl2krLAqE9fIqC"
+        );
+        assert_eq!(accounts[0].payload.as_value()["refresh_token"], REFRESH);
     }
 
     #[test]

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -106,6 +106,9 @@ impl TryFrom<AuthAccountSummary> for AuthAccountDto {
 #[derive(Debug, Clone, Serialize)]
 pub struct AuthMutationResult {
     pub account: AuthAccountDto,
+    /// All accounts persisted by a batch import. Login flows contain the
+    /// primary account only; sub2api imports populate the complete list.
+    pub imported_accounts: Vec<AuthAccountDto>,
     /// Set when persistence succeeded but the requested follow-up operation
     /// (currently initial model sync) did not.
     pub warning: Option<String>,
@@ -493,7 +496,8 @@ async fn sync_after_login(
         }
     };
     Ok(AuthMutationResult {
-        account,
+        account: account.clone(),
+        imported_accounts: vec![account.clone()],
         warning,
         notice,
     })
@@ -836,8 +840,18 @@ async fn import_and_sync(
             );
         }
     }
-    // The primary account drives the UI refresh; extra accounts appear on reload.
-    let account = AuthAccountDto::try_from(summaries[0].clone()).map_err(safe_error)?;
+    // Keep the existing primary-account field for compatibility, but also
+    // return every persisted account so batch imports can identify all rows.
+    let imported_accounts = summaries
+        .iter()
+        .cloned()
+        .map(AuthAccountDto::try_from)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(safe_error)?;
+    let account = imported_accounts
+        .first()
+        .cloned()
+        .ok_or_else(|| "导入后未找到账号".to_owned())?;
     let mut notice = CODEX_IMPORT_NOTICE.to_owned();
     if summaries.len() > 1 || skipped > 0 {
         notice = format!(
@@ -851,7 +865,8 @@ async fn import_and_sync(
         );
     }
     Ok(AuthMutationResult {
-        account,
+        account: account.clone(),
+        imported_accounts,
         warning,
         notice: Some(notice),
     })
@@ -1095,6 +1110,7 @@ mod tests {
         let list = serde_json::to_string(&vec![dto.clone()]).unwrap();
         let mutation = serde_json::to_string(&AuthMutationResult {
             account: dto,
+            imported_accounts: vec![],
             warning: None,
             notice: None,
         })

--- a/src/components/layout/ChannelTabs.tsx
+++ b/src/components/layout/ChannelTabs.tsx
@@ -8,14 +8,14 @@ import { authApi, channelApi } from "../../lib/api";
  * 全宽底边框 + 图标 + 完整标签 + 数量徽标，路由 /channels 与 /channels/auth。
  * 数量自行轻量拉取，保证两个 tab 徽标在任何页面都显示。
  */
-export function ChannelTabs() {
+export function ChannelTabs({ refreshKey = 0 }: { refreshKey?: number }) {
   const [channelCount, setChannelCount] = useState<number | null>(null);
   const [authCount, setAuthCount] = useState<number | null>(null);
 
   useEffect(() => {
     channelApi.getAll().then(cs => setChannelCount(cs.length)).catch(() => {});
     authApi.accountsList().then(as => setAuthCount(as.length)).catch(() => {});
-  }, []);
+  }, [refreshKey]);
 
   const base =
     "inline-flex items-center gap-1.5 whitespace-nowrap border-b-2 px-3 py-1.5 text-sm font-medium transition-colors";

--- a/src/pages/AuthChannelsPage.tsx
+++ b/src/pages/AuthChannelsPage.tsx
@@ -115,17 +115,17 @@ export function AuthChannelsPage() {
   // "Provider filter 不隐藏新增账号后的刷新结果").
   const visibleAccounts = accounts.filter((a) => a.provider === selectedProvider);
 
-  const load = useCallback(async () => {
-    setLoading(true);
+  const load = useCallback(async (showLoading = true) => {
+    if (showLoading) setLoading(true);
     try { setAccounts(await authApi.accountsList()); }
     catch (_) { setNotice({ kind: "error", message: "Auth 账号加载失败，请检查本地服务后重试。" }); }
-    finally { setLoading(false); }
+    finally { if (showLoading) setLoading(false); }
   }, []);
   useEffect(() => { void load(); }, [load]);
 
   const runFor = async (id: string, success: string, work: () => Promise<void>) => {
     setPendingId(id);
-    try { await work(); setNotice({ kind: "success", message: success }); await load(); }
+    try { await work(); setNotice({ kind: "success", message: success }); await load(false); }
     catch (_) { setNotice({ kind: "error", message: "操作失败，请稍后重试。" }); }
     finally { setPendingId(null); }
   };
@@ -135,7 +135,7 @@ export function AuthChannelsPage() {
     try {
       await authApi.refreshQuota(id);
       setNotice({ kind: "success", message: "额度刷新完成。" });
-      await load();
+      await load(false);
     } catch (_) {
       setNotice({ kind: "error", message: "额度刷新失败，已保留上次额度数据。" });
     } finally {
@@ -148,7 +148,7 @@ export function AuthChannelsPage() {
     setReloginAccount(null);
     const displayName = activeProvider.displayName;
     setNotice(result.warning ? { kind: "warning", message: "账号已保存但暂不参与路由：模型同步失败。" } : { kind: "success", message: `${displayName} 账号登录完成。` });
-    void load();
+    void load(false);
   };
   const importAuth = async (format: ImportFormat) => {
     // Web 版：浏览器文件选择器读取内容后按内容导入
@@ -159,7 +159,7 @@ export function AuthChannelsPage() {
       try {
         const result = await authApi.loginImportContent("codex", content, format);
         setNotice(result.warning ? { kind: "warning", message: "账号已保存但暂不参与路由：模型同步失败。" } : { kind: "success", message: importSuccessMessage(result, "已导入账号。") });
-        await load();
+        await load(false);
         setChannelTabRefreshKey((key) => key + 1);
       } catch (_) {
         setNotice({ kind: "error", message: `导入失败，请确认所选文件是有效的${optionLabel(format)}。` });
@@ -193,7 +193,7 @@ export function AuthChannelsPage() {
     try {
       const result = await authApi.loginImport("codex", path, format);
       setNotice(result.warning ? { kind: "warning", message: "账号已保存但暂不参与路由：模型同步失败。" } : { kind: "success", message: importSuccessMessage(result, `已从 ${label} 导入账号。`) });
-      await load();
+      await load(false);
       setChannelTabRefreshKey((key) => key + 1);
     } catch (_) {
       setNotice({ kind: "error", message: `导入失败，请确认所选文件是有效的${optionLabel(format)}。` });
@@ -207,7 +207,7 @@ export function AuthChannelsPage() {
       await authApi.logout(account.id);
       setNotice({ kind: "success", message: "账号已删除。" });
       setConfirmation(null);
-      await load();
+      await load(false);
     } catch (_) {
       setNotice({ kind: "error", message: "操作失败，请稍后重试。" });
     } finally {
@@ -247,7 +247,7 @@ export function AuthChannelsPage() {
       const result = await authApi.exportJson(account.id, path);
       const backup = result.backup_path ? `；已备份原文件：${result.backup_path}` : "";
       setNotice({ kind: "success", message: `已导出到 ${result.path}${backup}` });
-      await load();
+      await load(false);
     } catch (_) {
       setNotice({ kind: "error", message: "导出失败，请稍后重试。" });
     } finally {
@@ -262,7 +262,7 @@ export function AuthChannelsPage() {
     {loading ? <div className="flex min-h-64 items-center justify-center gap-2 text-sm text-muted-foreground"><Loader2 size={18} className="animate-spin" />加载 Auth 账号…</div> : <div className="grid grid-cols-1 gap-5 xl:grid-cols-2">{visibleAccounts.map(account => <AccountCard key={account.id} account={account} pending={pendingId === account.id || quotaPendingId === account.id} quotaPending={quotaPendingId === account.id} onEdit={() => setEditAccount(account)} onToggle={() => void runFor(account.id, account.disabled ? "账号已启用。" : "账号已停用。", () => authApi.toggle(account.id, !account.disabled).then(() => undefined))} onDelete={() => setConfirmation({ kind: "delete", account })} onRefresh={() => void runFor(account.id, "令牌刷新完成。", () => authApi.refreshToken(account.id).then(() => undefined))} onRefreshQuota={() => void refreshQuota(account.id)} onSync={() => setSyncAccount(account)} onExport={() => void exportAuth(account)} onRelogin={() => { setReloginAccount(account); setSelectedProvider(account.provider); setShowLogin(true); }} />)}{visibleAccounts.length === 0 && <EmptyAccountSlot provider={activeProvider} onLogin={() => { setReloginAccount(null); setShowLogin(true); }} onSelectImportFormat={(format) => void importAuth(format)} busy={pendingId === "import"} />}</div>}
     {showLogin && <LoginModal provider={activeProvider} replaceAccountId={reloginAccount?.id} onClose={() => { setShowLogin(false); setReloginAccount(null); }} onCompleted={completeLogin} />}
     {editAccount && <EditModal account={editAccount} pending={pendingId === editAccount.id} onClose={() => setEditAccount(null)} onSave={async input => { await runFor(input.id, "账号配置已保存。", () => authApi.update(input).then(() => undefined)); setEditAccount(null); }} />}
-    {syncAccount && <ModelSyncModal account={syncAccount} onClose={() => setSyncAccount(null)} onSynced={() => { void load(); setNotice({ kind: "success", message: "模型同步完成。" }); }} />}
+    {syncAccount && <ModelSyncModal account={syncAccount} onClose={() => setSyncAccount(null)} onSynced={() => { void load(false); setNotice({ kind: "success", message: "模型同步完成。" }); }} />}
     {confirmation && <ConfirmationDialog confirmation={confirmation} pending={pendingId === confirmation.account.id} onCancel={() => setConfirmation(null)} onConfirm={() => void confirmAction()} />}
   </div>;
 }

--- a/src/pages/AuthChannelsPage.tsx
+++ b/src/pages/AuthChannelsPage.tsx
@@ -25,6 +25,17 @@ function optionLabel(format: ImportFormat) {
   return IMPORT_OPTIONS.find((option) => option.format === format)?.label ?? "Codex auth.json";
 }
 
+function importAccountLabel(account: AuthAccount) {
+  return account.email || account.label || account.account_id;
+}
+
+function importSuccessMessage(result: AuthMutationResult, fallback: string) {
+  const imported = result.imported_accounts ?? [result.account];
+  if (imported.length <= 1) return result.notice || fallback;
+  const labels = imported.map(importAccountLabel).join("、");
+  return `${result.notice || `成功导入 ${imported.length} 个账号。`} 导入账号：${labels}`;
+}
+
 /// 「导入」触发按钮 + 三格式下拉菜单。头部与空状态卡片共用，
 /// 各自持有打开状态并在点击外部时收起。
 function ImportDropdown({ busy, onSelect }: { busy: boolean; onSelect: (format: ImportFormat) => void }) {
@@ -77,6 +88,7 @@ export function AuthChannelsPage() {
   const [syncAccount, setSyncAccount] = useState<AuthAccount | null>(null);
   const [confirmation, setConfirmation] = useState<Confirmation | null>(null);
   const [notice, setNotice] = useState<{ kind: "success" | "error" | "warning"; message: string } | null>(null);
+  const [channelTabRefreshKey, setChannelTabRefreshKey] = useState(0);
 
   useEffect(() => {
     let disposed = false;
@@ -146,8 +158,9 @@ export function AuthChannelsPage() {
       setPendingId("import"); setNotice({ kind: "success", message: "正在导入 …" });
       try {
         const result = await authApi.loginImportContent("codex", content, format);
-        setNotice(result.warning ? { kind: "warning", message: "账号已保存但暂不参与路由：模型同步失败。" } : { kind: "success", message: result.notice || "已导入账号。" });
+        setNotice(result.warning ? { kind: "warning", message: "账号已保存但暂不参与路由：模型同步失败。" } : { kind: "success", message: importSuccessMessage(result, "已导入账号。") });
         await load();
+        setChannelTabRefreshKey((key) => key + 1);
       } catch (_) {
         setNotice({ kind: "error", message: `导入失败，请确认所选文件是有效的${optionLabel(format)}。` });
       } finally { setPendingId(null); }
@@ -179,8 +192,9 @@ export function AuthChannelsPage() {
     setPendingId("import"); setNotice({ kind: "success", message: `正在读取 ${label} …` });
     try {
       const result = await authApi.loginImport("codex", path, format);
-      setNotice(result.warning ? { kind: "warning", message: "账号已保存但暂不参与路由：模型同步失败。" } : { kind: "success", message: result.notice || `已从 ${label} 导入账号。` });
+      setNotice(result.warning ? { kind: "warning", message: "账号已保存但暂不参与路由：模型同步失败。" } : { kind: "success", message: importSuccessMessage(result, `已从 ${label} 导入账号。`) });
       await load();
+      setChannelTabRefreshKey((key) => key + 1);
     } catch (_) {
       setNotice({ kind: "error", message: `导入失败，请确认所选文件是有效的${optionLabel(format)}。` });
     } finally { setPendingId(null); }
@@ -241,7 +255,7 @@ export function AuthChannelsPage() {
     }
   };
 
-  return <div className="page-shell space-y-3"><div className="page-header sticky top-0 z-30 -mx-7 -mt-7 mb-2 flex-col bg-card/90 px-7 pt-3 backdrop-blur-md"><div className="flex w-full items-start justify-between gap-4 pb-1.5"><div><h1 className="page-title">渠道管理</h1><p className="page-subtitle mt-0.5">登录各厂商订阅账号，作为上游路由候选</p></div><div className="flex items-center gap-2"><button onClick={() => { setReloginAccount(null); setShowLogin(true); }} disabled={pendingId === "import"} className="action-primary"><KeyRound size={16} />登录账号</button>{activeProvider.supportsImport && <ImportDropdown busy={pendingId === "import"} onSelect={(format) => void importAuth(format)} />}</div></div><ChannelTabs /></div>
+  return <div className="page-shell space-y-3"><div className="page-header sticky top-0 z-30 -mx-7 -mt-7 mb-2 flex-col bg-card/90 px-7 pt-3"><div className="flex w-full items-start justify-between gap-4 pb-1.5"><div><h1 className="page-title">渠道管理</h1><p className="page-subtitle mt-0.5">登录各厂商订阅账号，作为上游路由候选</p></div><div className="flex items-center gap-2"><button onClick={() => { setReloginAccount(null); setShowLogin(true); }} disabled={pendingId === "import"} className="action-primary"><KeyRound size={16} />登录账号</button>{activeProvider.supportsImport && <ImportDropdown busy={pendingId === "import"} onSelect={(format) => void importAuth(format)} />}</div></div><ChannelTabs refreshKey={channelTabRefreshKey} /></div>
     {notice && <div role="status" className={`flex items-center justify-between gap-3 rounded-2xl border px-4 py-3 text-sm ${notice.kind === "error" ? "border-destructive/25 bg-destructive/10 text-destructive" : notice.kind === "warning" ? "border-warning/25 bg-warning/10 text-warning" : "border-success/25 bg-success/10 text-success"}`}><span>{notice.message}</span><button onClick={() => setNotice(null)} aria-label="关闭提示"><X size={16} /></button></div>}
     <ProviderPills selected={selectedProvider} onSelect={setSelectedProvider} /><p className="text-sm text-muted-foreground">登录后作为路由候选并消耗订阅额度；开启 Auth 账号优先后，将优先使用。</p>
     <div className="flex gap-2 rounded-2xl border border-destructive/25 bg-destructive/10 px-4 py-3 text-xs leading-5 text-destructive"><CircleAlert className="mt-0.5 shrink-0" size={16} /><p>⚠️ 风险提示：此提供商使用的订阅 / OAuth 会话未获官方授权用于代理 / 路由器使用。账户可能被限制或封禁。使用风险自负。</p></div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -257,6 +257,8 @@ export interface AuthAccount {
 
 export interface AuthMutationResult {
   account: AuthAccount;
+  /** Batch-imported accounts; login flows contain the primary account only. */
+  imported_accounts?: AuthAccount[];
   warning: string | null;
   notice: string | null;
 }


### PR DESCRIPTION
## Bug

导入 Sub2API 合并导出文件后，后端提示“成功导入 10 个账号”，但前端账号页面没有显示对应的 10 个账号，导致用户无法确认导入结果，已导入账号也无法在页面中直接管理。

同时，在账号页面对单个账号执行“刷新额度”“刷新令牌”或“同步模型”后，页面会跳回顶部，用户会丢失当前操作位置。

## 复现方式

1. 打开“渠道管理 → Auth 账号”。
2. 选择导入 Sub2API 格式。
3. 导入包含多个 OpenAI 账号的合并导出文件，例如包含 10 个账号的文件。
4. 页面提示成功导入 10 个账号。
5. 观察账号列表和顶部账号数量。

实际结果：

- 成功提示显示导入了 10 个账号，但前端没有展示对应账号。
- 顶部 Auth 账号数量仍可能保持导入前的旧值。

## 根因

- 后端批量导入虽然将所有账号写入数据库，但 `AuthMutationResult` 只返回 `summaries[0]`，前端拿不到其余账号。
- `ChannelTabs` 的账号数量只在首次挂载时请求一次，导入完成后不会重新获取数量。
- 账号操作完成后刷新列表时会先显示整页加载占位，页面高度变化导致滚动位置回到顶部。

## 修复

- 返回本次 Sub2API 批量导入的全部账号摘要 `imported_accounts`。
- 前端使用完整导入结果展示本次实际导入的账号，避免只显示数量但页面没有对应账号。
- 导入成功后重新加载账号列表和顶部 Auth 账号数量。
- 将操作后的列表刷新改为静默刷新，保持当前滚动位置。
- 保留原有 `account` 字段，兼容单账号登录流程。

## 验证

- `pnpm build` 通过。
- `cargo check --manifest-path src-tauri/Cargo.toml` 通过。
- 已确认目标合并文件包含 10 条 `platform=openai` 账号，根节点为 `accounts` 数组。

## 影响范围

修复 Sub2API 合并文件导入后前端账号未展示、账号数量未更新，以及账号操作后页面跳回顶部的问题。

本 PR 不引入新的结构化导入报告、错误分类或导入弹窗。