### PR TITLE
feat: optimize audit log storage and loading

### DIFF
--- a/docs/superpowers/plans/2026-09-09-audit-log-policy.md
+++ b/docs/superpowers/plans/2026-09-09-audit-log-policy.md
@@ -1,0 +1,38 @@
+# Audit Log Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add configurable basic/detailed audit logging, retention cleanup, and summary/detail log APIs so large request bodies no longer slow the audit page or grow the database by default.
+
+**Architecture:** Store policy in the existing settings backend. Centralize policy application at log creation, expose summary rows for list views and full rows only on demand, and run bounded periodic retention cleanup against logs and security findings.
+
+**Tech Stack:** Rust, sqlx/SQLite, Axum/Tauri command bridge, React/TypeScript, existing settings store.
+
+**Spec:** Existing approved audit-log redesign discussed in the thread.
+
+## Global Constraints
+
+- Preserve detailed-log compatibility for existing rows and all current protocol paths.
+- New defaults are `basic` logging and 7-day retention; `0` means permanent.
+- All frontend/backend calls continue through `runtime.ts`/Tauri command dispatch.
+- Use UTF-8-safe truncation and bounded cleanup batches; never run routine VACUUM online.
+
+### Task 1: Settings and policy model
+
+Add typed settings fields, migration/default handling, and general-settings controls for log level and retention.
+
+### Task 2: Summary/detail log APIs
+
+Add DTOs and repository queries that exclude large bodies from list responses; retain full detail retrieval by ID.
+
+### Task 3: Centralized write policy and retention maintenance
+
+Apply basic/detail policy on every log write, add retention cleanup with orphan-finding cleanup, and start maintenance loops for desktop/headless.
+
+### Task 4: Frontend lazy details and UX
+
+Load summaries initially, fetch full detail only when expanded, cache details, and handle basic rows/loading states.
+
+### Task 5: Regression verification
+
+Add focused Rust tests, run formatting/build/test/clippy, and verify the existing database behavior with read-only performance checks.

--- a/src-tauri/migrations/030_request_log_policy.sql
+++ b/src-tauri/migrations/030_request_log_policy.sql
@@ -1,0 +1,5 @@
+-- Request-log policy metadata. Existing rows remain detailed for compatibility.
+ALTER TABLE request_logs ADD COLUMN detail_level TEXT NOT NULL DEFAULT 'detailed';
+ALTER TABLE request_logs ADD COLUMN started_at TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_logs_started ON request_logs(started_at);

--- a/src-tauri/src/adaptor/mod.rs
+++ b/src-tauri/src/adaptor/mod.rs
@@ -34,7 +34,9 @@ fn blocking_client_map() -> &'static Mutex<HashMap<u64, reqwest::Client>> {
 /// 兜底客户端并打日志（与旧行为一致，但只告警一次桶）。
 pub fn blocking_client(timeout_secs: u64) -> reqwest::Client {
     let key = timeout_secs.max(1);
-    let mut buckets = blocking_client_map().lock().unwrap_or_else(|e| e.into_inner());
+    let mut buckets = blocking_client_map()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
     if let Some(client) = buckets.get(&key) {
         return client.clone();
     }
@@ -88,21 +90,33 @@ mod client_reuse_tests {
     #[test]
     fn blocking_clients_are_bucketed_by_timeout() {
         let before = {
-            let map = blocking_client_map().lock().unwrap_or_else(|e| e.into_inner());
+            let map = blocking_client_map()
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             assert!(!map.contains_key(&12345) && !map.contains_key(&12346));
             map.len()
         };
         let _a = blocking_client(12345);
         let _b = blocking_client(12345);
         {
-            let map = blocking_client_map().lock().unwrap_or_else(|e| e.into_inner());
+            let map = blocking_client_map()
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             assert!(map.contains_key(&12345), "bucket must be cached");
-            assert!(map.len() >= before + 1, "same timeout must share one bucket");
+            assert!(
+                map.len() >= before + 1,
+                "same timeout must share one bucket"
+            );
         }
         let _c = blocking_client(12346);
         {
-            let map = blocking_client_map().lock().unwrap_or_else(|e| e.into_inner());
-            assert!(map.contains_key(&12346), "second timeout must get its own bucket");
+            let map = blocking_client_map()
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            assert!(
+                map.contains_key(&12346),
+                "second timeout must get its own bucket"
+            );
             assert!(map.len() >= before + 2);
         }
     }
@@ -111,8 +125,13 @@ mod client_reuse_tests {
     #[test]
     fn blocking_client_normalizes_timeout_key() {
         let _a = blocking_client(0);
-        let map = blocking_client_map().lock().unwrap_or_else(|e| e.into_inner());
-        assert!(map.contains_key(&1), "timeout 0 must normalize to the 1s bucket");
+        let map = blocking_client_map()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        assert!(
+            map.contains_key(&1),
+            "timeout 0 must normalize to the 1s bucket"
+        );
     }
 }
 

--- a/src-tauri/src/audit_log.rs
+++ b/src-tauri/src/audit_log.rs
@@ -1,0 +1,176 @@
+//! 审计日志策略：控制正文是否落库，并按保留期清理历史记录。
+
+use crate::{db::models::RequestLog, settings_store::SettingsStore};
+use sqlx::SqlitePool;
+use std::sync::{OnceLock, RwLock};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogDetailLevel {
+    Basic,
+    Detailed,
+}
+
+impl LogDetailLevel {
+    pub fn parse(value: &str) -> Self {
+        if value.eq_ignore_ascii_case("detailed") {
+            Self::Detailed
+        } else {
+            Self::Basic
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LogPolicy {
+    pub detail_level: LogDetailLevel,
+    /// 0 means retain forever.
+    pub retention_days: u64,
+}
+
+impl Default for LogPolicy {
+    fn default() -> Self {
+        Self {
+            detail_level: LogDetailLevel::Basic,
+            retention_days: 7,
+        }
+    }
+}
+
+static POLICY: OnceLock<RwLock<LogPolicy>> = OnceLock::new();
+
+fn policy_cell() -> &'static RwLock<LogPolicy> {
+    // Library consumers and migration/integration tests may create a
+    // Repository without booting AppState. Preserve the historical detailed
+    // write behavior until the application startup explicitly applies the
+    // persisted policy (whose product default is basic).
+    POLICY.get_or_init(|| {
+        RwLock::new(LogPolicy {
+            detail_level: LogDetailLevel::Detailed,
+            retention_days: 7,
+        })
+    })
+}
+
+pub fn policy_from_settings(settings: &SettingsStore) -> LogPolicy {
+    let defaults = LogPolicy::default();
+    let retention_days = settings.get_u64("logs.retention_days", defaults.retention_days);
+    LogPolicy {
+        detail_level: LogDetailLevel::parse(&settings.get_str("logs.detail_level", "basic")),
+        retention_days: normalize_retention_days(retention_days),
+    }
+}
+
+/// Supported retention values shared by UI and backend. Unknown persisted
+/// values fall back to the safe default instead of creating an unbounded
+/// cleanup interval or overflowing chrono's duration conversion.
+pub fn normalize_retention_days(value: u64) -> u64 {
+    match value {
+        0 | 1 | 7 | 30 | 90 => value,
+        _ => LogPolicy::default().retention_days,
+    }
+}
+
+pub fn apply_settings(settings: &SettingsStore) {
+    let policy = policy_from_settings(settings);
+    if let Ok(mut current) = policy_cell().write() {
+        *current = policy;
+    }
+}
+
+pub fn current_policy() -> LogPolicy {
+    policy_cell()
+        .read()
+        .map(|policy| *policy)
+        .unwrap_or_default()
+}
+
+/// Apply the active policy immediately before persistence. This centralizes
+/// all request-log write paths because they already share Repository::create_log.
+pub fn effective_log(log: &RequestLog) -> RequestLog {
+    effective_log_with_policy(log, current_policy())
+}
+
+pub fn effective_log_with_policy(log: &RequestLog, policy: LogPolicy) -> RequestLog {
+    let mut effective = log.clone();
+    if policy.detail_level == LogDetailLevel::Basic {
+        effective.request_body = None;
+        effective.response_choices = None;
+    }
+    effective
+}
+
+/// Delete expired rows in small transactions so cleanup does not hold the
+/// SQLite write lock for the entire history.
+pub async fn cleanup_expired_logs(
+    pool: &SqlitePool,
+    retention_days: u64,
+) -> Result<u64, sqlx::Error> {
+    if retention_days == 0 {
+        return Ok(0);
+    }
+    let cutoff = (chrono::Utc::now() - chrono::Duration::days(retention_days as i64)).to_rfc3339();
+    let mut deleted = 0;
+    loop {
+        let mut tx = pool.begin().await?;
+        let findings = sqlx::query(
+            "DELETE FROM request_security_findings WHERE log_id IN \
+             (SELECT id FROM request_logs WHERE created_at < ? LIMIT 500)",
+        )
+        .bind(&cutoff)
+        .execute(&mut *tx)
+        .await?;
+        let rows = sqlx::query(
+            "DELETE FROM request_logs WHERE id IN \
+             (SELECT id FROM request_logs WHERE created_at < ? LIMIT 500)",
+        )
+        .bind(&cutoff)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        deleted += rows.rows_affected();
+        if rows.rows_affected() == 0 {
+            break;
+        }
+        let _ = findings;
+    }
+    Ok(deleted)
+}
+
+pub async fn run_maintenance_loop(pool: SqlitePool, settings: SettingsStore) {
+    apply_settings(&settings);
+    let run = || async {
+        let policy = policy_from_settings(&settings);
+        if let Err(error) = cleanup_expired_logs(&pool, policy.retention_days).await {
+            tracing::warn!(%error, "审计日志自动清理失败");
+        }
+        apply_settings(&settings);
+    };
+    run().await;
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(6 * 60 * 60));
+    loop {
+        interval.tick().await;
+        run().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::models::RequestLog;
+
+    #[test]
+    fn basic_policy_drops_large_payloads() {
+        let mut log = RequestLog::default();
+        log.request_body = Some("large".into());
+        log.response_choices = Some("response".into());
+        let effective = effective_log_with_policy(&log, LogPolicy::default());
+        assert!(effective.request_body.is_none());
+        assert!(effective.response_choices.is_none());
+    }
+
+    #[test]
+    fn detail_level_parser_is_safe() {
+        assert_eq!(LogDetailLevel::parse("detailed"), LogDetailLevel::Detailed);
+        assert_eq!(LogDetailLevel::parse("unexpected"), LogDetailLevel::Basic);
+    }
+}

--- a/src-tauri/src/auth_provider/codex_backend.rs
+++ b/src-tauri/src/auth_provider/codex_backend.rs
@@ -449,8 +449,7 @@ fn usage_window(value: Option<&Value>) -> Option<QuotaWindow> {
         .map(|time| time.to_rfc3339());
     // Same `has_data` rule as the header parser: an all-empty window must not
     // manufacture an empty bar.
-    let has_data =
-        used_percent != 0.0 || window_minutes != 0 || reset_at.is_some();
+    let has_data = used_percent != 0.0 || window_minutes != 0 || reset_at.is_some();
     has_data.then(|| QuotaWindow {
         used_percent: Some(used_percent),
         window_minutes: Some(window_minutes),

--- a/src-tauri/src/auth_provider/codex_login.rs
+++ b/src-tauri/src/auth_provider/codex_login.rs
@@ -355,12 +355,15 @@ impl CodexLogin {
                 return Err(ProviderError::ImportFailed);
             }
         };
-        self.import_codex_account(CodexAccountPayload { label: None, payload })
-            .await
-            .map(|result| LoginResult {
-                last_refreshed_at: last_refresh.or(result.last_refreshed_at),
-                ..result
-            })
+        self.import_codex_account(CodexAccountPayload {
+            label: None,
+            payload,
+        })
+        .await
+        .map(|result| LoginResult {
+            last_refreshed_at: last_refresh.or(result.last_refreshed_at),
+            ..result
+        })
     }
 
     /// Shared tail of every import path: refresh an expired token, then turn
@@ -738,11 +741,13 @@ fn codex_payload_from_tokens(tokens: &Value) -> Result<ProviderPayload, Provider
 /// export.  Only `platform == "openai"` accounts whose credentials carry the
 /// full four-field token set qualify; everything else is skipped (the command
 /// layer surfaces the skip count).
-fn sub2api_codex_accounts(
-    value: &Value,
-) -> Result<Vec<CodexAccountPayload>, ProviderError> {
+fn sub2api_codex_accounts(value: &Value) -> Result<Vec<CodexAccountPayload>, ProviderError> {
     let mut accounts = Vec::new();
-    for entry in value.get("accounts").and_then(Value::as_array).unwrap_or(&Vec::new()) {
+    for entry in value
+        .get("accounts")
+        .and_then(Value::as_array)
+        .unwrap_or(&Vec::new())
+    {
         if entry.get("platform").and_then(Value::as_str) != Some("openai") {
             continue;
         }
@@ -1570,7 +1575,10 @@ mod tests {
         });
         let accounts = sub2api_codex_accounts(&fixture).unwrap();
         assert_eq!(accounts.len(), 1);
-        assert_eq!(accounts[0].payload.as_value()["account_id"], "real-export-id");
+        assert_eq!(
+            accounts[0].payload.as_value()["account_id"],
+            "real-export-id"
+        );
         assert_eq!(
             accounts[0].label.as_deref(),
             Some("jennifersimon497104t@outlook.com_40刀")

--- a/src-tauri/src/auth_provider/kimi_backend.rs
+++ b/src-tauri/src/auth_provider/kimi_backend.rs
@@ -429,7 +429,10 @@ mod tests {
             .route(
                 "/coding/v1/chat/completions",
                 post(
-                    move |State(s): State<MockState>, uri: axum::extract::OriginalUri, h: HeaderMap, body: axum::body::Bytes| {
+                    move |State(s): State<MockState>,
+                          uri: axum::extract::OriginalUri,
+                          h: HeaderMap,
+                          body: axum::body::Bytes| {
                         let s = s.clone();
                         async move {
                             s.chat_hits.fetch_add(1, Ordering::SeqCst);
@@ -447,7 +450,10 @@ mod tests {
             .route(
                 "/coding/v1/messages",
                 post(
-                    move |State(s): State<MockState>, uri: axum::extract::OriginalUri, h: HeaderMap, body: axum::body::Bytes| {
+                    move |State(s): State<MockState>,
+                          uri: axum::extract::OriginalUri,
+                          h: HeaderMap,
+                          body: axum::body::Bytes| {
                         let s = s.clone();
                         async move {
                             s.messages_hits.fetch_add(1, Ordering::SeqCst);
@@ -464,26 +470,23 @@ mod tests {
             )
             .route(
                 "/coding/v1/models",
-                get(
-                    move |State(s): State<MockState>, h: HeaderMap| async move {
-                        s.chat_headers.lock().unwrap().push(h.clone());
-                        s.uris.lock().unwrap().push(
-                            axum::http::Uri::from_static("/coding/v1/models"),
-                        );
-                        let status = s
-                            .models_status
-                            .load(std::sync::atomic::Ordering::SeqCst);
-                        if status != 0 {
-                            return (
-                                axum::http::StatusCode::from_u16(status as u16).unwrap(),
-                                Json(json!({"error": "upstream"})),
-                            )
-                                .into_response();
-                        }
-                        let body = s.models_response.lock().unwrap().clone();
-                        (axum::http::StatusCode::OK, Json(body)).into_response()
-                    },
-                ),
+                get(move |State(s): State<MockState>, h: HeaderMap| async move {
+                    s.chat_headers.lock().unwrap().push(h.clone());
+                    s.uris
+                        .lock()
+                        .unwrap()
+                        .push(axum::http::Uri::from_static("/coding/v1/models"));
+                    let status = s.models_status.load(std::sync::atomic::Ordering::SeqCst);
+                    if status != 0 {
+                        return (
+                            axum::http::StatusCode::from_u16(status as u16).unwrap(),
+                            Json(json!({"error": "upstream"})),
+                        )
+                            .into_response();
+                    }
+                    let body = s.models_response.lock().unwrap().clone();
+                    (axum::http::StatusCode::OK, Json(body)).into_response()
+                }),
             )
             .route(
                 "/oauth/device",
@@ -633,10 +636,7 @@ mod tests {
                 {"id": "weird", "protocol": "nope"}
             ]
         });
-        let models = provider
-            .list_models(&account(), &payload())
-            .await
-            .unwrap();
+        let models = provider.list_models(&account(), &payload()).await.unwrap();
         let ids: Vec<_> = models.iter().map(|m| m.id.as_str()).collect();
         assert_eq!(ids, ["kimi-k2.5", "kimi-k2.5-anthropic", "weird"]);
         // The weird protocol is fail-closed as unavailable, never routed.
@@ -646,7 +646,10 @@ mod tests {
         assert_eq!(uri.path(), "/coding/v1/models");
         let h = &state.chat_headers.lock().unwrap()[0];
         assert_eq!(
-            h.get(reqwest::header::AUTHORIZATION).unwrap().to_str().unwrap(),
+            h.get(reqwest::header::AUTHORIZATION)
+                .unwrap()
+                .to_str()
+                .unwrap(),
             "Bearer tok"
         );
         assert_eq!(
@@ -662,7 +665,10 @@ mod tests {
             .models_status
             .store(401, std::sync::atomic::Ordering::SeqCst);
         let result = provider.list_models(&account(), &payload()).await;
-        assert!(matches!(result, Err(crate::auth_provider::ProviderError::Unauthorized)));
+        assert!(matches!(
+            result,
+            Err(crate::auth_provider::ProviderError::Unauthorized)
+        ));
     }
 
     #[tokio::test]

--- a/src-tauri/src/auth_provider/kimi_login.rs
+++ b/src-tauri/src/auth_provider/kimi_login.rs
@@ -421,9 +421,7 @@ impl KimiLogin {
                     });
                 }
                 Err(RefreshError::Unauthorized) => return Err(ProviderError::Unauthorized),
-                Err(RefreshError::PaymentRequired) => {
-                    return Err(ProviderError::PaymentRequired)
-                }
+                Err(RefreshError::PaymentRequired) => return Err(ProviderError::PaymentRequired),
                 Err(RefreshError::Retryable) => {
                     attempt += 1;
                     if attempt >= 3 {
@@ -624,14 +622,21 @@ mod tests {
         body: axum::body::Bytes,
     ) -> (axum::http::StatusCode, Json<Value>) {
         state.token_hits.fetch_add(1, Ordering::SeqCst);
-        state.token_times.lock().unwrap().push(std::time::Instant::now());
+        state
+            .token_times
+            .lock()
+            .unwrap()
+            .push(std::time::Instant::now());
         state.headers.lock().unwrap().push(headers.clone());
         state
             .seen
             .lock()
             .unwrap()
             .push(String::from_utf8_lossy(&body).to_string());
-        if state.always_pending.load(std::sync::atomic::Ordering::SeqCst) {
+        if state
+            .always_pending
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
             return (
                 axum::http::StatusCode::BAD_REQUEST,
                 Json(json!({"error": "authorization_pending"})),

--- a/src-tauri/src/auth_provider/maintenance.rs
+++ b/src-tauri/src/auth_provider/maintenance.rs
@@ -199,7 +199,10 @@ mod tests {
             .await
             .unwrap();
         if status == "invalid" {
-            repository.mark_invalid(&account.id, retry, None).await.unwrap();
+            repository
+                .mark_invalid(&account.id, retry, None)
+                .await
+                .unwrap();
         }
         account.id
     }

--- a/src-tauri/src/auth_provider/service.rs
+++ b/src-tauri/src/auth_provider/service.rs
@@ -1808,7 +1808,10 @@ mod tests {
             async fn import(&self, _: &[u8]) -> Result<LoginResult, ProviderError> {
                 Err(ProviderError::ImportFailed)
             }
-            async fn refresh(&self, payload: &ProviderPayload) -> Result<RefreshedPayload, ProviderError> {
+            async fn refresh(
+                &self,
+                payload: &ProviderPayload,
+            ) -> Result<RefreshedPayload, ProviderError> {
                 let token = payload
                     .as_value()
                     .get("refresh_token")

--- a/src-tauri/src/auth_provider/types.rs
+++ b/src-tauri/src/auth_provider/types.rs
@@ -285,7 +285,9 @@ impl fmt::Debug for ProviderRequest<'_> {
 /// and never includes tokens, OAuth codes, request bodies, or auth.json bytes.
 #[derive(Clone, PartialEq, Eq)]
 pub enum ProviderError {
-    UnknownProvider { provider: String },
+    UnknownProvider {
+        provider: String,
+    },
     InvalidPayload,
     LoginFailed,
     LoginCancelled,
@@ -301,7 +303,9 @@ pub enum ProviderError {
     /// "membership benefits").  Terminal: retrying on a maintenance cadence
     /// never fixes an inactive membership.
     PaymentRequired,
-    UnsupportedFeatures { pointer: String },
+    UnsupportedFeatures {
+        pointer: String,
+    },
     Retryable,
     Storage,
     Protocol,
@@ -358,9 +362,7 @@ impl fmt::Display for ProviderError {
             Self::AuthorizationDenied => formatter.write_str("provider authorization was denied"),
             Self::ImportFailed => formatter.write_str("provider credential import failed"),
             Self::Unauthorized => formatter.write_str("provider credentials were rejected"),
-            Self::PaymentRequired => {
-                formatter.write_str("provider subscription is not usable")
-            }
+            Self::PaymentRequired => formatter.write_str("provider subscription is not usable"),
             Self::UnsupportedFeatures { pointer } => {
                 write!(formatter, "unsupported provider request field at {pointer}")
             }

--- a/src-tauri/src/commands/app_config.rs
+++ b/src-tauri/src/commands/app_config.rs
@@ -1267,10 +1267,9 @@ mod tests {
         assert_eq!(reset["auth_mode"], "chatgpt");
         assert!(reset["OPENAI_API_KEY"].is_null());
 
-        let backup: serde_json::Value = serde_json::from_str(&fs::read_to_string(
-            dir.join("auth.json.waliapi-backup"),
+        let backup: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(dir.join("auth.json.waliapi-backup")).unwrap(),
         )
-        .unwrap())
         .unwrap();
         assert_eq!(backup["OPENAI_API_KEY"], "sk-waliapi");
     }

--- a/src-tauri/src/commands/log.rs
+++ b/src-tauri/src/commands/log.rs
@@ -94,6 +94,73 @@ impl From<RequestLog> for LogDto {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct LogSummaryDto {
+    #[serde(flatten)]
+    pub log: LogDto,
+    pub detail_level: String,
+    pub detail_available: bool,
+    pub started_at: Option<String>,
+    pub request_body_bytes: i64,
+    pub response_choices_bytes: i64,
+}
+
+impl From<crate::db::models::RequestLogSummary> for LogSummaryDto {
+    fn from(s: crate::db::models::RequestLogSummary) -> Self {
+        let detail_available = s.detail_level == "detailed"
+            && (s.request_body_bytes > 0 || s.response_choices_bytes > 0);
+        let log = LogDto {
+            id: s.id,
+            seq: s.seq,
+            api_key_name: s.api_key_name,
+            channel_name: s.channel_name,
+            model: s.model,
+            upstream_model: s.upstream_model,
+            mode: s.mode,
+            status_code: s.status_code,
+            prompt_tokens: s.prompt_tokens,
+            completion_tokens: s.completion_tokens,
+            total_tokens: s.total_tokens,
+            cached_tokens: s.cached_tokens,
+            duration_ms: s.duration_ms,
+            error_message: s.error_message,
+            is_stream: s.is_stream == 1,
+            is_retry: s.is_retry == 1,
+            created_at: s.created_at,
+            request_body: None,
+            response_choices: None,
+            risk_level: s.risk_level,
+            risk_score: s.risk_score,
+            risk_summary: s.risk_summary,
+            security_action: s.security_action,
+            sanitized: s.sanitized == 1,
+            blocked_reason: s.blocked_reason,
+            trace_id: s.trace_id,
+            reasoning_effort: s.reasoning_effort,
+            downstream_protocol: s.downstream_protocol,
+            downstream_endpoint: s.downstream_endpoint,
+            route_group: s.route_group,
+            upstream_protocol: s.upstream_protocol,
+            upstream_endpoint: s.upstream_endpoint,
+            provider: s.provider,
+            codec_version: s.codec_version,
+            failure_class: s.failure_class,
+            identity_revision: s.identity_revision,
+            client_cancelled: s.client_cancelled.map(|v| v == 1),
+            stream_committed: s.stream_committed.map(|v| v == 1),
+            upstream_type: s.upstream_type,
+        };
+        Self {
+            log,
+            detail_level: s.detail_level,
+            detail_available,
+            started_at: s.started_at,
+            request_body_bytes: s.request_body_bytes,
+            response_choices_bytes: s.response_choices_bytes,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SecurityFindingDto {
     pub id: String,
     pub log_id: String,
@@ -146,14 +213,14 @@ pub struct GetLogsInput {
 pub async fn get_logs(
     input: GetLogsInput,
     state: tauri::State<'_, std::sync::Arc<AppState>>,
-) -> Result<Vec<LogDto>, String> {
+) -> Result<Vec<LogSummaryDto>, String> {
     get_logs_impl(input, &*state).await
 }
 
 pub async fn get_logs_impl(
     input: GetLogsInput,
     state: &std::sync::Arc<AppState>,
-) -> Result<Vec<LogDto>, String> {
+) -> Result<Vec<LogSummaryDto>, String> {
     let repo = Repository::new(state.db.pool.clone());
     let limit = input.limit.unwrap_or(50);
     let offset = input.offset.unwrap_or(0);
@@ -168,7 +235,7 @@ pub async fn get_logs_impl(
         || input.upstream_type.is_some();
 
     let logs = if has_search {
-        repo.search_logs_by_upstream_type(
+        repo.search_log_summaries(
             input.keyword.as_deref(),
             input.api_key_name.as_deref(),
             input.channel_name.as_deref(),
@@ -182,11 +249,11 @@ pub async fn get_logs_impl(
         )
         .await
     } else {
-        repo.get_logs(limit, offset).await
+        repo.get_log_summaries(limit, offset).await
     };
 
     logs.map_err(|e| e.to_string())
-        .map(|ls| ls.into_iter().map(Into::into).collect())
+        .map(|ls| ls.into_iter().map(LogSummaryDto::from).collect())
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -8,6 +8,10 @@ use crate::AppState;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Settings {
+    #[serde(default = "default_log_detail_level")]
+    pub log_detail_level: String,
+    #[serde(default = "default_log_retention_days")]
+    pub log_retention_days: u64,
     #[serde(default = "default_port")]
     pub server_port: u16,
     #[serde(default = "default_host")]
@@ -96,10 +100,18 @@ fn default_ocr_concurrency() -> i32 {
 fn default_ocr_dpi() -> i32 {
     200
 }
+fn default_log_detail_level() -> String {
+    "basic".to_string()
+}
+fn default_log_retention_days() -> u64 {
+    7
+}
 
 impl Default for Settings {
     fn default() -> Self {
         Settings {
+            log_detail_level: default_log_detail_level(),
+            log_retention_days: default_log_retention_days(),
             server_port: default_port(),
             server_host: default_host(),
             ui_theme: default_theme(),
@@ -155,7 +167,9 @@ pub struct FeatureFlagsDto {
 }
 
 #[tauri::command]
-pub fn get_feature_flags(state: tauri::State<'_, Arc<AppState>>) -> Result<FeatureFlagsDto, String> {
+pub fn get_feature_flags(
+    state: tauri::State<'_, Arc<AppState>>,
+) -> Result<FeatureFlagsDto, String> {
     let f = crate::core::feature_flags::read_feature_flags(&state.settings);
     Ok(FeatureFlagsDto {
         new_routeplan: f.new_routeplan,
@@ -170,7 +184,17 @@ pub fn get_feature_flags(state: tauri::State<'_, Arc<AppState>>) -> Result<Featu
 #[tauri::command]
 pub async fn get_settings(state: tauri::State<'_, Arc<AppState>>) -> Result<Settings, String> {
     let store = &state.settings;
+    let detail_level = get_str(store, "logs.detail_level", "basic");
+    let log_detail_level = if detail_level.eq_ignore_ascii_case("detailed") {
+        "detailed".to_string()
+    } else {
+        "basic".to_string()
+    };
+    let log_retention_days =
+        crate::audit_log::normalize_retention_days(get_u64(store, "logs.retention_days", 7));
     let settings = Settings {
+        log_detail_level,
+        log_retention_days,
         server_port: get_u64(store, "server.port", 8777) as u16,
         server_host: get_str(store, "server.host", "127.0.0.1"),
         ui_theme: get_str(store, "ui.theme", "dark"),
@@ -203,31 +227,119 @@ pub async fn save_settings(
     settings: Settings,
     state: tauri::State<'_, Arc<AppState>>,
 ) -> Result<(), String> {
+    if !settings.log_detail_level.eq_ignore_ascii_case("basic")
+        && !settings.log_detail_level.eq_ignore_ascii_case("detailed")
+    {
+        return Err("无效的日志级别，仅支持 basic 或 detailed".to_string());
+    }
+    if !matches!(settings.log_retention_days, 0 | 1 | 7 | 30 | 90) {
+        return Err("无效的日志保留期，仅支持 1、7、30、90 天或永久".to_string());
+    }
     state.settings.set_many(&[
-        ("server.port".to_string(), serde_json::json!(settings.server_port)),
-        ("server.host".to_string(), serde_json::json!(settings.server_host)),
+        (
+            "logs.detail_level".to_string(),
+            serde_json::json!(settings.log_detail_level),
+        ),
+        (
+            "logs.retention_days".to_string(),
+            serde_json::json!(settings.log_retention_days),
+        ),
+        (
+            "server.port".to_string(),
+            serde_json::json!(settings.server_port),
+        ),
+        (
+            "server.host".to_string(),
+            serde_json::json!(settings.server_host),
+        ),
         ("ui.theme".to_string(), serde_json::json!(settings.ui_theme)),
-        ("ui.language".to_string(), serde_json::json!(settings.ui_language)),
-        ("general.minimize_to_tray".to_string(), serde_json::json!(settings.minimize_to_tray)),
-        ("general.close_to_tray".to_string(), serde_json::json!(settings.close_to_tray)),
-        ("general.auto_start".to_string(), serde_json::json!(settings.auto_start)),
-        ("retry.enabled".to_string(), serde_json::json!(settings.retry_enabled)),
-        ("retry.times".to_string(), serde_json::json!(settings.retry_times)),
-        ("security.enabled".to_string(), serde_json::json!(settings.security_enabled)),
-        ("security.mode".to_string(), serde_json::json!(settings.security_mode)),
-        ("security.scan_unicode".to_string(), serde_json::json!(settings.security_scan_unicode)),
-        ("security.scan_tools".to_string(), serde_json::json!(settings.security_scan_tools)),
-        ("security.scan_network".to_string(), serde_json::json!(settings.security_scan_network)),
-        ("security.scan_response".to_string(), serde_json::json!(settings.security_scan_response)),
-        ("security.redact_secrets".to_string(), serde_json::json!(settings.security_redact_secrets)),
-        ("security.block_on_critical".to_string(), serde_json::json!(settings.security_block_on_critical)),
-        ("routing.prefer_auth_accounts".to_string(), serde_json::json!(settings.routing_prefer_auth_accounts)),
-        ("routing.prefer_same_protocol".to_string(), serde_json::json!(settings.routing_prefer_same_protocol)),
-        ("ocr.enabled".to_string(), serde_json::json!(settings.ocr_enabled)),
-        ("ocr.max_pages".to_string(), serde_json::json!(settings.ocr_max_pages)),
-        ("ocr.concurrency".to_string(), serde_json::json!(settings.ocr_concurrency)),
+        (
+            "ui.language".to_string(),
+            serde_json::json!(settings.ui_language),
+        ),
+        (
+            "general.minimize_to_tray".to_string(),
+            serde_json::json!(settings.minimize_to_tray),
+        ),
+        (
+            "general.close_to_tray".to_string(),
+            serde_json::json!(settings.close_to_tray),
+        ),
+        (
+            "general.auto_start".to_string(),
+            serde_json::json!(settings.auto_start),
+        ),
+        (
+            "retry.enabled".to_string(),
+            serde_json::json!(settings.retry_enabled),
+        ),
+        (
+            "retry.times".to_string(),
+            serde_json::json!(settings.retry_times),
+        ),
+        (
+            "security.enabled".to_string(),
+            serde_json::json!(settings.security_enabled),
+        ),
+        (
+            "security.mode".to_string(),
+            serde_json::json!(settings.security_mode),
+        ),
+        (
+            "security.scan_unicode".to_string(),
+            serde_json::json!(settings.security_scan_unicode),
+        ),
+        (
+            "security.scan_tools".to_string(),
+            serde_json::json!(settings.security_scan_tools),
+        ),
+        (
+            "security.scan_network".to_string(),
+            serde_json::json!(settings.security_scan_network),
+        ),
+        (
+            "security.scan_response".to_string(),
+            serde_json::json!(settings.security_scan_response),
+        ),
+        (
+            "security.redact_secrets".to_string(),
+            serde_json::json!(settings.security_redact_secrets),
+        ),
+        (
+            "security.block_on_critical".to_string(),
+            serde_json::json!(settings.security_block_on_critical),
+        ),
+        (
+            "routing.prefer_auth_accounts".to_string(),
+            serde_json::json!(settings.routing_prefer_auth_accounts),
+        ),
+        (
+            "routing.prefer_same_protocol".to_string(),
+            serde_json::json!(settings.routing_prefer_same_protocol),
+        ),
+        (
+            "ocr.enabled".to_string(),
+            serde_json::json!(settings.ocr_enabled),
+        ),
+        (
+            "ocr.max_pages".to_string(),
+            serde_json::json!(settings.ocr_max_pages),
+        ),
+        (
+            "ocr.concurrency".to_string(),
+            serde_json::json!(settings.ocr_concurrency),
+        ),
         ("ocr.dpi".to_string(), serde_json::json!(settings.ocr_dpi)),
     ])?;
+    crate::audit_log::apply_settings(&state.settings);
+    // 缩短保留期后立即清理，避免等待后台维护周期。
+    let retention_days = crate::audit_log::policy_from_settings(&state.settings).retention_days;
+    let pool = state.db.pool.clone();
+    tauri::async_runtime::spawn(async move {
+        if let Err(error) = crate::audit_log::cleanup_expired_logs(&pool, retention_days).await {
+            tracing::warn!(%error, "审计日志设置变更后的清理失败");
+        }
+    });
     Ok(())
 }
 

--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -89,16 +89,19 @@ pub async fn get_model_stats_impl(
 ) -> Result<Vec<ModelStatsDto>, String> {
     let repo = Repository::new(state.db.pool.clone());
     let stats = repo.get_model_stats().await.map_err(|e| e.to_string())?;
-    Ok(stats.into_iter().map(|s| ModelStatsDto {
-        model: s.model,
-        request_count: s.request_count,
-        input_tokens: s.input_tokens,
-        output_tokens: s.output_tokens,
-        cached_tokens: s.cached_tokens,
-        total_tokens: s.total_tokens,
-        success_rate: s.success_rate,
-        avg_latency_ms: s.avg_latency_ms,
-    }).collect())
+    Ok(stats
+        .into_iter()
+        .map(|s| ModelStatsDto {
+            model: s.model,
+            request_count: s.request_count,
+            input_tokens: s.input_tokens,
+            output_tokens: s.output_tokens,
+            cached_tokens: s.cached_tokens,
+            total_tokens: s.total_tokens,
+            success_rate: s.success_rate,
+            avg_latency_ms: s.avg_latency_ms,
+        })
+        .collect())
 }
 
 // ── Token 趋势 ──
@@ -128,14 +131,20 @@ pub async fn get_token_trend_impl(
 ) -> Result<Vec<TokenTrendPointDto>, String> {
     let hours = hours.unwrap_or(24);
     let repo = Repository::new(state.db.pool.clone());
-    let points = repo.get_token_trend(hours).await.map_err(|e| e.to_string())?;
-    Ok(points.into_iter().map(|p| TokenTrendPointDto {
-        hour: p.hour,
-        model: p.model,
-        input_tokens: p.input_tokens,
-        output_tokens: p.output_tokens,
-        cached_tokens: p.cached_tokens,
-        total_tokens: p.total_tokens,
-        request_count: p.request_count,
-    }).collect())
+    let points = repo
+        .get_token_trend(hours)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(points
+        .into_iter()
+        .map(|p| TokenTrendPointDto {
+            hour: p.hour,
+            model: p.model,
+            input_tokens: p.input_tokens,
+            output_tokens: p.output_tokens,
+            cached_tokens: p.cached_tokens,
+            total_tokens: p.total_tokens,
+            request_count: p.request_count,
+        })
+        .collect())
 }

--- a/src-tauri/src/commands/wiki.rs
+++ b/src-tauri/src/commands/wiki.rs
@@ -191,8 +191,8 @@ pub async fn save_wiki_page(
             "[]",
         )
         .await;
-    let _ =
-        crate::services::wiki::project::append_log(&project_id, &format!("update | {}", path)).await;
+    let _ = crate::services::wiki::project::append_log(&project_id, &format!("update | {}", path))
+        .await;
     Ok(())
 }
 

--- a/src-tauri/src/core/attempt.rs
+++ b/src-tauri/src/core/attempt.rs
@@ -1545,7 +1545,10 @@ mod tests {
             );
         }
         // 非 404 与无 body 版本逐字一致（对照矩阵抽样）。
-        assert_eq!(upstream_failover_decision_with_body(400, Some("x")), stop(400));
+        assert_eq!(
+            upstream_failover_decision_with_body(400, Some("x")),
+            stop(400)
+        );
         assert_eq!(upstream_failover_decision_with_body(401, None), stop(502));
         assert_eq!(upstream_failover_decision_with_body(405, None), stop(405));
         assert_eq!(

--- a/src-tauri/src/core/plan_executor.rs
+++ b/src-tauri/src/core/plan_executor.rs
@@ -201,7 +201,9 @@ where
                 let meta = last_attempt_meta;
                 let last_failure = flow.last_failure().cloned();
                 let body = match &last_failure {
-                    Some(f) => serde_json::json!({ "error": { "message": message, "failure_class": f.failure_class.as_str() } }),
+                    Some(f) => {
+                        serde_json::json!({ "error": { "message": message, "failure_class": f.failure_class.as_str() } })
+                    }
                     None => serde_json::json!({ "error": { "message": message } }),
                 };
                 return PlanExecution {

--- a/src-tauri/src/core/weighted_key.rs
+++ b/src-tauri/src/core/weighted_key.rs
@@ -36,10 +36,7 @@ mod tests {
     use std::collections::HashMap;
 
     fn pool(entries: &[(&str, i64)]) -> Vec<(String, i64)> {
-        entries
-            .iter()
-            .map(|(k, w)| (k.to_string(), *w))
-            .collect()
+        entries.iter().map(|(k, w)| (k.to_string(), *w)).collect()
     }
 
     /// 等权两 Key 的分布回归（#34 根因）：修复前第二个 Key 命中率为 0。

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -391,6 +391,54 @@ pub struct RequestLog {
     pub cached_tokens: i64,
 }
 
+/// Lightweight row used by the audit-log list. Large request/response bodies
+/// are intentionally excluded from this contract and loaded only by id.
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct RequestLogSummary {
+    pub id: String,
+    pub seq: Option<i64>,
+    pub api_key_name: Option<String>,
+    pub channel_name: Option<String>,
+    pub model: String,
+    pub upstream_model: Option<String>,
+    pub mode: String,
+    pub status_code: i64,
+    pub prompt_tokens: i64,
+    pub completion_tokens: i64,
+    pub total_tokens: i64,
+    pub cached_tokens: i64,
+    pub duration_ms: i64,
+    pub error_message: Option<String>,
+    pub is_stream: i64,
+    pub is_retry: i64,
+    pub created_at: String,
+    pub risk_level: String,
+    pub risk_score: i64,
+    pub risk_summary: Option<String>,
+    pub security_action: String,
+    pub sanitized: i64,
+    pub blocked_reason: Option<String>,
+    pub trace_id: Option<String>,
+    pub reasoning_effort: Option<String>,
+    pub downstream_protocol: Option<String>,
+    pub downstream_endpoint: Option<String>,
+    pub route_group: Option<String>,
+    pub upstream_protocol: Option<String>,
+    pub upstream_endpoint: Option<String>,
+    pub provider: Option<String>,
+    pub codec_version: Option<String>,
+    pub failure_class: Option<String>,
+    pub identity_revision: Option<i64>,
+    pub client_cancelled: Option<i64>,
+    pub stream_committed: Option<i64>,
+    pub upstream_type: String,
+    pub detail_level: String,
+    pub started_at: Option<String>,
+    pub request_body_bytes: i64,
+    pub response_choices_bytes: i64,
+    pub has_request_body: bool,
+}
+
 impl Default for RequestLog {
     fn default() -> Self {
         Self {

--- a/src-tauri/src/db/repository.rs
+++ b/src-tauri/src/db/repository.rs
@@ -1190,12 +1190,25 @@ impl Repository {
     // ==================== Request Log ====================
 
     pub async fn create_log(&self, log: &RequestLog) -> Result<(), sqlx::Error> {
+        self.create_log_with_policy(log, crate::audit_log::current_policy())
+            .await
+    }
+
+    /// Persist a request log using an explicit policy. The normal runtime path
+    /// uses `create_log`; this variant keeps policy application close to the
+    /// INSERT and makes the behavior independently testable.
+    pub async fn create_log_with_policy(
+        &self,
+        log: &RequestLog,
+        policy: crate::audit_log::LogPolicy,
+    ) -> Result<(), sqlx::Error> {
+        let log = crate::audit_log::effective_log_with_policy(log, policy);
         // Insert with seq auto-incremented via subquery (atomic, avoids race condition).
         // The 11 T09 observability columns (migration 016) are bound as Option<> so
         // legacy callers using `..Default::default()` persist NULLs for them.
         sqlx::query(
-            "INSERT INTO request_logs (id, seq, api_key_id, api_key_name, channel_id, channel_name, model, upstream_model, mode, status_code, prompt_tokens, completion_tokens, total_tokens, cached_tokens, duration_ms, error_message, is_stream, is_retry, created_at, request_body, response_choices, risk_level, risk_score, risk_summary, security_action, sanitized, blocked_reason, trace_id, reasoning_effort, downstream_protocol, downstream_endpoint, route_group, upstream_protocol, upstream_endpoint, provider, codec_version, failure_class, identity_revision, client_cancelled, stream_committed, upstream_type)
-             VALUES (?, (SELECT COALESCE(MAX(seq), 0) + 1 FROM request_logs), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            "INSERT INTO request_logs (id, seq, api_key_id, api_key_name, channel_id, channel_name, model, upstream_model, mode, status_code, prompt_tokens, completion_tokens, total_tokens, cached_tokens, duration_ms, error_message, is_stream, is_retry, created_at, request_body, response_choices, risk_level, risk_score, risk_summary, security_action, sanitized, blocked_reason, trace_id, reasoning_effort, downstream_protocol, downstream_endpoint, route_group, upstream_protocol, upstream_endpoint, provider, codec_version, failure_class, identity_revision, client_cancelled, stream_committed, upstream_type, detail_level)
+             VALUES (?, (SELECT COALESCE(MAX(seq), 0) + 1 FROM request_logs), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
         )
         .bind(&log.id)
         .bind(&log.api_key_id)
@@ -1237,6 +1250,10 @@ impl Repository {
         .bind(log.client_cancelled)
         .bind(log.stream_committed)
         .bind(&log.upstream_type)
+        .bind(match policy.detail_level {
+            crate::audit_log::LogDetailLevel::Detailed => "detailed",
+            crate::audit_log::LogDetailLevel::Basic => "basic",
+        })
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -1292,6 +1309,10 @@ impl Repository {
     }
 
     pub async fn delete_logs_before(&self, before_date: &str) -> Result<u64, sqlx::Error> {
+        sqlx::query("DELETE FROM request_security_findings WHERE log_id IN (SELECT id FROM request_logs WHERE created_at < ?)")
+            .bind(before_date)
+            .execute(&self.pool)
+            .await?;
         let result = sqlx::query("DELETE FROM request_logs WHERE created_at < ?")
             .bind(before_date)
             .execute(&self.pool)
@@ -1300,6 +1321,9 @@ impl Repository {
     }
 
     pub async fn delete_all_logs(&self) -> Result<u64, sqlx::Error> {
+        sqlx::query("DELETE FROM request_security_findings")
+            .execute(&self.pool)
+            .await?;
         let result = sqlx::query("DELETE FROM request_logs")
             .execute(&self.pool)
             .await?;
@@ -1307,6 +1331,10 @@ impl Repository {
     }
 
     pub async fn delete_log(&self, id: &str) -> Result<(), sqlx::Error> {
+        sqlx::query("DELETE FROM request_security_findings WHERE log_id = ?")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
         sqlx::query("DELETE FROM request_logs WHERE id = ?")
             .bind(id)
             .execute(&self.pool)
@@ -1322,6 +1350,92 @@ impl Repository {
         .bind(offset)
         .fetch_all(&self.pool)
         .await
+    }
+
+    pub async fn get_log_summaries(
+        &self,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<crate::db::models::RequestLogSummary>, sqlx::Error> {
+        self.search_log_summaries(
+            None, None, None, None, None, None, None, None, limit, offset,
+        )
+        .await
+    }
+
+    pub async fn search_log_summaries(
+        &self,
+        keyword: Option<&str>,
+        api_key_name: Option<&str>,
+        channel_name: Option<&str>,
+        model: Option<&str>,
+        date_from: Option<&str>,
+        date_to: Option<&str>,
+        trace_id: Option<&str>,
+        upstream_type: Option<&str>,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<crate::db::models::RequestLogSummary>, sqlx::Error> {
+        let mut q = sqlx::QueryBuilder::new(
+            "SELECT id, seq, api_key_name, channel_name, model, upstream_model, mode, status_code, \
+             prompt_tokens, completion_tokens, total_tokens, cached_tokens, duration_ms, error_message, \
+             is_stream, is_retry, created_at, risk_level, risk_score, risk_summary, security_action, \
+             sanitized, blocked_reason, trace_id, reasoning_effort, downstream_protocol, downstream_endpoint, \
+             route_group, upstream_protocol, upstream_endpoint, provider, codec_version, failure_class, \
+             identity_revision, client_cancelled, stream_committed, upstream_type, \
+             COALESCE(detail_level, 'detailed') AS detail_level, started_at, \
+             COALESCE(length(CAST(request_body AS BLOB)), 0) AS request_body_bytes, \
+             COALESCE(length(CAST(response_choices AS BLOB)), 0) AS response_choices_bytes, \
+             (request_body IS NOT NULL) AS has_request_body \
+             FROM request_logs WHERE 1=1",
+        );
+        if let Some(kw) = keyword {
+            let pattern = format!("%{}%", kw);
+            q.push(" AND (api_key_name LIKE ")
+                .push_bind(pattern.clone());
+            q.push(" OR channel_name LIKE ").push_bind(pattern.clone());
+            q.push(" OR model LIKE ").push_bind(pattern.clone());
+            q.push(" OR upstream_model LIKE ")
+                .push_bind(pattern.clone());
+            q.push(" OR api_key_id LIKE ").push_bind(pattern.clone());
+            q.push(" OR id LIKE ").push_bind(pattern);
+            q.push(")");
+        }
+        for (column, value) in [
+            ("api_key_name", api_key_name),
+            ("channel_name", channel_name),
+        ] {
+            if let Some(value) = value {
+                q.push(" AND ")
+                    .push(column)
+                    .push(" LIKE ")
+                    .push_bind(format!("%{}%", value));
+            }
+        }
+        if let Some(value) = model {
+            let pattern = format!("%{}%", value);
+            q.push(" AND (model LIKE ").push_bind(pattern.clone());
+            q.push(" OR upstream_model LIKE ").push_bind(pattern);
+            q.push(")");
+        }
+        if let Some(value) = date_from {
+            q.push(" AND created_at >= ").push_bind(value);
+        }
+        if let Some(value) = date_to {
+            q.push(" AND created_at <= ").push_bind(value);
+        }
+        if let Some(value) = trace_id {
+            q.push(" AND trace_id LIKE ")
+                .push_bind(format!("%{}%", value));
+        }
+        if let Some(value) = upstream_type {
+            q.push(" AND upstream_type = ").push_bind(value);
+        }
+        q.push(" ORDER BY created_at DESC LIMIT ").push_bind(limit);
+        q.push(" OFFSET ").push_bind(offset);
+        q.build_query_as::<crate::db::models::RequestLogSummary>()
+            .fetch_all(&self.pool)
+            .await
     }
 
     pub async fn search_logs(

--- a/src-tauri/src/endpoint_executor/driver.rs
+++ b/src-tauri/src/endpoint_executor/driver.rs
@@ -24,10 +24,11 @@ use crate::db::repository::Repository;
 use crate::endpoint_executor::sse::StreamPumpCore;
 use crate::endpoint_executor::{
     dispatch_auth_account_executor, dispatch_auth_account_stream_executor, dispatch_executor,
-    dispatch_stream_executor, next_upstream_item, StreamAttemptResult, UpstreamItem, UpstreamStream,
+    dispatch_stream_executor, next_upstream_item, StreamAttemptResult, UpstreamItem,
+    UpstreamStream,
 };
-use crate::security::gate::AuditedRequest;
 use crate::security;
+use crate::security::gate::AuditedRequest;
 use crate::utils;
 use axum::body::Body;
 use axum::http::{header, StatusCode};
@@ -71,8 +72,6 @@ fn extract_reasoning_effort(audited: &AuditedRequest) -> Option<String> {
         _ => None,
     }
 }
-
-
 
 /// Multi-key load balancing: if the channel has extra API keys in
 /// `channel_api_keys`, randomly select one weighted by `weight`. The
@@ -167,8 +166,9 @@ async fn record_channel_mode_outcome(
         }
         crate::core::attempt::AttemptResult::Failure(failure) if affects_mode_health(failure) => {
             let now = crate::utils::time::now_iso();
-            let cooldown_until = (Utc::now() + chrono::Duration::minutes(MODE_FAILURE_COOLDOWN_MINUTES))
-                .to_rfc3339_opts(SecondsFormat::Millis, true);
+            let cooldown_until = (Utc::now()
+                + chrono::Duration::minutes(MODE_FAILURE_COOLDOWN_MINUTES))
+            .to_rfc3339_opts(SecondsFormat::Millis, true);
             repo.record_channel_mode_failure(
                 channel_id,
                 endpoint,
@@ -444,16 +444,19 @@ async fn write_non_stream_log(
         }
         // OpenAI Responses API: synthesize from `output`
         else if let Some(output) = execution.body.get("output").and_then(|o| o.as_array()) {
-            let choices: Vec<serde_json::Value> = output.iter().map(|item| {
-                serde_json::json!({
-                    "index": item.get("index").unwrap_or(&serde_json::json!(0)),
-                    "message": {
-                        "role": "assistant",
-                        "content": item.get("content"),
-                    },
-                    "finish_reason": "stop",
+            let choices: Vec<serde_json::Value> = output
+                .iter()
+                .map(|item| {
+                    serde_json::json!({
+                        "index": item.get("index").unwrap_or(&serde_json::json!(0)),
+                        "message": {
+                            "role": "assistant",
+                            "content": item.get("content"),
+                        },
+                        "finish_reason": "stop",
+                    })
                 })
-            }).collect();
+                .collect();
             serde_json::to_string(&choices).ok()
         } else {
             None
@@ -1133,9 +1136,7 @@ fn upstream_snippet(bytes: &[u8], max_bytes: usize) -> String {
 /// upstream content-type (when not SSE), and a sanitized preview of what was
 /// actually read — that the driver appends to the stable
 /// "upstream stream ended before a valid first SSE record" message prefix.
-async fn buffer_first_record(
-    upstream: &mut UpstreamStream,
-) -> Result<(Vec<u8>, Vec<u8>), String> {
+async fn buffer_first_record(upstream: &mut UpstreamStream) -> Result<(Vec<u8>, Vec<u8>), String> {
     let mut buffer = Vec::new();
     let ct_note = if upstream
         .content_type
@@ -1215,7 +1216,10 @@ struct StreamSnapshot {
 /// 每帧后同步落账快照：用量恒新；响应内容/choices 首个非空内容立即快照
 /// （短流取消时才有正文可折算 completion），之后仅在协议终止或内容较上次
 /// 快照增长 ≥16KB 时重建——每帧重建会把流式复制放大成 O(n²)。
-fn update_stream_snapshot(snapshot: &std::sync::Arc<std::sync::Mutex<StreamSnapshot>>, pump: &StreamPumpCore) {
+fn update_stream_snapshot(
+    snapshot: &std::sync::Arc<std::sync::Mutex<StreamSnapshot>>,
+    pump: &StreamPumpCore,
+) {
     let mut s = snapshot.lock().unwrap_or_else(|e| e.into_inner());
     s.usage = pump.usage();
     let content = pump.accumulated_content();
@@ -1397,11 +1401,7 @@ impl Drop for StreamLogFinalizer {
 
 /// 取消行的实际写入（从 Drop 中拆出便于复用与测试）。
 async fn write_cancelled_row(f: &StreamLogFinalizer) {
-    let snap = f
-        .snapshot
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .clone();
+    let snap = f.snapshot.lock().unwrap_or_else(|e| e.into_inner()).clone();
     let (mut p, mut c, mut t, cached) = snap.usage;
     let choices = snap.response_choices;
     // 兜底：上游未回报 usage 时按请求体 + 已收到内容本地估算，
@@ -1415,8 +1415,17 @@ async fn write_cancelled_row(f: &StreamLogFinalizer) {
         c = ec;
         t = et;
     }
-    f.write(true, false, Some("client_cancelled"), p, c, t, cached, choices)
-        .await;
+    f.write(
+        true,
+        false,
+        Some("client_cancelled"),
+        p,
+        c,
+        t,
+        cached,
+        choices,
+    )
+    .await;
 }
 
 /// 流式超时配置（FIX-08）：首帧等待与帧间空闲分别限时，0 表示禁用该项。
@@ -1943,9 +1952,9 @@ mod tests {
         // ending the stream.  To test idle timeout specifically, we use a
         // stream that yields one chunk then hangs (pending forever).
         let first_chunk = first_chunk.to_vec();
-        let body = futures_util::stream::iter(vec![Ok::<_, std::io::Error>(
-            bytes::Bytes::from(first_chunk),
-        )])
+        let body = futures_util::stream::iter(vec![Ok::<_, std::io::Error>(bytes::Bytes::from(
+            first_chunk,
+        ))])
         .chain(futures_util::stream::pending())
         .boxed();
 
@@ -1954,8 +1963,7 @@ mod tests {
             headers: vec![],
             body,
         };
-        let (first_frame, carry) =
-            buffer_first_record(&mut upstream).await.unwrap();
+        let (first_frame, carry) = buffer_first_record(&mut upstream).await.unwrap();
         assert!(carry.is_empty(), "single record, no carry");
 
         let mut sup = crate::core::stream_supervisor::StreamSupervisor::new();
@@ -2454,10 +2462,7 @@ mod tests {
     /// 构造「首记录 + 内容/用量块 + 终止标记，随后挂死」的上游体：
     /// 协议终止事件之后上游流永远不结束（模拟 ModelScope 发完数据延迟关
     /// 连接甚至不关连接的行为），用于验证终止早退。
-    fn hanging_after_terminal_upstream(
-        with_stop: bool,
-        with_usage: bool,
-    ) -> UpstreamStream {
+    fn hanging_after_terminal_upstream(with_stop: bool, with_usage: bool) -> UpstreamStream {
         let mut chunks: Vec<Result<bytes::Bytes, std::io::Error>> = vec![Ok(bytes::Bytes::from_static(
             b"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"role\":\"assistant\",\"model\":\"up-model\",\"content\":[]}}\n\n",
         ))];
@@ -2471,7 +2476,9 @@ mod tests {
         }
         chunks.push(Ok(bytes::Bytes::from(second)));
         let body = futures_util::stream::iter(chunks)
-            .chain(futures_util::stream::pending::<Result<bytes::Bytes, std::io::Error>>())
+            .chain(futures_util::stream::pending::<
+                Result<bytes::Bytes, std::io::Error>,
+            >())
             .boxed();
         UpstreamStream {
             content_type: "text/event-stream".to_string(),
@@ -2544,7 +2551,17 @@ mod tests {
             duration_ms: 5,
             last_failure: None,
         };
-        write_non_stream_log(&repo, &api_key(), &audited, "chat", &execution, 5, "{}", None).await;
+        write_non_stream_log(
+            &repo,
+            &api_key(),
+            &audited,
+            "chat",
+            &execution,
+            5,
+            "{}",
+            None,
+        )
+        .await;
 
         let logs = repo.get_logs(10, 0).await.unwrap();
         assert_eq!(logs.len(), 1);
@@ -2668,25 +2685,34 @@ mod tests {
         // 上游挂死时若实现退化回「等 EOF」，这里 10s 超时直接失败。
         let mut bytes = Vec::new();
         tokio::pin!(stream);
-        let consumed = tokio::time::timeout(
-            std::time::Duration::from_secs(10),
-            async {
-                while let Some(item) = stream.next().await {
-                    bytes.extend_from_slice(&item.unwrap());
-                }
-            },
-        )
+        let consumed = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            while let Some(item) = stream.next().await {
+                bytes.extend_from_slice(&item.unwrap());
+            }
+        })
         .await;
-        assert!(consumed.is_ok(), "stream must complete on protocol terminal without upstream EOF");
+        assert!(
+            consumed.is_ok(),
+            "stream must complete on protocol terminal without upstream EOF"
+        );
 
         let logs = repo.get_logs(10, 0).await.unwrap();
         assert_eq!(logs.len(), 1, "exactly one row after terminal completion");
         let row = &logs[0];
-        assert_eq!(row.status_code, 200, "protocol-complete stream is a success, not 499: {row:?}");
-        assert_eq!(row.completion_tokens, 5, "upstream-reported usage must be recorded");
+        assert_eq!(
+            row.status_code, 200,
+            "protocol-complete stream is a success, not 499: {row:?}"
+        );
+        assert_eq!(
+            row.completion_tokens, 5,
+            "upstream-reported usage must be recorded"
+        );
         assert!(row.client_cancelled.unwrap_or(0) == 0);
         let choices = row.response_choices.as_deref().unwrap_or_default();
-        assert!(choices.contains("hi"), "accumulated content must be recorded: {choices}");
+        assert!(
+            choices.contains("hi"),
+            "accumulated content must be recorded: {choices}"
+        );
     }
 
     /// #57 取消路径：客户端中途断开（流被 drop）时，499 行记录流泵快照里
@@ -2842,14 +2868,11 @@ mod tests {
 
         let mut bytes = Vec::new();
         tokio::pin!(stream);
-        let finished = tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            async {
-                while let Some(item) = stream.next().await {
-                    bytes.extend_from_slice(&item.unwrap());
-                }
-            },
-        )
+        let finished = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while let Some(item) = stream.next().await {
+                bytes.extend_from_slice(&item.unwrap());
+            }
+        })
         .await;
         assert!(finished.is_ok(), "idle timeout must end the hung stream");
         let text = String::from_utf8_lossy(&bytes);
@@ -2861,7 +2884,10 @@ mod tests {
         // 提交后超时 = 流错误：落 502 行（非 499、非成功 200）。
         let logs = repo.get_logs(10, 0).await.unwrap();
         assert_eq!(logs.len(), 1);
-        assert_eq!(logs[0].status_code, 502, "idle timeout is a stream error: {logs:?}");
+        assert_eq!(
+            logs[0].status_code, 502,
+            "idle timeout is a stream error: {logs:?}"
+        );
     }
 
     /// FIX-08：StreamTimeouts 缺省值——首帧 60s、空闲 120s。

--- a/src-tauri/src/endpoint_executor/estimate_usage.rs
+++ b/src-tauri/src/endpoint_executor/estimate_usage.rs
@@ -150,8 +150,7 @@ static CL100K_SINGLETON: std::sync::OnceLock<Option<tiktoken_rs::CoreBPE>> =
 
 /// 仅供测试观察：BPE 实际构建次数。
 #[cfg(test)]
-static CL100K_BUILDS: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
+static CL100K_BUILDS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
 fn cl100k_singleton() -> Option<&'static tiktoken_rs::CoreBPE> {
     CL100K_SINGLETON
@@ -161,7 +160,9 @@ fn cl100k_singleton() -> Option<&'static tiktoken_rs::CoreBPE> {
             match cl100k_base() {
                 Ok(bpe) => Some(bpe),
                 Err(e) => {
-                    tracing::warn!("cl100k_base tokenizer init failed, falling back to char estimate: {e}");
+                    tracing::warn!(
+                        "cl100k_base tokenizer init failed, falling back to char estimate: {e}"
+                    );
                     None
                 }
             }

--- a/src-tauri/src/endpoint_executor/mod.rs
+++ b/src-tauri/src/endpoint_executor/mod.rs
@@ -105,10 +105,7 @@ pub enum UpstreamItem<E> {
 ///
 /// If the stream does not produce an item within `idle_timeout`, returns
 /// [`UpstreamItem::IdleTimeout`] instead of waiting indefinitely.
-pub async fn next_upstream_item<S, E>(
-    upstream: &mut S,
-    idle_timeout: Duration,
-) -> UpstreamItem<E>
+pub async fn next_upstream_item<S, E>(upstream: &mut S, idle_timeout: Duration) -> UpstreamItem<E>
 where
     S: futures_util::Stream<Item = Result<bytes::Bytes, E>> + Unpin,
 {
@@ -1077,11 +1074,7 @@ pub fn extract_usage(protocol: &str, endpoint: &str, body: &Value) -> Option<Tok
             .and_then(|d| d.get("cached_tokens"))
             .and_then(Value::as_u64)
             .or_else(|| usage.get("cache_read_input_tokens").and_then(Value::as_u64))
-            .or_else(|| {
-                usage
-                    .get("prompt_cache_hit_tokens")
-                    .and_then(Value::as_u64)
-            })
+            .or_else(|| usage.get("prompt_cache_hit_tokens").and_then(Value::as_u64))
             .unwrap_or(0);
         return Some(TokenUsage {
             prompt_tokens: input,
@@ -1105,9 +1098,7 @@ pub fn extract_usage(protocol: &str, endpoint: &str, body: &Value) -> Option<Tok
         .and_then(Value::as_u64)
         .or_else(|| {
             // DeepSeek-compatible upstreams use their own cache-hit field.
-            usage
-                .get("prompt_cache_hit_tokens")
-                .and_then(Value::as_u64)
+            usage.get("prompt_cache_hit_tokens").and_then(Value::as_u64)
         })
         .unwrap_or(0);
     Some(TokenUsage {
@@ -1201,7 +1192,11 @@ mod tests {
         headers.insert("retry-after", "3600".parse().unwrap());
         let dur = retry_after_from_headers(&headers).unwrap();
         // With ±20% jitter on 5s, range is [4, 6].
-        assert!(dur.as_secs() >= 4 && dur.as_secs() <= 6, "capped+jit={:?}", dur);
+        assert!(
+            dur.as_secs() >= 4 && dur.as_secs() <= 6,
+            "capped+jit={:?}",
+            dur
+        );
     }
 
     #[test]

--- a/src-tauri/src/endpoint_executor/sse.rs
+++ b/src-tauri/src/endpoint_executor/sse.rs
@@ -41,7 +41,8 @@ pub fn parse_data_payload(record: &[u8]) -> Result<String, String> {
 /// 标记，防止故障/恶意上游把内存与日志体积放大到失控。下游转发不受影响
 /// （转发的字节不经过累积），仅影响落库的 response_choices。
 pub(crate) const MAX_ACCUMULATED_CONTENT_BYTES: usize = 4 * 1024 * 1024;
-pub(crate) const ACCUMULATION_TRUNCATION_MARKER: &str = "\n\n[... WaLiAPI: accumulated content truncated ...]";
+pub(crate) const ACCUMULATION_TRUNCATION_MARKER: &str =
+    "\n\n[... WaLiAPI: accumulated content truncated ...]";
 
 /// Validate only enough framing to retain the pre-commit failover barrier.
 /// Full protocol validation belongs to the decoder factory selected at prepare
@@ -137,7 +138,14 @@ impl StreamPumpCore {
             })?;
             for event in &events {
                 output.extend_from_slice(event.as_bytes());
-                accumulate_from_sse_event(event, &mut accumulated_content, &mut accumulated_reasoning, &mut response_role, &mut finish_reason, &mut tool_calls_map);
+                accumulate_from_sse_event(
+                    event,
+                    &mut accumulated_content,
+                    &mut accumulated_reasoning,
+                    &mut response_role,
+                    &mut finish_reason,
+                    &mut tool_calls_map,
+                );
                 terminal_registered |= sse_event_is_terminal(event);
             }
         }
@@ -203,7 +211,9 @@ impl StreamPumpCore {
 
     /// 帧间空闲超时观测（FIX-08）：记录到流监督状态机供诊断，不改变泵状态。
     pub fn mark_idle_timeout(&mut self) {
-        let _ = self.supervisor.on_timeout(crate::core::stream_supervisor::StreamTimeoutKind::StreamIdle);
+        let _ = self
+            .supervisor
+            .on_timeout(crate::core::stream_supervisor::StreamTimeoutKind::StreamIdle);
     }
 
     pub fn finish(&mut self) -> Result<Vec<u8>, PumpError> {
@@ -255,7 +265,8 @@ impl StreamPumpCore {
         if !self.accumulation_truncated
             && self.accumulated_content.len() >= MAX_ACCUMULATED_CONTENT_BYTES
         {
-            self.accumulated_content.push_str(ACCUMULATION_TRUNCATION_MARKER);
+            self.accumulated_content
+                .push_str(ACCUMULATION_TRUNCATION_MARKER);
             self.accumulation_truncated = true;
         }
         if self.accumulation_truncated {
@@ -342,19 +353,13 @@ fn accumulate_from_sse_event(
         if let Some(choices) = v.get("choices").and_then(|c| c.as_array()) {
             for choice in choices {
                 // role (usually on the first delta)
-                if let Some(r) = choice
-                    .pointer("/delta/role")
-                    .and_then(|r| r.as_str())
-                {
+                if let Some(r) = choice.pointer("/delta/role").and_then(|r| r.as_str()) {
                     if role.is_none() {
                         *role = Some(r.to_string());
                     }
                 }
                 // content
-                if let Some(c) = choice
-                    .pointer("/delta/content")
-                    .and_then(|c| c.as_str())
-                {
+                if let Some(c) = choice.pointer("/delta/content").and_then(|c| c.as_str()) {
                     content.push_str(c);
                 }
                 // reasoning_content (DeepSeek / OpenAI o-series)
@@ -370,10 +375,7 @@ fn accumulate_from_sse_event(
                     .and_then(|tc| tc.as_array())
                 {
                     for tc in tcs {
-                        let idx = tc
-                            .get("index")
-                            .and_then(|i| i.as_i64())
-                            .unwrap_or(0);
+                        let idx = tc.get("index").and_then(|i| i.as_i64()).unwrap_or(0);
                         let entry = tool_calls_map
                             .entry(idx)
                             .or_insert_with(|| serde_json::json!({"index": idx, "id": null, "type": "function", "function": {"name": "", "arguments": ""}}));
@@ -383,9 +385,15 @@ fn accumulate_from_sse_event(
                         if let Some(t) = tc.pointer("/function/name").and_then(|n| n.as_str()) {
                             entry["function"]["name"] = serde_json::json!(t);
                         }
-                        if let Some(args) = tc.pointer("/function/arguments").and_then(|a| a.as_str()) {
-                            if let Some(existing) = entry.pointer("/function/arguments").and_then(|a| a.as_str()) {
-                                entry["function"]["arguments"] = serde_json::json!(format!("{existing}{args}"));
+                        if let Some(args) =
+                            tc.pointer("/function/arguments").and_then(|a| a.as_str())
+                        {
+                            if let Some(existing) = entry
+                                .pointer("/function/arguments")
+                                .and_then(|a| a.as_str())
+                            {
+                                entry["function"]["arguments"] =
+                                    serde_json::json!(format!("{existing}{args}"));
                             } else {
                                 entry["function"]["arguments"] = serde_json::json!(args);
                             }
@@ -414,7 +422,9 @@ fn accumulate_from_sse_event(
                         if block.get("type").and_then(|t| t.as_str()) == Some("tool_use") {
                             let idx = block.get("id").and_then(|i| i.as_str()).unwrap_or("");
                             // Use a hash of the id as the key for tool calls
-                            let key = idx.bytes().fold(0i64, |acc, b| acc.wrapping_mul(31).wrapping_add(b as i64));
+                            let key = idx
+                                .bytes()
+                                .fold(0i64, |acc, b| acc.wrapping_mul(31).wrapping_add(b as i64));
                             tool_calls_map.insert(key, serde_json::json!({
                                 "index": key,
                                 "id": idx,
@@ -441,8 +451,13 @@ fn accumulate_from_sse_event(
                                 // Append to the most recent tool call's arguments
                                 if let Some((&_k, _)) = tool_calls_map.last_key_value() {
                                     if let Some(entry) = tool_calls_map.get_mut(&_k) {
-                                        let existing = entry.pointer("/function/arguments").and_then(|a| a.as_str()).unwrap_or("").to_string();
-                                        entry["function"]["arguments"] = serde_json::json!(format!("{existing}{pj}"));
+                                        let existing = entry
+                                            .pointer("/function/arguments")
+                                            .and_then(|a| a.as_str())
+                                            .unwrap_or("")
+                                            .to_string();
+                                        entry["function"]["arguments"] =
+                                            serde_json::json!(format!("{existing}{pj}"));
                                     }
                                 }
                             }
@@ -709,7 +724,15 @@ mod tests {
         assert!(error.message().contains("bad upstream event"));
     }
 
-    fn accumulate(event: &str) -> (String, String, Option<String>, Option<String>, std::collections::BTreeMap<i64, serde_json::Value>) {
+    fn accumulate(
+        event: &str,
+    ) -> (
+        String,
+        String,
+        Option<String>,
+        Option<String>,
+        std::collections::BTreeMap<i64, serde_json::Value>,
+    ) {
         let mut content = String::new();
         let mut reasoning = String::new();
         let mut role = None;
@@ -731,12 +754,10 @@ mod tests {
     /// `response_choices` empty for every streaming Responses request.
     #[test]
     fn responses_api_output_text_deltas_are_accumulated() {
-        let (mut content, ..) = accumulate(
-            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}",
-        );
-        let (c2, reasoning, _, _, _) = accumulate(
-            "data: {\"type\":\"response.output_text.delta\",\"delta\":\" world\"}",
-        );
+        let (mut content, ..) =
+            accumulate("data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}");
+        let (c2, reasoning, _, _, _) =
+            accumulate("data: {\"type\":\"response.output_text.delta\",\"delta\":\" world\"}");
         content.push_str(&c2);
         assert_eq!(content, "Hello world");
         assert!(reasoning.is_empty());
@@ -765,7 +786,10 @@ mod tests {
         );
         assert_eq!(tool_calls.len(), 1);
         let tc = tool_calls.values().next().unwrap();
-        assert_eq!(tc.pointer("/function/name").and_then(|n| n.as_str()), Some("get_weather"));
+        assert_eq!(
+            tc.pointer("/function/name").and_then(|n| n.as_str()),
+            Some("get_weather")
+        );
         assert!(tc
             .pointer("/function/arguments")
             .and_then(|a| a.as_str())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod adaptor;
+pub mod audit_log;
 #[cfg(test)]
 mod auth_integration_tests;
 pub mod auth_provider;
@@ -12,8 +13,8 @@ mod protocol;
 mod rollout_integration_tests;
 pub mod security;
 pub mod server;
-pub mod settings_store;
 pub mod services;
+pub mod settings_store;
 pub mod utils;
 pub mod web_server;
 
@@ -74,7 +75,11 @@ pub struct AppState {
 pub fn run() {
     // 获取可执行文件所在目录
     let exe_dir = std::env::current_exe()
-        .map(|path| path.parent().map(|p| p.to_path_buf()).unwrap_or(std::path::PathBuf::from(".")))
+        .map(|path| {
+            path.parent()
+                .map(|p| p.to_path_buf())
+                .unwrap_or(std::path::PathBuf::from("."))
+        })
         .unwrap_or(std::path::PathBuf::from("."));
 
     // 日志目录：数据目录下的 logs/（与 headless 一致、用户可写）。此前写
@@ -203,9 +208,8 @@ pub fn run() {
                     Arc::new(db::repository::Repository::new(db.pool.clone())),
                     auth_provider::ProviderRegistry::new(),
                 ));
-                let (event_tx, _) = tokio::sync::broadcast::channel(
-                    server::event_bridge::EVENT_CHANNEL_CAPACITY,
-                );
+                let (event_tx, _) =
+                    tokio::sync::broadcast::channel(server::event_bridge::EVENT_CHANNEL_CAPACITY);
                 let emit_handle = app_handle.clone();
                 let state = Arc::new(AppState {
                     db,
@@ -231,6 +235,12 @@ pub fn run() {
                     data_dir,
                 });
                 app_handle.manage(state.clone());
+
+                crate::audit_log::apply_settings(&state.settings);
+                tauri::async_runtime::spawn(crate::audit_log::run_maintenance_loop(
+                    state.db.pool.clone(),
+                    state.settings.clone(),
+                ));
 
                 tauri::async_runtime::spawn(async move {
                     auth_provider::maintenance::run_maintenance_loop(auth_service).await;
@@ -413,6 +423,11 @@ fn should_close_to_tray(app: &tauri::AppHandle) -> bool {
 
 fn env_flag(name: &str) -> bool {
     std::env::var(name)
-        .map(|value| matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
         .unwrap_or(false)
 }

--- a/src-tauri/src/protocol/anthropic.rs
+++ b/src-tauri/src/protocol/anthropic.rs
@@ -37,7 +37,11 @@ fn event(name: &str, value: Value) -> String {
 
 impl AnthropicStreamState {
     pub fn usage(&self) -> (i64, i64, i64) {
-        (self.input_tokens as i64, self.output_tokens as i64, self.cached_tokens as i64)
+        (
+            self.input_tokens as i64,
+            self.output_tokens as i64,
+            self.cached_tokens as i64,
+        )
     }
     /// Feed arbitrary network bytes.  A TCP chunk may split a UTF-8 codepoint,
     /// an SSE field, or the CRLF event delimiter, so bytes are retained until a

--- a/src-tauri/src/protocol/codec/directions/responses_to_messages/decode.rs
+++ b/src-tauri/src/protocol/codec/directions/responses_to_messages/decode.rs
@@ -85,7 +85,11 @@ fn usage_from_messages(value: &Value) -> Usage {
         cache_read_input_tokens: value
             .pointer("/usage/cache_read_input_tokens")
             .and_then(Value::as_u64)
-            .or_else(|| value.pointer("/usage/input_tokens_details/cached_tokens").and_then(Value::as_u64))
+            .or_else(|| {
+                value
+                    .pointer("/usage/input_tokens_details/cached_tokens")
+                    .and_then(Value::as_u64)
+            })
             .unwrap_or(0),
         usage_unknown: input.is_none() || output.is_none(),
     }
@@ -107,7 +111,11 @@ pub(super) fn merge_usage(usage: &mut Usage, value: &Value) {
     if let Some(cache_read) = value
         .get("cache_read_input_tokens")
         .and_then(Value::as_u64)
-        .or_else(|| value.pointer("/input_tokens_details/cached_tokens").and_then(Value::as_u64))
+        .or_else(|| {
+            value
+                .pointer("/input_tokens_details/cached_tokens")
+                .and_then(Value::as_u64)
+        })
     {
         usage.cache_read_input_tokens = cache_read;
     }

--- a/src-tauri/src/protocol/codec/identity.rs
+++ b/src-tauri/src/protocol/codec/identity.rs
@@ -190,9 +190,7 @@ impl IdentityStreamDecoder {
                 // DeepSeek-compatible upstreams report cache hits with their
                 // own field names instead of OpenAI *_details or Anthropic
                 // cache_read_input_tokens.
-                usage
-                    .get("prompt_cache_hit_tokens")
-                    .and_then(Value::as_u64)
+                usage.get("prompt_cache_hit_tokens").and_then(Value::as_u64)
             })
         {
             merged.cache_read_input_tokens = cache_read;
@@ -303,11 +301,7 @@ pub(crate) fn parse_usage(protocol: Protocol, body: &Value) -> Option<Usage> {
                     .and_then(|d| d.get("cached_tokens"))
                     .and_then(Value::as_u64)
             })
-            .or_else(|| {
-                usage
-                    .get("prompt_cache_hit_tokens")
-                    .and_then(Value::as_u64)
-            })
+            .or_else(|| usage.get("prompt_cache_hit_tokens").and_then(Value::as_u64))
             .unwrap_or_default(),
         usage_unknown: input.is_none() || output.is_none(),
     })

--- a/src-tauri/src/protocol/codec/messages/mod.rs
+++ b/src-tauri/src/protocol/codec/messages/mod.rs
@@ -13,8 +13,8 @@ mod message;
 mod stream;
 
 pub use decode::{decode_messages_response_to_chat, NonStreamResponseDecoder};
-pub use encode::encode_messages_to_chat;
 pub(crate) use encode::anthropic_thinking_to_reasoning_effort;
+pub use encode::encode_messages_to_chat;
 pub use stream::MessagesStreamDecoder;
 // Facade contract: these pre-split public items stay reachable through
 // `messages::` (zero public API change).  `usage_from_messages` has no in-crate

--- a/src-tauri/src/protocol/codec/responses_codec/decode.rs
+++ b/src-tauri/src/protocol/codec/responses_codec/decode.rs
@@ -159,7 +159,11 @@ pub fn usage_from_responses(response: &Value) -> Usage {
     let cached = response
         .pointer("/usage/input_tokens_details/cached_tokens")
         .and_then(Value::as_u64)
-        .or_else(|| response.pointer("/usage/cache_read_input_tokens").and_then(Value::as_u64))
+        .or_else(|| {
+            response
+                .pointer("/usage/cache_read_input_tokens")
+                .and_then(Value::as_u64)
+        })
         .unwrap_or(0);
     Usage {
         input_tokens: input.unwrap_or(0),

--- a/src-tauri/src/protocol/codec/responses_codec/tests.rs
+++ b/src-tauri/src/protocol/codec/responses_codec/tests.rs
@@ -265,9 +265,16 @@ data: {"type":"response.function_call_arguments.done","output_index":0,"item_id"
 
     // delta 事件本身不应该出现在下游输出里——不下发任何参数内容
     for line in output.lines() {
-        let Some(rest) = line.strip_prefix("data: ") else { continue };
-        let Ok(v) = serde_json::from_str::<serde_json::Value>(rest) else { continue };
-        if let Some(tcs) = v.pointer("/choices/0/delta/tool_calls").and_then(|t| t.as_array()) {
+        let Some(rest) = line.strip_prefix("data: ") else {
+            continue;
+        };
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(rest) else {
+            continue;
+        };
+        if let Some(tcs) = v
+            .pointer("/choices/0/delta/tool_calls")
+            .and_then(|t| t.as_array())
+        {
             for tc in tcs {
                 if let Some(a) = tc.pointer("/function/arguments").and_then(|a| a.as_str()) {
                     assert_eq!(
@@ -284,7 +291,11 @@ data: {"type":"response.function_call_arguments.done","output_index":0,"item_id"
         1,
         "id 应恰好出现一次"
     );
-    assert_eq!(output.matches("Shanghai").count(), 1, "完整参数应恰好发送一次");
+    assert_eq!(
+        output.matches("Shanghai").count(),
+        1,
+        "完整参数应恰好发送一次"
+    );
 }
 
 #[test]

--- a/src-tauri/src/security/mod.rs
+++ b/src-tauri/src/security/mod.rs
@@ -349,7 +349,11 @@ mod merge_tests {
         scan_response_into(&mut request, &body, &settings_with_response_scan(), &[]);
         assert!(!request.findings.is_empty(), "secret must produce findings");
         assert_ne!(request.risk_level, RiskLevel::Clean);
-        assert!(request.summary.contains("响应侧"), "summary: {}", request.summary);
+        assert!(
+            request.summary.contains("响应侧"),
+            "summary: {}",
+            request.summary
+        );
         assert!(request.findings.iter().all(|f| f.phase == "response"));
     }
 

--- a/src-tauri/src/server/admin_auth.rs
+++ b/src-tauri/src/server/admin_auth.rs
@@ -52,7 +52,8 @@ impl SessionStore {
                 *last = Instant::now();
             }
         }
-        self.inner.insert(token, (session, Instant::now() + SESSION_TTL));
+        self.inner
+            .insert(token, (session, Instant::now() + SESSION_TTL));
     }
 
     pub fn get(&self, token: &str) -> Option<AdminSession> {
@@ -72,7 +73,8 @@ impl SessionStore {
 
     /// 吊销某用户的全部会话（FIX-17：改密后旧会话一律失效）。
     pub fn revoke_all_for_user(&self, user_id: &str) {
-        self.inner.retain(|_, (session, _)| session.user_id != user_id);
+        self.inner
+            .retain(|_, (session, _)| session.user_id != user_id);
     }
 
     /// 清扫全部过期会话（FIX-17：不依赖逐条 get 才惰性删除）。
@@ -142,12 +144,18 @@ impl LoginThrottle {
             Some(e) if now.duration_since(e.last_failure) <= FAIL_MEMORY => e.failures + 1,
             _ => 1,
         };
-        self.inner
-            .insert(key.to_string(), FailEntry { failures: next, last_failure: now });
+        self.inner.insert(
+            key.to_string(),
+            FailEntry {
+                failures: next,
+                last_failure: now,
+            },
+        );
         // 顺带修剪长期无活动的条目，防随机用户名撑爆计数表。
         if let Ok(mut last) = self.last_prune.lock() {
             if last.elapsed() >= FAIL_MEMORY {
-                self.inner.retain(|_, e| now.duration_since(e.last_failure) <= FAIL_MEMORY);
+                self.inner
+                    .retain(|_, e| now.duration_since(e.last_failure) <= FAIL_MEMORY);
                 *last = now;
             }
         }
@@ -236,7 +244,11 @@ pub async fn find_user_by_username(
     }))
 }
 
-pub async fn update_password(pool: &SqlitePool, user_id: &str, new_password: &str) -> Result<(), String> {
+pub async fn update_password(
+    pool: &SqlitePool,
+    user_id: &str,
+    new_password: &str,
+) -> Result<(), String> {
     let hash = hash_password(new_password)?;
     let now = chrono::Utc::now().to_rfc3339();
     sqlx::query("UPDATE admin_users SET password_hash = ?, must_change_password = 0, updated_at = ? WHERE id = ?")
@@ -249,7 +261,11 @@ pub async fn update_password(pool: &SqlitePool, user_id: &str, new_password: &st
     Ok(())
 }
 
-pub async fn update_username(pool: &SqlitePool, user_id: &str, new_username: &str) -> Result<(), String> {
+pub async fn update_username(
+    pool: &SqlitePool,
+    user_id: &str,
+    new_username: &str,
+) -> Result<(), String> {
     let now = chrono::Utc::now().to_rfc3339();
     sqlx::query("UPDATE admin_users SET username = ?, updated_at = ? WHERE id = ?")
         .bind(new_username)
@@ -263,7 +279,10 @@ pub async fn update_username(pool: &SqlitePool, user_id: &str, new_username: &st
 
 /// 首次启动时若无 admin 用户，创建 admin + 随机 16 位密码并写入 INITIAL_PASSWORD 文件。
 /// `data_dir` 为应用数据目录（容器内 /data/<identifier>）。
-pub async fn ensure_initial_admin(pool: &SqlitePool, data_dir: &std::path::Path) -> Result<(), String> {
+pub async fn ensure_initial_admin(
+    pool: &SqlitePool,
+    data_dir: &std::path::Path,
+) -> Result<(), String> {
     let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM admin_users")
         .fetch_one(pool)
         .await
@@ -302,7 +321,10 @@ pub async fn ensure_initial_admin(pool: &SqlitePool, data_dir: &std::path::Path)
         log::warn!("创建数据目录失败: {e}");
     }
     let file = data_dir.join("INITIAL_PASSWORD");
-    if let Err(e) = std::fs::write(&file, format!("username: {username}\npassword: {password}\n")) {
+    if let Err(e) = std::fs::write(
+        &file,
+        format!("username: {username}\npassword: {password}\n"),
+    ) {
         log::warn!("写入 INITIAL_PASSWORD 失败: {e}");
     } else {
         log::info!("初始密码已写入 {}", file.display());
@@ -396,7 +418,10 @@ mod tests {
         }
         assert_eq!(throttle.penalty_remaining("alice", t0), Duration::ZERO);
         assert_eq!(throttle.penalty_remaining("dave", t0), Duration::ZERO);
-        assert_eq!(throttle.penalty_remaining(LOGIN_GLOBAL_KEY, t0), Duration::ZERO);
+        assert_eq!(
+            throttle.penalty_remaining(LOGIN_GLOBAL_KEY, t0),
+            Duration::ZERO
+        );
     }
 
     #[test]

--- a/src-tauri/src/server/admin_routes.rs
+++ b/src-tauri/src/server/admin_routes.rs
@@ -127,7 +127,8 @@ async fn require_auth(
         .admin_sessions
         .get(&token)
         .ok_or_else(unauthorized)?;
-    req.extensions_mut().insert(AdminIdentity { token, session });
+    req.extensions_mut()
+        .insert(AdminIdentity { token, session });
     Ok(next.run(req).await)
 }
 
@@ -266,9 +267,7 @@ async fn logout(
     let mut response = Json(json!({ "ok": true })).into_response();
     response.headers_mut().insert(
         header::SET_COOKIE,
-        HeaderValue::from_static(
-            "waliapi_admin_token=; Path=/; Max-Age=0; SameSite=Lax; HttpOnly",
-        ),
+        HeaderValue::from_static("waliapi_admin_token=; Path=/; Max-Age=0; SameSite=Lax; HttpOnly"),
     );
     response
 }
@@ -307,10 +306,7 @@ async fn change_password(
 
     // 改密吊销该用户全部旧会话（FIX-17）：密码已轮换，改密前签发的
     // 会话（含其他设备）一律失效；当前会话凭新状态续期，无需重新登录。
-    shared
-        .state
-        .admin_sessions
-        .revoke_all_for_user(&user.id);
+    shared.state.admin_sessions.revoke_all_for_user(&user.id);
     let session = AdminSession {
         must_change_password: false,
         ..identity.session.clone()
@@ -348,9 +344,13 @@ async fn change_username(
     {
         return Err(bad_request("用户名已被占用".to_string()));
     }
-    admin_auth::update_username(&shared.state.db.pool, &identity.session.user_id, &new_username)
-        .await
-        .map_err(internal_error)?;
+    admin_auth::update_username(
+        &shared.state.db.pool,
+        &identity.session.user_id,
+        &new_username,
+    )
+    .await
+    .map_err(internal_error)?;
 
     // 同步更新当前会话中的用户名
     let session = AdminSession {
@@ -446,12 +446,10 @@ async fn dispatch(shared: &SharedState, cmd: &str, args: Value) -> Result<Value,
         "update_channel" => {
             to_json(commands::channel::update_channel(arg(&args, "input")?, state).await)
         }
-        "toggle_channel" => {
-            to_json(
-                commands::channel::toggle_channel(arg(&args, "id")?, arg(&args, "status")?, state)
-                    .await,
-            )
-        }
+        "toggle_channel" => to_json(
+            commands::channel::toggle_channel(arg(&args, "id")?, arg(&args, "status")?, state)
+                .await,
+        ),
         "delete_channel" => {
             to_json(commands::channel::delete_channel(arg(&args, "id")?, state).await)
         }
@@ -469,21 +467,17 @@ async fn dispatch(shared: &SharedState, cmd: &str, args: Value) -> Result<Value,
         "get_channel_extra_keys" => {
             to_json(commands::channel::get_channel_extra_keys(arg(&args, "id")?, state).await)
         }
-        "get_channel_extra_key_value" => {
-            to_json(
-                commands::channel::get_channel_extra_key_value(arg(&args, "keyId")?, state).await,
+        "get_channel_extra_key_value" => to_json(
+            commands::channel::get_channel_extra_key_value(arg(&args, "keyId")?, state).await,
+        ),
+        "toggle_channel_extra_key" => to_json(
+            commands::channel::toggle_channel_extra_key(
+                arg(&args, "keyId")?,
+                arg(&args, "status")?,
+                state,
             )
-        }
-        "toggle_channel_extra_key" => {
-            to_json(
-                commands::channel::toggle_channel_extra_key(
-                    arg(&args, "keyId")?,
-                    arg(&args, "status")?,
-                    state,
-                )
-                .await,
-            )
-        }
+            .await,
+        ),
         "delete_channel_extra_key" => {
             to_json(commands::channel::delete_channel_extra_key(arg(&args, "keyId")?, state).await)
         }
@@ -558,28 +552,24 @@ async fn dispatch(shared: &SharedState, cmd: &str, args: Value) -> Result<Value,
         "auth_login_cancel" => {
             to_json(commands::auth::auth_login_cancel(arg(&args, "sessionId")?, state).await)
         }
-        "auth_login_import" => {
-            to_json(
-                commands::auth::auth_login_import(
-                    arg(&args, "provider")?,
-                    arg(&args, "path")?,
-                    arg(&args, "format")?,
-                    state,
-                )
-                .await,
+        "auth_login_import" => to_json(
+            commands::auth::auth_login_import(
+                arg(&args, "provider")?,
+                arg(&args, "path")?,
+                arg(&args, "format")?,
+                state,
             )
-        }
-        "auth_login_import_content" => {
-            to_json(
-                commands::auth::auth_login_import_content(
-                    arg(&args, "provider")?,
-                    arg(&args, "content")?,
-                    arg(&args, "format")?,
-                    state,
-                )
-                .await,
+            .await,
+        ),
+        "auth_login_import_content" => to_json(
+            commands::auth::auth_login_import_content(
+                arg(&args, "provider")?,
+                arg(&args, "content")?,
+                arg(&args, "format")?,
+                state,
             )
-        }
+            .await,
+        ),
         "auth_default_import_path" => to_json(commands::auth::auth_default_import_path().await),
         "auth_logout" => to_json(commands::auth::auth_logout(arg(&args, "id")?, state).await),
         "auth_refresh_token" => {
@@ -591,21 +581,15 @@ async fn dispatch(shared: &SharedState, cmd: &str, args: Value) -> Result<Value,
         "auth_sync_models" => {
             to_json(commands::auth::auth_sync_models(arg(&args, "id")?, state).await)
         }
-        "auth_export_json" => {
-            to_json(
-                commands::auth::auth_export_json(arg(&args, "id")?, arg(&args, "path")?, state)
-                    .await,
-            )
-        }
+        "auth_export_json" => to_json(
+            commands::auth::auth_export_json(arg(&args, "id")?, arg(&args, "path")?, state).await,
+        ),
         "auth_export_json_content" => {
             to_json(commands::auth::auth_export_json_content(arg(&args, "id")?, state).await)
         }
-        "auth_toggle" => {
-            to_json(
-                commands::auth::auth_toggle(arg(&args, "id")?, arg(&args, "disabled")?, state)
-                    .await,
-            )
-        }
+        "auth_toggle" => to_json(
+            commands::auth::auth_toggle(arg(&args, "id")?, arg(&args, "disabled")?, state).await,
+        ),
         "auth_quota_status" => {
             to_json(commands::auth::auth_quota_status(arg(&args, "id")?, state).await)
         }
@@ -614,7 +598,9 @@ async fn dispatch(shared: &SharedState, cmd: &str, args: Value) -> Result<Value,
         // ── 仪表盘 / 设置 / 服务状态 ──
         "get_dashboard_stats" => to_json(commands::stats::get_dashboard_stats(state).await),
         "get_model_stats" => to_json(commands::stats::get_model_stats(state).await),
-        "get_token_trend" => to_json(commands::stats::get_token_trend(arg(&args, "hours")?, state).await),
+        "get_token_trend" => {
+            to_json(commands::stats::get_token_trend(arg(&args, "hours")?, state).await)
+        }
         "get_settings" => to_json(commands::settings::get_settings(state).await),
         "save_settings" => {
             to_json(commands::settings::save_settings(arg(&args, "settings")?, state).await)
@@ -644,64 +630,50 @@ async fn dispatch(shared: &SharedState, cmd: &str, args: Value) -> Result<Value,
         "get_builtin_security_rules" => {
             to_json(commands::security::get_builtin_security_rules(state).await)
         }
-        "update_builtin_security_rule" => {
-            to_json(
-                commands::security::update_builtin_security_rule(
-                    arg(&args, "id")?,
-                    arg(&args, "input")?,
-                    state,
-                )
-                .await,
+        "update_builtin_security_rule" => to_json(
+            commands::security::update_builtin_security_rule(
+                arg(&args, "id")?,
+                arg(&args, "input")?,
+                state,
             )
-        }
-        "delete_builtin_security_rule" => {
-            to_json(commands::security::delete_builtin_security_rule(arg(&args, "id")?, state).await)
-        }
+            .await,
+        ),
+        "delete_builtin_security_rule" => to_json(
+            commands::security::delete_builtin_security_rule(arg(&args, "id")?, state).await,
+        ),
         "reset_builtin_security_rules" => {
             to_json(commands::security::reset_builtin_security_rules(state).await)
         }
         "get_custom_security_rules" => {
             to_json(commands::security::get_custom_security_rules(state).await)
         }
-        "create_custom_security_rule" => {
-            to_json(
-                commands::security::create_custom_security_rule(arg(&args, "input")?, state).await,
+        "create_custom_security_rule" => to_json(
+            commands::security::create_custom_security_rule(arg(&args, "input")?, state).await,
+        ),
+        "toggle_custom_security_rule" => to_json(
+            commands::security::toggle_custom_security_rule(
+                arg(&args, "id")?,
+                arg(&args, "enabled")?,
+                state,
             )
-        }
-        "toggle_custom_security_rule" => {
-            to_json(
-                commands::security::toggle_custom_security_rule(
-                    arg(&args, "id")?,
-                    arg(&args, "enabled")?,
-                    state,
-                )
-                .await,
-            )
-        }
+            .await,
+        ),
         "delete_custom_security_rule" => {
             to_json(commands::security::delete_custom_security_rule(arg(&args, "id")?, state).await)
         }
 
         // ── 导入 / 导出 ──
         "export_channels" => to_json(commands::import_export::export_channels(state).await),
-        "import_walicode_backup" => {
-            to_json(
-                commands::import_export::import_walicode_backup(arg(&args, "content")?, state)
-                    .await,
-            )
-        }
-        "import_waliapi_export" => {
-            to_json(
-                commands::import_export::import_waliapi_export(arg(&args, "content")?, state).await,
-            )
-        }
+        "import_walicode_backup" => to_json(
+            commands::import_export::import_walicode_backup(arg(&args, "content")?, state).await,
+        ),
+        "import_waliapi_export" => to_json(
+            commands::import_export::import_waliapi_export(arg(&args, "content")?, state).await,
+        ),
         "scan_local_ai_configs" => to_json(commands::import_export::scan_local_ai_configs().await),
-        "import_scanned_sources" => {
-            to_json(
-                commands::import_export::import_scanned_sources(arg(&args, "sources")?, state)
-                    .await,
-            )
-        }
+        "import_scanned_sources" => to_json(
+            commands::import_export::import_scanned_sources(arg(&args, "sources")?, state).await,
+        ),
         #[cfg(feature = "desktop-ui")]
         "pick_import_file" => {
             let app = desktop_app("文件选择对话框")?;
@@ -728,107 +700,77 @@ async fn dispatch(shared: &SharedState, cmd: &str, args: Value) -> Result<Value,
         "get_knowledge_bases" => {
             to_json(commands::knowledge_base::get_knowledge_bases(state).await)
         }
-        "create_knowledge_base" => {
-            to_json(
-                commands::knowledge_base::create_knowledge_base(state, arg(&args, "input")?).await,
+        "create_knowledge_base" => to_json(
+            commands::knowledge_base::create_knowledge_base(state, arg(&args, "input")?).await,
+        ),
+        "update_knowledge_base" => to_json(
+            commands::knowledge_base::update_knowledge_base(
+                state,
+                arg(&args, "id")?,
+                arg(&args, "input")?,
             )
-        }
-        "update_knowledge_base" => {
-            to_json(
-                commands::knowledge_base::update_knowledge_base(
-                    state,
-                    arg(&args, "id")?,
-                    arg(&args, "input")?,
-                )
-                .await,
-            )
-        }
+            .await,
+        ),
         "delete_knowledge_base" => {
             to_json(commands::knowledge_base::delete_knowledge_base(state, arg(&args, "id")?).await)
         }
         "get_kb_documents" => {
             to_json(commands::knowledge_base::get_kb_documents(state, arg(&args, "kbId")?).await)
         }
-        "delete_kb_document" => {
-            to_json(
-                commands::knowledge_base::delete_kb_document(
-                    state,
-                    arg(&args, "docId")?,
-                    arg(&args, "kbId")?,
-                )
+        "delete_kb_document" => to_json(
+            commands::knowledge_base::delete_kb_document(
+                state,
+                arg(&args, "docId")?,
+                arg(&args, "kbId")?,
+            )
+            .await,
+        ),
+        "reindex_kb_document" => to_json(
+            commands::knowledge_base::reindex_kb_document(state, arg(&args, "docId")?).await,
+        ),
+        "get_kb_tags" => to_json(
+            commands::knowledge_base::get_kb_tags(state, arg(&args, "kbId")?, arg(&args, "limit")?)
                 .await,
-            )
-        }
-        "reindex_kb_document" => {
-            to_json(
-                commands::knowledge_base::reindex_kb_document(state, arg(&args, "docId")?).await,
-            )
-        }
-        "get_kb_tags" => {
-            to_json(
-                commands::knowledge_base::get_kb_tags(
-                    state,
-                    arg(&args, "kbId")?,
-                    arg(&args, "limit")?,
-                )
-                .await,
-            )
-        }
-        "search_knowledge_base" => {
-            to_json(
-                commands::knowledge_base::search_knowledge_base(state, arg(&args, "input")?).await,
-            )
-        }
+        ),
+        "search_knowledge_base" => to_json(
+            commands::knowledge_base::search_knowledge_base(state, arg(&args, "input")?).await,
+        ),
         "ask_knowledge_base" => {
-            to_json(
-                commands::knowledge_base::ask_knowledge_base(state, arg(&args, "input")?).await,
-            )
+            to_json(commands::knowledge_base::ask_knowledge_base(state, arg(&args, "input")?).await)
         }
         "get_kb_stats" => {
             to_json(commands::knowledge_base::get_kb_stats(state, arg(&args, "kbId")?).await)
         }
         "upload_kb_document" => {
-            to_json(
-                commands::knowledge_base::upload_kb_document(state, arg(&args, "input")?).await,
-            )
+            to_json(commands::knowledge_base::upload_kb_document(state, arg(&args, "input")?).await)
         }
-        "get_kb_conversations" => {
-            to_json(
-                commands::knowledge_base::get_kb_conversations(state, arg(&args, "kbId")?).await,
-            )
-        }
-        "clear_kb_conversations" => {
-            to_json(
-                commands::knowledge_base::clear_kb_conversations(state, arg(&args, "kbId")?).await,
-            )
-        }
+        "get_kb_conversations" => to_json(
+            commands::knowledge_base::get_kb_conversations(state, arg(&args, "kbId")?).await,
+        ),
+        "clear_kb_conversations" => to_json(
+            commands::knowledge_base::clear_kb_conversations(state, arg(&args, "kbId")?).await,
+        ),
         "get_kb_sources" => {
             to_json(commands::knowledge_base::get_kb_sources(state, arg(&args, "kbId")?).await)
         }
-        "delete_kb_source" => {
-            to_json(
-                commands::knowledge_base::delete_kb_source(
-                    state,
-                    arg(&args, "sourceId")?,
-                    arg(&args, "kbId")?,
-                )
-                .await,
+        "delete_kb_source" => to_json(
+            commands::knowledge_base::delete_kb_source(
+                state,
+                arg(&args, "sourceId")?,
+                arg(&args, "kbId")?,
             )
-        }
-        "import_kb_source" => {
-            to_json(
-                commands::knowledge_base::import_kb_source(
-                    state,
-                    arg(&args, "kbId")?,
-                    arg(&args, "input")?,
-                )
-                .await,
+            .await,
+        ),
+        "import_kb_source" => to_json(
+            commands::knowledge_base::import_kb_source(
+                state,
+                arg(&args, "kbId")?,
+                arg(&args, "input")?,
             )
-        }
+            .await,
+        ),
         "get_kb_index_status" => {
-            to_json(
-                commands::knowledge_base::get_kb_index_status(state, arg(&args, "kbId")?).await,
-            )
+            to_json(commands::knowledge_base::get_kb_index_status(state, arg(&args, "kbId")?).await)
         }
         "build_kb_index" => {
             to_json(commands::knowledge_base::build_kb_index(state, arg(&args, "kbId")?).await)
@@ -847,101 +789,81 @@ async fn dispatch(shared: &SharedState, cmd: &str, args: Value) -> Result<Value,
         "get_wiki_project" => {
             to_json(commands::wiki::get_wiki_project(state, arg(&args, "id")?).await)
         }
-        "update_wiki_project" => {
-            to_json(
-                commands::wiki::update_wiki_project(state, arg(&args, "id")?, arg(&args, "input")?)
-                    .await,
-            )
-        }
+        "update_wiki_project" => to_json(
+            commands::wiki::update_wiki_project(state, arg(&args, "id")?, arg(&args, "input")?)
+                .await,
+        ),
         "delete_wiki_project" => {
             to_json(commands::wiki::delete_wiki_project(state, arg(&args, "id")?).await)
         }
         "get_wiki_pages" => {
             to_json(commands::wiki::get_wiki_pages(state, arg(&args, "projectId")?).await)
         }
-        "get_wiki_page" => {
-            to_json(
-                commands::wiki::get_wiki_page(state, arg(&args, "projectId")?, arg(&args, "path")?)
-                    .await,
-            )
-        }
-        "save_wiki_page" => {
-            to_json(
-                commands::wiki::save_wiki_page(
-                    state,
-                    arg(&args, "projectId")?,
-                    arg(&args, "path")?,
-                    arg(&args, "content")?,
-                )
+        "get_wiki_page" => to_json(
+            commands::wiki::get_wiki_page(state, arg(&args, "projectId")?, arg(&args, "path")?)
                 .await,
+        ),
+        "save_wiki_page" => to_json(
+            commands::wiki::save_wiki_page(
+                state,
+                arg(&args, "projectId")?,
+                arg(&args, "path")?,
+                arg(&args, "content")?,
             )
-        }
+            .await,
+        ),
         "get_wiki_sources" => {
             to_json(commands::wiki::get_wiki_sources(state, arg(&args, "projectId")?).await)
         }
-        "add_wiki_source" => {
-            to_json(
-                commands::wiki::add_wiki_source(
-                    state,
-                    arg(&args, "projectId")?,
-                    arg(&args, "input")?,
-                )
+        "add_wiki_source" => to_json(
+            commands::wiki::add_wiki_source(state, arg(&args, "projectId")?, arg(&args, "input")?)
                 .await,
-            )
-        }
+        ),
         "delete_wiki_source" => {
             to_json(commands::wiki::delete_wiki_source(state, arg(&args, "sourceId")?).await)
         }
-        "search_wiki" => {
-            to_json(
-                commands::wiki::search_wiki(
-                    state,
-                    arg(&args, "projectId")?,
-                    arg(&args, "query")?,
-                    arg(&args, "topK")?,
-                )
-                .await,
+        "search_wiki" => to_json(
+            commands::wiki::search_wiki(
+                state,
+                arg(&args, "projectId")?,
+                arg(&args, "query")?,
+                arg(&args, "topK")?,
             )
-        }
+            .await,
+        ),
         "get_wiki_graph" => {
             to_json(commands::wiki::get_wiki_graph(state, arg(&args, "projectId")?).await)
         }
-        "get_wiki_tags" => {
-            to_json(
-                commands::wiki::get_wiki_tags(state, arg(&args, "projectId")?, arg(&args, "limit")?)
-                    .await,
-            )
-        }
+        "get_wiki_tags" => to_json(
+            commands::wiki::get_wiki_tags(state, arg(&args, "projectId")?, arg(&args, "limit")?)
+                .await,
+        ),
         "get_wiki_stats" => {
             to_json(commands::wiki::get_wiki_stats(state, arg(&args, "projectId")?).await)
         }
-        "ingest_wiki_source" => {
-            to_json(
-                commands::wiki::ingest_wiki_source(
-                    state,
-                    arg(&args, "projectId")?,
-                    arg(&args, "sourceId")?,
-                )
-                .await,
+        "ingest_wiki_source" => to_json(
+            commands::wiki::ingest_wiki_source(
+                state,
+                arg(&args, "projectId")?,
+                arg(&args, "sourceId")?,
             )
-        }
+            .await,
+        ),
         "rescan_wiki_sources" => {
             to_json(commands::wiki::rescan_wiki_sources(state, arg(&args, "projectId")?).await)
         }
 
         // ── 应用配置（容器内通常全部不可用，由前端置灰）──
         "get_app_configs" => to_json(commands::app_config::get_app_configs(state).await),
-        "apply_app_config" => {
-            to_json(
-                commands::app_config::apply_app_config(
-                    arg(&args, "appName")?,
-                    arg(&args, "apiKey")?,
-                    arg(&args, "model")?,
-                    state,
-                )
-                .await,
+        "apply_app_config" => to_json(
+            commands::app_config::apply_app_config(
+                arg(&args, "appName")?,
+                arg(&args, "apiKey")?,
+                arg(&args, "model")?,
+                state,
             )
-        }
+            .await,
+        ),
         "clear_app_config" => {
             to_json(commands::app_config::clear_app_config(arg(&args, "appName")?).await)
         }

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -170,7 +170,8 @@ async fn maybe_route_plan(
         &mut plan_rng,
     ) {
         Ok(plan) => plan,
-        Err(e) => {            let code = e.http_status();
+        Err(e) => {
+            let code = e.http_status();
             // I-3: a facade rejection (auth / no candidate / no endpoint)
             // must be observable in the RequestLog on BOTH paths, except for
             // Count Tokens which is deliberately excluded from request history.
@@ -205,8 +206,7 @@ async fn maybe_route_plan(
     {
         let (retry_enabled, retry_times) =
             crate::core::proxy::get_retry_settings(&shared.state.settings);
-        let (per_group, total) =
-            route_plan::retry_budget_from_settings(retry_enabled, retry_times);
+        let (per_group, total) = route_plan::retry_budget_from_settings(retry_enabled, retry_times);
         plan.apply_retry_budget(per_group, total);
     }
     if is_stream {
@@ -221,9 +221,7 @@ async fn maybe_route_plan(
             trace_id,
             shared.state.auth_service.clone(),
             // 流式超时（FIX-08）从设置读取（stream.*_timeout_secs，缺省 60/120s）。
-            crate::endpoint_executor::driver::StreamTimeouts::from_settings(
-                &shared.state.settings,
-            ),
+            crate::endpoint_executor::driver::StreamTimeouts::from_settings(&shared.state.settings),
         )
         .await;
         Ok(Some(resp))
@@ -1441,8 +1439,7 @@ impl NativeStreamFinalizer {
     }
 
     fn mark_done(&self) {
-        self.done
-            .store(true, std::sync::atomic::Ordering::SeqCst);
+        self.done.store(true, std::sync::atomic::Ordering::SeqCst);
     }
 
     /// 上游中断：502 行 + 已解析的部分用量。
@@ -1467,13 +1464,9 @@ impl NativeStreamFinalizer {
 
     /// 请求体 prompt 估算（completion 无内容可估时为 0）。
     fn estimated_usage(&self) -> Option<(i64, i64, i64)> {
-        let req_body =
-            serde_json::to_value(&self.request).unwrap_or(serde_json::Value::Null);
-        let (p, c, t) = crate::endpoint_executor::estimate_usage::estimate_usage(
-            &req_body,
-            None,
-            &self.model,
-        );
+        let req_body = serde_json::to_value(&self.request).unwrap_or(serde_json::Value::Null);
+        let (p, c, t) =
+            crate::endpoint_executor::estimate_usage::estimate_usage(&req_body, None, &self.model);
         (t > 0).then_some((p, c, t))
     }
 }
@@ -1579,8 +1572,13 @@ impl NativeSseUsageParser {
     /// FIX-12：改 `&mut self`——解析器在 Mutex 内共享，Drop/中断路径需要
     /// 多次读取部分用量而不消耗解析器。
     fn finish(&mut self) -> Option<(i64, i64, i64)> {
-        (!self.malformed_or_oversized && self.stopped)
-            .then(|| (self.input.unwrap_or(0), self.output.unwrap_or(0), self.cached.unwrap_or(0)))
+        (!self.malformed_or_oversized && self.stopped).then(|| {
+            (
+                self.input.unwrap_or(0),
+                self.output.unwrap_or(0),
+                self.cached.unwrap_or(0),
+            )
+        })
     }
 }
 
@@ -1831,10 +1829,7 @@ fn request_has_image_blocks(body: &serde_json::Value) -> bool {
 /// FIX-18（#15）：原生渠道 400 且请求含图片块时，在错误体 message 追加
 /// 诊断提示。视觉能力路由（`supports_vision` 渠道标记 + failover 跳过）
 /// 为长期方案（docs/reliability-fixes-prd.md 票 03），当前只提示不改路由。
-fn annotate_vision_hint(
-    err: StoredNativeError,
-    request: &serde_json::Value,
-) -> StoredNativeError {
+fn annotate_vision_hint(err: StoredNativeError, request: &serde_json::Value) -> StoredNativeError {
     const HINT: &str =
         "（该渠道疑似不支持图片：请求含图片内容块而上游以 400 拒绝，可切换到支持视觉的渠道）";
     if err.status != StatusCode::BAD_REQUEST || !request_has_image_blocks(request) {
@@ -2422,7 +2417,10 @@ pub async fn handle_messages(
                     .and_then(|value| value.as_str())
                     .unwrap_or("OpenAI Chat Completions upstream rejected the request");
                 last_error = format!("{}: {message}", channel.name);
-                match upstream_failover_decision_with_body(status.as_u16(), Some(upstream.to_string().as_str())) {
+                match upstream_failover_decision_with_body(
+                    status.as_u16(),
+                    Some(upstream.to_string().as_str()),
+                ) {
                     FailoverDecision::Failover => {
                         last_openai_error = Some((status, message.to_string(), response_headers));
                     }
@@ -4254,7 +4252,9 @@ mod anthropic_handler_tests {
             status: StatusCode::TOO_MANY_REQUESTS,
             content_type: None,
             headers: vec![],
-            body: bytes::Bytes::from(r#"{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}"#),
+            body: bytes::Bytes::from(
+                r#"{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}"#,
+            ),
         };
         let untouched = annotate_vision_hint(err429, &request);
         assert!(!String::from_utf8_lossy(&untouched.body).contains("疑似不支持"));
@@ -4625,8 +4625,12 @@ mod list_models_tests {
                 serde_json::json!({"alias-b": "claude-sonnet-4"}),
             ),
         ];
-        let visibility =
-            ApiKeyVisibility::from(&key(&["api-a"], &[], &["gpt-4o", "alias-a"], &["gpt-4o-mini"]));
+        let visibility = ApiKeyVisibility::from(&key(
+            &["api-a"],
+            &[],
+            &["gpt-4o", "alias-a"],
+            &["gpt-4o-mini"],
+        ));
         let models = collect_config_models(&channels, Some(&visibility));
         let ids: Vec<&str> = models.iter().map(|m| m.id.as_str()).collect();
         assert_eq!(ids, vec!["gpt-4o", "alias-a"]);

--- a/src-tauri/src/server/router.rs
+++ b/src-tauri/src/server/router.rs
@@ -404,9 +404,8 @@ mod tests {
             .find_map(|l| l.strip_prefix("password: "))
             .unwrap()
             .to_string();
-        let login_body = |pw: &str| {
-            serde_json::json!({ "username": "admin", "password": pw }).to_string()
-        };
+        let login_body =
+            |pw: &str| serde_json::json!({ "username": "admin", "password": pw }).to_string();
 
         // 成功登录：HttpOnly Cookie + 初始密码文件删除 + token 可用
         let res = app
@@ -425,8 +424,13 @@ mod tests {
             .and_then(|v| v.to_str().ok())
             .unwrap()
             .to_string();
-        assert!(cookie.contains("HttpOnly"), "cookie 必须带 HttpOnly: {cookie}");
-        let body = axum::body::to_bytes(res.into_body(), 64 * 1024).await.unwrap();
+        assert!(
+            cookie.contains("HttpOnly"),
+            "cookie 必须带 HttpOnly: {cookie}"
+        );
+        let body = axum::body::to_bytes(res.into_body(), 64 * 1024)
+            .await
+            .unwrap();
         let token = serde_json::from_slice::<serde_json::Value>(&body).unwrap()["token"]
             .as_str()
             .unwrap()
@@ -450,7 +454,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(res.into_body(), 64 * 1024).await.unwrap();
+        let body = axum::body::to_bytes(res.into_body(), 64 * 1024)
+            .await
+            .unwrap();
         let token2 = serde_json::from_slice::<serde_json::Value>(&body).unwrap()["token"]
             .as_str()
             .unwrap()
@@ -503,7 +509,11 @@ mod tests {
                 ))
                 .await
                 .unwrap();
-            assert_eq!(res.status(), StatusCode::BAD_REQUEST, "第 {i} 次失败应为 400");
+            assert_eq!(
+                res.status(),
+                StatusCode::BAD_REQUEST,
+                "第 {i} 次失败应为 400"
+            );
         }
         let res = app
             .clone()
@@ -514,7 +524,11 @@ mod tests {
             ))
             .await
             .unwrap();
-        assert_eq!(res.status(), StatusCode::TOO_MANY_REQUESTS, "第 7 次应被限速");
+        assert_eq!(
+            res.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "第 7 次应被限速"
+        );
         assert!(res.headers().get("Retry-After").is_some());
     }
 }

--- a/src-tauri/src/services/knowledge/retriever.rs
+++ b/src-tauri/src/services/knowledge/retriever.rs
@@ -1,9 +1,9 @@
 use super::index::HnswIndex;
 use super::models::SearchResult;
 use super::repository::KbRepository;
+use crate::server::event_bridge::EventSink;
 use sqlx::SqlitePool;
 use std::path::PathBuf;
-use crate::server::event_bridge::EventSink;
 
 /// Default HNSW parameters
 const DEFAULT_M: usize = 16;

--- a/src-tauri/src/services/mcp/handlers.rs
+++ b/src-tauri/src/services/mcp/handlers.rs
@@ -1732,14 +1732,8 @@ async fn handle_tool_call(
 
             // Call the wiki update_page handler logic
             let wiki_repo = WikiRepository::new(pool.clone());
-            let result = wiki_handlers::update_page_inner(
-                pool,
-                &wiki_repo,
-                project_id,
-                path,
-                content,
-            )
-            .await;
+            let result =
+                wiki_handlers::update_page_inner(pool, &wiki_repo, project_id, path, content).await;
 
             match result {
                 Ok(()) => Ok(serde_json::json!({

--- a/src-tauri/src/services/wiki/handlers.rs
+++ b/src-tauri/src/services/wiki/handlers.rs
@@ -300,15 +300,7 @@ pub async fn update_page(
     let content = body.get("content").and_then(|c| c.as_str()).unwrap_or("");
 
     let repo = WikiRepository::new(shared.state.db.pool.clone());
-    match update_page_inner(
-        &shared.state.db.pool,
-        &repo,
-        &id,
-        &path,
-        content,
-    )
-    .await
-    {
+    match update_page_inner(&shared.state.db.pool, &repo, &id, &path, content).await {
         Ok(()) => Json(serde_json::json!({ "ok": true, "path": path })).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
     }

--- a/src-tauri/src/services/wiki/ingest.rs
+++ b/src-tauri/src/services/wiki/ingest.rs
@@ -899,10 +899,7 @@ async fn replace_graph_edges(
     project_id: &str,
     links: Vec<(String, String)>,
 ) -> Result<(), String> {
-    let mut tx = pool
-        .begin()
-        .await
-        .map_err(|e| format!("DB error: {}", e))?;
+    let mut tx = pool.begin().await.map_err(|e| format!("DB error: {}", e))?;
     sqlx::query("DELETE FROM wiki_graph_edges WHERE project_id = ?")
         .bind(project_id)
         .execute(&mut *tx)
@@ -913,7 +910,10 @@ async fn replace_graph_edges(
         let mut sql = String::from(
             "INSERT OR IGNORE INTO wiki_graph_edges (id, project_id, source_page, target_page, edge_type, weight, created_at) VALUES ",
         );
-        let groups: Vec<&str> = chunk.iter().map(|_| "(?, ?, ?, ?, 'wikilink', 1.0, ?)").collect();
+        let groups: Vec<&str> = chunk
+            .iter()
+            .map(|_| "(?, ?, ?, ?, 'wikilink', 1.0, ?)")
+            .collect();
         sql.push_str(&groups.join(", "));
         let mut query = sqlx::query(&sql);
         for (source, target) in chunk {
@@ -1121,8 +1121,14 @@ mod tests {
         .await
         .unwrap();
         // Alpha→Beta（标题解析）；Gamma→自身（路径直通）；Beta→ghost 不存在 → 无边
-        assert!(edges.contains(&("a.md".to_string(), "b.md".to_string())), "edges: {edges:?}");
-        assert!(edges.contains(&("docs/c.md".to_string(), "docs/c.md".to_string())), "edges: {edges:?}");
+        assert!(
+            edges.contains(&("a.md".to_string(), "b.md".to_string())),
+            "edges: {edges:?}"
+        );
+        assert!(
+            edges.contains(&("docs/c.md".to_string(), "docs/c.md".to_string())),
+            "edges: {edges:?}"
+        );
         assert_eq!(edges.len(), 2, "幽灵链接不得建边: {edges:?}");
     }
 

--- a/src-tauri/src/settings_store.rs
+++ b/src-tauri/src/settings_store.rs
@@ -80,8 +80,8 @@ impl FileSettingsBackend {
             std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
         }
         let tmp = self.path.with_extension("json.tmp");
-        let content = serde_json::to_string_pretty(&Value::Object(map.clone()))
-            .map_err(|e| e.to_string())?;
+        let content =
+            serde_json::to_string_pretty(&Value::Object(map.clone())).map_err(|e| e.to_string())?;
         std::fs::write(&tmp, content).map_err(|e| e.to_string())?;
         std::fs::rename(&tmp, &self.path).map_err(|e| e.to_string())?;
         Ok(())

--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -34,7 +34,9 @@ pub fn resolve_data_dir(explicit: Option<String>) -> PathBuf {
         }
     }
     // 与 tauri app_data_dir 对齐：$XDG_DATA_HOME/<identifier>（Docker 中即 /data/<identifier>）
-    let base = std::env::var("XDG_DATA_HOME").ok().filter(|v| !v.trim().is_empty());
+    let base = std::env::var("XDG_DATA_HOME")
+        .ok()
+        .filter(|v| !v.trim().is_empty());
     if let Some(base) = base {
         return PathBuf::from(base).join(crate::APP_IDENTIFIER);
     }
@@ -62,7 +64,11 @@ fn platform_default_data_dir() -> PathBuf {
 #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
 fn platform_default_data_dir() -> PathBuf {
     std::env::var("HOME")
-        .map(|v| PathBuf::from(v).join(".local/share").join(crate::APP_IDENTIFIER))
+        .map(|v| {
+            PathBuf::from(v)
+                .join(".local/share")
+                .join(crate::APP_IDENTIFIER)
+        })
         .unwrap_or_else(|_| PathBuf::from("."))
 }
 
@@ -102,11 +108,17 @@ pub async fn run(cfg: WebServerConfig) -> Result<(), String> {
         admin_sessions: server::admin_auth::SessionStore::new(),
         login_throttle: server::admin_auth::LoginThrottle::new(),
         events: server::event_bridge::EventSink::headless(event_tx),
-        settings: settings_store::SettingsStore::file(
-            settings_store::default_settings_path(&data_dir),
-        ),
+        settings: settings_store::SettingsStore::file(settings_store::default_settings_path(
+            &data_dir,
+        )),
         data_dir,
     });
+
+    crate::audit_log::apply_settings(&state.settings);
+    tauri::async_runtime::spawn(crate::audit_log::run_maintenance_loop(
+        state.db.pool.clone(),
+        state.settings.clone(),
+    ));
 
     tauri::async_runtime::spawn(crate::auth_provider::maintenance::run_maintenance_loop(
         auth_service,

--- a/src-tauri/tests/request_log.rs
+++ b/src-tauri/tests/request_log.rs
@@ -208,6 +208,50 @@ async fn request_log_create_log_persists_t09_fields_and_log_dto_maps_them() {
 }
 
 #[tokio::test]
+async fn request_log_summary_reports_size_without_loading_body() {
+    let pool = fresh_db().await;
+    let repo = Repository::new(pool);
+    let mut log = full_log(None, Some("summary"));
+    log.id = "summary-large".into();
+    log.request_body = Some("x".repeat(1024 * 1024));
+    repo.create_log(&log).await.expect("create_log");
+
+    let summaries = repo.get_log_summaries(20, 0).await.expect("summaries");
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].id, log.id);
+    assert!(summaries[0].has_request_body);
+    assert_eq!(summaries[0].request_body_bytes, 1024 * 1024);
+}
+
+#[tokio::test]
+async fn request_log_basic_policy_drops_bodies_at_persistence_boundary() {
+    let pool = fresh_db().await;
+    let repo = Repository::new(pool);
+    let mut log = full_log(None, Some("basic"));
+    log.id = "basic-log".into();
+    log.response_choices = Some("{\"choices\":[]}".into());
+    repo.create_log_with_policy(
+        &log,
+        waliapi_lib::audit_log::LogPolicy {
+            detail_level: waliapi_lib::audit_log::LogDetailLevel::Basic,
+            retention_days: 7,
+        },
+    )
+    .await
+    .expect("create basic log");
+
+    let stored = repo.get_log(&log.id).await.expect("get basic log");
+    assert!(stored.request_body.is_none());
+    assert!(stored.response_choices.is_none());
+    let level: String = sqlx::query_scalar("SELECT detail_level FROM request_logs WHERE id = ?")
+        .bind(&log.id)
+        .fetch_one(repo.pool())
+        .await
+        .unwrap();
+    assert_eq!(level, "basic");
+}
+
+#[tokio::test]
 async fn request_log_upstream_type_defaults_filters_and_round_trips() {
     let pool = fresh_db().await;
     let repo = Repository::new(pool);
@@ -340,4 +384,49 @@ async fn request_log_sanitized_log_body_is_what_gets_persisted() {
     assert!(serde_json::to_string(&raw)
         .unwrap()
         .contains("abcdefghijklmnopqrstuvwx"));
+}
+
+#[tokio::test]
+async fn request_log_cleanup_removes_expired_rows_and_findings() {
+    let pool = fresh_db().await;
+    let repo = Repository::new(pool.clone());
+    let mut old = full_log(None, Some("old"));
+    old.id = "old-log".into();
+    old.created_at = "2000-01-01T00:00:00Z".into();
+    repo.create_log(&old).await.expect("create old log");
+    sqlx::query(
+        "INSERT INTO request_security_findings
+         (id, log_id, phase, category, rule_id, severity, title, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind("finding-old")
+    .bind(&old.id)
+    .bind("request")
+    .bind("test")
+    .bind("test-rule")
+    .bind("low")
+    .bind("test")
+    .bind("2000-01-01T00:00:00Z")
+    .execute(&pool)
+    .await
+    .expect("insert finding");
+
+    let deleted = waliapi_lib::audit_log::cleanup_expired_logs(&pool, 1)
+        .await
+        .expect("cleanup");
+    assert_eq!(deleted, 1);
+    assert!(repo.get_log(&old.id).await.is_err());
+    let findings: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM request_security_findings WHERE log_id = ?")
+            .bind(&old.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(findings, 0);
+    assert_eq!(
+        waliapi_lib::audit_log::cleanup_expired_logs(&pool, 0)
+            .await
+            .unwrap(),
+        0
+    );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -96,6 +96,7 @@ export interface GetLogsInput {
 
 // Log commands
 export const logApi = {
+  /** 列表接口只返回摘要；正文由 get 按日志展开时懒加载。 */
   getAll: (input?: GetLogsInput) => invoke<RequestLog[]>("get_logs", { input: input || {} }),
   get: (id: string) => invoke<RequestLog>("get_log", { id }),
   getSecurityFindings: (logId: string) => invoke<SecurityFinding[]>("get_log_security_findings", { logId }),

--- a/src/pages/LogsPage.tsx
+++ b/src/pages/LogsPage.tsx
@@ -185,6 +185,8 @@ function getRoleMeta(role: string) {
 
 export function LogsPage() {
   const [logs, setLogs] = useState<RequestLog[]>([]);
+  const [details, setDetails] = useState<Record<string, RequestLog>>({});
+  const [detailLoadingId, setDetailLoadingId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [loadError, setLoadError] = useState(false);
   const [page, setPage] = useState(0);
@@ -281,8 +283,31 @@ export function LogsPage() {
     try {
       await logApi.delete(id);
       setLogs(prev => prev.filter(l => l.id !== id));
+      setDetails(prev => { const next = { ...prev }; delete next[id]; return next; });
+      if (expandedId === id) setExpandedId(null);
     } catch (e) {
       console.error("Failed to delete log:", e);
+    }
+  };
+
+  const handleToggleLog = async (id: string) => {
+    if (expandedId === id) {
+      setExpandedId(null);
+      return;
+    }
+    setExpandedId(id);
+    if (details[id]) return;
+    const summary = logs.find(log => log.id === id);
+    // 基本模式明确没有正文时无需再请求详情接口；展开直接展示说明。
+    if (summary?.detail_available === false || (summary?.detail_level === "basic" && !summary.request_body)) return;
+    setDetailLoadingId(id);
+    try {
+      const detail = await logApi.get(id);
+      setDetails(prev => ({ ...prev, [id]: detail }));
+    } catch (e) {
+      console.error("Failed to load log detail:", e);
+    } finally {
+      setDetailLoadingId(current => current === id ? null : current);
     }
   };
 
@@ -452,7 +477,12 @@ export function LogsPage() {
       {/* Table area — fills remaining height, scrolls internally */}
       <div className="flex-1 overflow-hidden px-7 pb-7 min-h-0">
         <div className="surface h-full overflow-hidden rounded-[24px] flex flex-col">
-          {logs.length === 0 ? (
+          {loading && logs.length === 0 ? (
+            <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center">
+              <RefreshCw className="h-10 w-10 animate-spin text-muted-foreground/60" />
+              <p className="text-base font-medium">正在加载审计日志…</p>
+            </div>
+          ) : logs.length === 0 ? (
             <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center">
               {loadError ? (
                 <>
@@ -506,7 +536,9 @@ export function LogsPage() {
                         key={log.id}
                         log={log}
                         expanded={expandedId === log.id}
-                        onToggle={() => setExpandedId(expandedId === log.id ? null : log.id)}
+                        detail={details[log.id]}
+                        detailLoading={detailLoadingId === log.id}
+                        onToggle={() => handleToggleLog(log.id)}
                         onDelete={() => handleDeleteLog(log.id)}
                         showTraceColumn={showTraceColumn}
                       />
@@ -552,12 +584,16 @@ export function LogsPage() {
 
 function LogRow({
   log,
+  detail,
+  detailLoading,
   expanded,
   onToggle,
   onDelete,
   showTraceColumn,
 }: {
   log: RequestLog;
+  detail?: RequestLog;
+  detailLoading: boolean;
   expanded: boolean;
   onToggle: () => void;
   onDelete: () => void;
@@ -650,7 +686,21 @@ function LogRow({
         <tr>
           <td colSpan={13} className="px-4 py-4 bg-slate-50/80 border-b border-border align-top">
             <div className="min-w-0 max-w-full overflow-hidden">
-              <LogDetail log={log} />
+              {detailLoading ? (
+                <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
+                  <RefreshCw size={15} className="animate-spin" /> 正在加载日志详情…
+                </div>
+              ) : detail ? (
+                <LogDetail log={detail} />
+              ) : log.detail_available === false || (!log.request_body && log.detail_level === "basic") ? (
+                <div className="rounded-xl border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-blue-800">
+                  该记录使用“基本”日志级别，未保存请求与响应正文；网络状态、渠道、模型、推理档位、响应码和 Token 等摘要信息仍可查看。
+                </div>
+              ) : (
+                <div className="rounded-xl border border-amber-100 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+                  日志详情暂时不可用，请稍后重试。
+                </div>
+              )}
             </div>
           </td>
         </tr>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -568,6 +568,38 @@ export function SettingsPage() {
           </div>
           </div>
           <div>
+            <h3 className="mb-3 text-sm font-medium text-muted-foreground">审计日志</h3>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div>
+                <label className="mb-2 block text-sm font-medium">日志级别</label>
+                <select
+                  value={settings.log_detail_level}
+                  onChange={e => setSettings({ ...settings, log_detail_level: e.target.value })}
+                  className={selectCls}
+                >
+                  <option value="basic">基本</option>
+                  <option value="detailed">详情</option>
+                </select>
+                <p className="mt-1 text-xs text-muted-foreground">基本模式只保存请求状态与用量摘要；详情模式会保存完整请求/响应正文，可能显著增加数据库大小。</p>
+              </div>
+              <div>
+                <label className="mb-2 block text-sm font-medium">日志保留期</label>
+                <select
+                  value={settings.log_retention_days}
+                  onChange={e => setSettings({ ...settings, log_retention_days: Number(e.target.value) })}
+                  className={selectCls}
+                >
+                  <option value={1}>1 天</option>
+                  <option value={7}>7 天</option>
+                  <option value={30}>30 天</option>
+                  <option value={90}>90 天</option>
+                  <option value={0}>永久保留</option>
+                </select>
+                <p className="mt-1 text-xs text-muted-foreground">过期审计日志会由服务自动清理；删除后数据库文件需单独压缩才会缩小。</p>
+              </div>
+            </div>
+          </div>
+          <div>
             <h3 className="mb-3 text-sm font-medium text-muted-foreground">路由设置</h3>
             <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
               <label className="surface-soft flex items-center justify-between rounded-2xl px-4 py-4">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -194,6 +194,11 @@ export interface RequestLog {
   client_cancelled: boolean | null;
   stream_committed: boolean | null;
   upstream_type: "channel" | "auth_account" | string;
+  /** 日志记录级别；摘要列表也会返回该字段。 */
+  detail_level?: "basic" | "detailed" | string;
+  /** 基本日志不提供正文，详细日志可按需加载。 */
+  detail_available?: boolean;
+  started_at?: string | null;
 }
 
 // Auth account contracts intentionally expose only renderer-safe account
@@ -423,6 +428,8 @@ export interface Settings {
   ocr_max_pages: number;
   ocr_concurrency: number;
   ocr_dpi: number;
+  log_detail_level: "basic" | "detailed" | string;
+  log_retention_days: number;
 }
 
 // Security rule types


### PR DESCRIPTION
## 变更说明

- 新增审计日志级别：基本 / 详情
- 新增日志保留期：1 / 7 / 30 / 90 天 / 永久
- 基本模式不保存 `request_body` 和 `response_choices`
- 日志列表改为摘要查询，展开时按需加载详情
- 新增后台定期清理和设置变更后的立即清理
- 清理日志时同步删除关联安全审计发现
- 补充数据库迁移、技术设计文档和集成测试

## 验证

- `pnpm build`
- `pnpm --filter waliapi-web build`
- `cargo test --manifest-path src-tauri/Cargo.toml --test request_log`（8/8）
- Rust 库测试 804/805；剩余 1 项为既有 `security_gate_block_zero_upstream` 基线失败