### PR TITLE
feat(auth): 新增 Codex Device Code 登录方式

### DIFF
--- a/src-tauri/src/auth_provider/codex_backend.rs
+++ b/src-tauri/src/auth_provider/codex_backend.rs
@@ -168,10 +168,13 @@ impl Provider for CodexProvider {
 
     async fn login(
         &self,
-        _context: &ProviderLoginContext,
+        context: &ProviderLoginContext,
         runtime: &dyn LoginRuntime,
     ) -> Result<LoginResult, ProviderError> {
-        self.login.login(runtime).await
+        match context.login_method {
+            super::AuthLoginMode::BrowserCallback => self.login.login(runtime).await,
+            super::AuthLoginMode::DeviceCode => self.login.login_device_code(runtime).await,
+        }
     }
 
     async fn import(&self, bytes: &[u8]) -> Result<LoginResult, ProviderError> {

--- a/src-tauri/src/auth_provider/codex_login.rs
+++ b/src-tauri/src/auth_provider/codex_login.rs
@@ -140,6 +140,18 @@ struct DeviceTokenResponse {
     code_verifier: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct DevicePollErrorEnvelope {
+    #[serde(default)]
+    error: DevicePollError,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DevicePollError {
+    #[serde(default)]
+    code: String,
+}
+
 impl ExtraTokenFields for CodexTokenFields {}
 
 type CodexOauthClient = Client<
@@ -412,6 +424,21 @@ impl CodexLogin {
                 Ok(response) if response.status() == StatusCode::NOT_FOUND => {
                     transient_failures = 0;
                 }
+                Ok(response) if response.status() == StatusCode::FORBIDDEN => {
+                    let code = response
+                        .json::<DevicePollErrorEnvelope>()
+                        .await
+                        .ok()
+                        .map(|body| body.error.code)
+                        .unwrap_or_default();
+                    match code.as_str() {
+                        "deviceauth_authorization_pending" => transient_failures = 0,
+                        "deviceauth_authorization_denied" | "access_denied" => {
+                            return Err(ProviderError::AuthorizationDenied);
+                        }
+                        _ => return Err(ProviderError::DeviceAuthorizationFailed),
+                    }
+                }
                 Ok(response) if response.status().is_server_error() => {
                     transient_failures = transient_failures.saturating_add(1);
                     if transient_failures > 5 {
@@ -419,12 +446,7 @@ impl CodexLogin {
                     }
                     interval = (interval.saturating_mul(2)).min(30);
                 }
-                Ok(response)
-                    if matches!(
-                        response.status(),
-                        StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED
-                    ) =>
-                {
+                Ok(response) if matches!(response.status(), StatusCode::UNAUTHORIZED) => {
                     return Err(ProviderError::AuthorizationDenied);
                 }
                 Ok(_) => return Err(ProviderError::DeviceAuthorizationFailed),
@@ -1369,7 +1391,13 @@ mod tests {
         assert_eq!(body["device_auth_id"], "private-device-auth-id");
         assert_eq!(body["user_code"], "ABCD-EFGH");
         if state.polls.fetch_add(1, Ordering::SeqCst) == 0 {
-            return (StatusCode::NOT_FOUND, axum::Json(json!({}))).into_response();
+            return (
+                StatusCode::FORBIDDEN,
+                axum::Json(json!({
+                    "error": {"code": "deviceauth_authorization_pending"}
+                })),
+            )
+                .into_response();
         }
         (
             StatusCode::OK,

--- a/src-tauri/src/auth_provider/codex_login.rs
+++ b/src-tauri/src/auth_provider/codex_login.rs
@@ -40,6 +40,11 @@ use super::{LoginResult, ProviderError, ProviderPayload, RefreshedPayload};
 pub const CODEX_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 pub const CODEX_AUTHORIZE_URL: &str = "https://auth.openai.com/oauth/authorize";
 pub const CODEX_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+pub const CODEX_DEVICE_USER_CODE_URL: &str =
+    "https://auth.openai.com/api/accounts/deviceauth/usercode";
+pub const CODEX_DEVICE_TOKEN_URL: &str = "https://auth.openai.com/api/accounts/deviceauth/token";
+pub const CODEX_DEVICE_VERIFICATION_URL: &str = "https://auth.openai.com/codex/device";
+pub const CODEX_DEVICE_REDIRECT_URI: &str = "https://auth.openai.com/deviceauth/callback";
 pub const CODEX_IMPORT_NOTICE: &str = "本机 Codex 仍维持原登录态，双方 token 不自动同步。";
 /// Registered loopback redirects used by the official Codex CLI.
 const CODEX_CALLBACK_PORT: u16 = 1455;
@@ -53,6 +58,10 @@ pub struct CodexLogin {
     token_url: String,
     timeout: Duration,
     callback_ports: (u16, u16),
+    device_user_code_url: String,
+    device_token_url: String,
+    device_verification_url: String,
+    client: reqwest::Client,
 }
 
 /// Production browser opener. Commands construct this from their `AppHandle`; tests inject a
@@ -106,6 +115,29 @@ struct CodexTokenFields {
     id_token: Option<String>,
     #[serde(default)]
     account_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeviceUserCodeResponse {
+    device_auth_id: String,
+    user_code: String,
+    #[serde(default)]
+    interval: Value,
+}
+
+impl DeviceUserCodeResponse {
+    fn interval_seconds(&self) -> u64 {
+        self.interval
+            .as_u64()
+            .or_else(|| self.interval.as_str().and_then(|value| value.parse().ok()))
+            .unwrap_or(5)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct DeviceTokenResponse {
+    authorization_code: String,
+    code_verifier: String,
 }
 
 impl ExtraTokenFields for CodexTokenFields {}
@@ -174,6 +206,10 @@ impl CodexLogin {
             token_url: CODEX_TOKEN_URL.to_owned(),
             timeout: Duration::from_secs(5 * 60),
             callback_ports: (CODEX_CALLBACK_PORT, CODEX_CALLBACK_FALLBACK_PORT),
+            device_user_code_url: CODEX_DEVICE_USER_CODE_URL.to_owned(),
+            device_token_url: CODEX_DEVICE_TOKEN_URL.to_owned(),
+            device_verification_url: CODEX_DEVICE_VERIFICATION_URL.to_owned(),
+            client: reqwest::Client::new(),
         }
     }
 
@@ -183,7 +219,24 @@ impl CodexLogin {
             token_url: token_url.into(),
             timeout: Duration::from_secs(5 * 60),
             callback_ports: (CODEX_CALLBACK_PORT, CODEX_CALLBACK_FALLBACK_PORT),
+            device_user_code_url: CODEX_DEVICE_USER_CODE_URL.to_owned(),
+            device_token_url: CODEX_DEVICE_TOKEN_URL.to_owned(),
+            device_verification_url: CODEX_DEVICE_VERIFICATION_URL.to_owned(),
+            client: reqwest::Client::new(),
         }
+    }
+
+    #[cfg(test)]
+    fn with_device_endpoints(
+        mut self,
+        user_code_url: impl Into<String>,
+        device_token_url: impl Into<String>,
+        verification_url: impl Into<String>,
+    ) -> Self {
+        self.device_user_code_url = user_code_url.into();
+        self.device_token_url = device_token_url.into();
+        self.device_verification_url = verification_url.into();
+        self
     }
 
     #[cfg(test)]
@@ -231,6 +284,163 @@ impl CodexLogin {
     ) -> Result<LoginResult, ProviderError> {
         let cancel = RuntimeCancel { runtime };
         self.login_flow(runtime, &cancel).await
+    }
+
+    /// OpenAI Codex 无头登录。设备凭据只在 provider 内部流转，UI 仅能看到
+    /// 授权地址、一次性代码和过期时间。
+    pub async fn login_device_code(
+        &self,
+        runtime: &dyn super::LoginRuntime,
+    ) -> Result<LoginResult, ProviderError> {
+        if runtime.is_cancelled() {
+            return Err(ProviderError::LoginCancelled);
+        }
+        runtime.set_step(super::LoginStep::Preparing).await;
+        let device = self.request_device_user_code(runtime).await?;
+        if device.device_auth_id.is_empty() || device.user_code.is_empty() {
+            return Err(ProviderError::DeviceAuthorizationFailed);
+        }
+        let expires_at = (Utc::now() + ChronoDuration::minutes(15)).to_rfc3339();
+        runtime
+            .present_device_authorization(
+                &self.device_verification_url,
+                &device.user_code,
+                Some(expires_at),
+            )
+            .await?;
+        runtime.set_step(super::LoginStep::Authorizing).await;
+        // 自动打开浏览器仅是辅助能力；Docker 用户可在其他设备手动授权。
+        let _ = runtime.open_browser(&self.device_verification_url).await;
+        runtime.set_step(super::LoginStep::Waiting).await;
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(15 * 60);
+        let interval = device.interval_seconds().clamp(1, 30);
+        let (code, verifier) = self
+            .poll_device_code(
+                runtime,
+                &device.device_auth_id,
+                &device.user_code,
+                interval,
+                deadline,
+            )
+            .await?;
+        runtime.set_step(super::LoginStep::Exchanging).await;
+        tokio::select! {
+            _ = runtime.cancelled() => Err(ProviderError::LoginCancelled),
+            result = self.exchange_code(
+                CODEX_DEVICE_REDIRECT_URI,
+                code,
+                PkceCodeVerifier::new(verifier),
+            ) => result,
+        }
+    }
+
+    async fn request_device_user_code(
+        &self,
+        runtime: &dyn super::LoginRuntime,
+    ) -> Result<DeviceUserCodeResponse, ProviderError> {
+        for attempt in 0..=3_u32 {
+            let response = tokio::select! {
+                _ = runtime.cancelled() => return Err(ProviderError::LoginCancelled),
+                response = self.client.post(&self.device_user_code_url)
+                    .json(&json!({"client_id": CODEX_CLIENT_ID})).send() => response,
+            };
+            match response {
+                Ok(response) if response.status().is_success() => {
+                    return response
+                        .json()
+                        .await
+                        .map_err(|_| ProviderError::DeviceAuthorizationFailed);
+                }
+                Ok(response)
+                    if matches!(
+                        response.status(),
+                        StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED
+                    ) =>
+                {
+                    return Err(ProviderError::AuthorizationDenied);
+                }
+                Ok(response) if !response.status().is_server_error() => {
+                    return Err(ProviderError::DeviceAuthorizationFailed);
+                }
+                Ok(_) | Err(_) if attempt < 3 => {
+                    let delay = Duration::from_secs(1_u64 << attempt);
+                    tokio::select! {
+                        _ = runtime.cancelled() => return Err(ProviderError::LoginCancelled),
+                        _ = tokio::time::sleep(delay) => {}
+                    }
+                }
+                Ok(_) | Err(_) => return Err(ProviderError::DeviceAuthorizationFailed),
+            }
+        }
+        Err(ProviderError::DeviceAuthorizationFailed)
+    }
+
+    async fn poll_device_code(
+        &self,
+        runtime: &dyn super::LoginRuntime,
+        device_auth_id: &str,
+        user_code: &str,
+        mut interval: u64,
+        deadline: tokio::time::Instant,
+    ) -> Result<(String, String), ProviderError> {
+        let mut transient_failures = 0_u8;
+        loop {
+            if runtime.is_cancelled() {
+                return Err(ProviderError::LoginCancelled);
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(ProviderError::LoginTimeout);
+            }
+            let response = tokio::select! {
+                _ = runtime.cancelled() => return Err(ProviderError::LoginCancelled),
+                response = self.client.post(&self.device_token_url).json(&json!({
+                    "device_auth_id": device_auth_id,
+                    "user_code": user_code,
+                })).send() => response,
+            };
+            match response {
+                Ok(response) if response.status() == StatusCode::OK => {
+                    let result: DeviceTokenResponse = response
+                        .json()
+                        .await
+                        .map_err(|_| ProviderError::TokenExchangeFailed)?;
+                    if result.authorization_code.is_empty() || result.code_verifier.is_empty() {
+                        return Err(ProviderError::TokenExchangeFailed);
+                    }
+                    return Ok((result.authorization_code, result.code_verifier));
+                }
+                Ok(response) if response.status() == StatusCode::NOT_FOUND => {
+                    transient_failures = 0;
+                }
+                Ok(response) if response.status().is_server_error() => {
+                    transient_failures = transient_failures.saturating_add(1);
+                    if transient_failures > 5 {
+                        return Err(ProviderError::Retryable);
+                    }
+                    interval = (interval.saturating_mul(2)).min(30);
+                }
+                Ok(response)
+                    if matches!(
+                        response.status(),
+                        StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED
+                    ) =>
+                {
+                    return Err(ProviderError::AuthorizationDenied);
+                }
+                Ok(_) => return Err(ProviderError::DeviceAuthorizationFailed),
+                Err(_) => {
+                    transient_failures = transient_failures.saturating_add(1);
+                    if transient_failures > 5 {
+                        return Err(ProviderError::Retryable);
+                    }
+                    interval = (interval.saturating_mul(2)).min(30);
+                }
+            }
+            tokio::select! {
+                _ = runtime.cancelled() => return Err(ProviderError::LoginCancelled),
+                _ = tokio::time::sleep(Duration::from_secs(interval)) => {}
+            }
+        }
     }
 
     /// The command layer owns the cancellation sender, while this method owns
@@ -1136,6 +1346,134 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
         (format!("http://{addr}/token"), hits, server)
+    }
+
+    #[derive(Clone)]
+    struct DeviceMockState {
+        polls: Arc<AtomicUsize>,
+    }
+
+    async fn device_user_code(axum::Json(body): axum::Json<Value>) -> axum::Json<Value> {
+        assert_eq!(body, json!({"client_id": CODEX_CLIENT_ID}));
+        axum::Json(json!({
+            "device_auth_id": "private-device-auth-id",
+            "user_code": "ABCD-EFGH",
+            "interval": "1"
+        }))
+    }
+
+    async fn device_poll(
+        State(state): State<DeviceMockState>,
+        axum::Json(body): axum::Json<Value>,
+    ) -> impl IntoResponse {
+        assert_eq!(body["device_auth_id"], "private-device-auth-id");
+        assert_eq!(body["user_code"], "ABCD-EFGH");
+        if state.polls.fetch_add(1, Ordering::SeqCst) == 0 {
+            return (StatusCode::NOT_FOUND, axum::Json(json!({}))).into_response();
+        }
+        (
+            StatusCode::OK,
+            axum::Json(json!({
+                "authorization_code": "device-authorization-code",
+                "code_verifier": "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv"
+            })),
+        )
+            .into_response()
+    }
+
+    async fn device_exchange(Form(form): Form<HashMap<String, String>>) -> axum::Json<Value> {
+        assert_eq!(
+            form.get("grant_type").map(String::as_str),
+            Some("authorization_code")
+        );
+        assert_eq!(
+            form.get("code").map(String::as_str),
+            Some("device-authorization-code")
+        );
+        assert_eq!(
+            form.get("redirect_uri").map(String::as_str),
+            Some(CODEX_DEVICE_REDIRECT_URI)
+        );
+        assert_eq!(
+            form.get("client_id").map(String::as_str),
+            Some(CODEX_CLIENT_ID)
+        );
+        assert_eq!(
+            form.get("code_verifier").map(String::as_str),
+            Some("vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv")
+        );
+        axum::Json(json!({
+            "access_token": jwt(json!({"exp": 4_102_444_800_i64})),
+            "refresh_token": REFRESH,
+            "id_token": jwt(json!({"email": "device@example.test", "plan_type": "plus"})),
+            "account_id": "account-device",
+            "token_type": "Bearer"
+        }))
+    }
+
+    #[derive(Default)]
+    struct DeviceRuntime {
+        verification: std::sync::Mutex<Option<(String, String, Option<String>)>>,
+    }
+
+    #[async_trait::async_trait]
+    impl super::super::LoginRuntime for DeviceRuntime {
+        async fn open_browser(&self, _: &str) -> Result<(), ProviderError> {
+            Err(ProviderError::BrowserOpenFailed)
+        }
+        async fn set_step(&self, _: super::super::LoginStep) {}
+        async fn present_device_authorization(
+            &self,
+            url: &str,
+            code: &str,
+            expires_at: Option<String>,
+        ) -> Result<(), ProviderError> {
+            *self.verification.lock().unwrap() =
+                Some((url.to_owned(), code.to_owned(), expires_at));
+            Ok(())
+        }
+        fn is_cancelled(&self) -> bool {
+            false
+        }
+        async fn cancelled(&self) {
+            std::future::pending::<()>().await
+        }
+    }
+
+    #[tokio::test]
+    async fn device_code_pending_then_exchanges_with_official_redirect() {
+        let state = DeviceMockState {
+            polls: Arc::new(AtomicUsize::new(0)),
+        };
+        let app = Router::new()
+            .route("/usercode", post(device_user_code))
+            .route("/device-token", post(device_poll))
+            .route("/oauth-token", post(device_exchange))
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let base = format!("http://{addr}");
+        let login = CodexLogin::with_endpoints("http://unused.test", format!("{base}/oauth-token"))
+            .with_device_endpoints(
+                format!("{base}/usercode"),
+                format!("{base}/device-token"),
+                "https://verify.example.test",
+            );
+        let runtime = DeviceRuntime::default();
+        let result = login.login_device_code(&runtime).await.unwrap();
+        assert_eq!(result.account_id, "account-device");
+        assert_eq!(result.label, "device@example.test");
+        assert_eq!(state.polls.load(Ordering::SeqCst), 2);
+        let verification = runtime.verification.lock().unwrap().clone().unwrap();
+        assert_eq!(verification.0, "https://verify.example.test");
+        assert_eq!(verification.1, "ABCD-EFGH");
+        assert!(verification.2.is_some());
+        let serialized = serde_json::to_string(result.payload.as_value()).unwrap();
+        assert!(!serialized.contains("private-device-auth-id"));
+        assert!(!serialized.contains("device-authorization-code"));
+        assert!(!serialized.contains("code_verifier"));
+        server.abort();
     }
 
     struct CallbackRuntime;

--- a/src-tauri/src/auth_provider/kimi_backend.rs
+++ b/src-tauri/src/auth_provider/kimi_backend.rs
@@ -832,7 +832,13 @@ mod tests {
 
         // New login: OAuth mock succeeds, result carries a uuid-shaped id.
         let fresh = provider
-            .login(&ProviderLoginContext { replacement: None }, &runtime)
+            .login(
+                &ProviderLoginContext {
+                    login_method: crate::auth_provider::AuthLoginMode::DeviceCode,
+                    replacement: None,
+                },
+                &runtime,
+            )
             .await
             .unwrap();
         assert_eq!(
@@ -845,6 +851,7 @@ mod tests {
 
         // Replacement re-login reuses the persisted device_id.
         let context = ProviderLoginContext {
+            login_method: crate::auth_provider::AuthLoginMode::DeviceCode,
             replacement: Some(super::super::ReplacementContext {
                 local_account_id: "local-1".into(),
                 provider_account_id: DEVICE_ID.into(),
@@ -864,6 +871,7 @@ mod tests {
         let (provider, _state) = mock_provider().await;
         let runtime = TestRuntime::default();
         let context = ProviderLoginContext {
+            login_method: crate::auth_provider::AuthLoginMode::DeviceCode,
             replacement: Some(super::super::ReplacementContext {
                 local_account_id: "local-1".into(),
                 provider_account_id: DEVICE_ID.into(),

--- a/src-tauri/src/auth_provider/service.rs
+++ b/src-tauri/src/auth_provider/service.rs
@@ -83,6 +83,22 @@ impl AuthService {
         target: LoginTarget,
         runtime: &dyn LoginRuntime,
     ) -> Result<AuthenticatedLogin, ProviderError> {
+        let login_method = crate::auth_provider::spec::provider_spec(&kind)
+            .map(|spec| spec.login_mode)
+            .ok_or_else(|| ProviderError::UnknownProvider {
+                provider: kind.to_string(),
+            })?;
+        self.authenticate_with_method(kind, target, login_method, runtime)
+            .await
+    }
+
+    pub async fn authenticate_with_method(
+        &self,
+        kind: ProviderKind,
+        target: LoginTarget,
+        login_method: crate::auth_provider::AuthLoginMode,
+        runtime: &dyn LoginRuntime,
+    ) -> Result<AuthenticatedLogin, ProviderError> {
         let provider = self.registry.get(&kind)?;
         let replacement = match &target {
             LoginTarget::New => None,
@@ -100,7 +116,10 @@ impl AuthService {
                 })
             }
         };
-        let context = ProviderLoginContext { replacement };
+        let context = ProviderLoginContext {
+            login_method,
+            replacement,
+        };
         let result = provider.login(&context, runtime).await?;
         Ok(AuthenticatedLogin {
             replacement: context.replacement,

--- a/src-tauri/src/auth_provider/spec.rs
+++ b/src-tauri/src/auth_provider/spec.rs
@@ -18,6 +18,23 @@ pub enum AuthLoginMode {
     DeviceCode,
 }
 
+impl AuthLoginMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::BrowserCallback => "browser_callback",
+            Self::DeviceCode => "device_code",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "browser_callback" => Some(Self::BrowserCallback),
+            "device_code" => Some(Self::DeviceCode),
+            _ => None,
+        }
+    }
+}
+
 /// Immutable capability metadata for one provider.
 ///
 /// The struct intentionally stores only non-secret, renderer-safe values.
@@ -29,6 +46,7 @@ pub struct ProviderSpec {
     pub display_name: &'static str,
     pub icon_key: &'static str,
     pub login_mode: AuthLoginMode,
+    pub login_methods: &'static [AuthLoginMode],
     pub supports_import: bool,
     pub supports_export: bool,
     pub supports_quota: bool,
@@ -39,6 +57,7 @@ const CODEX: ProviderSpec = ProviderSpec {
     display_name: "Codex",
     icon_key: "codex",
     login_mode: AuthLoginMode::BrowserCallback,
+    login_methods: &[AuthLoginMode::BrowserCallback, AuthLoginMode::DeviceCode],
     supports_import: true,
     supports_export: true,
     supports_quota: true,
@@ -49,6 +68,7 @@ const KIMI: ProviderSpec = ProviderSpec {
     display_name: "Kimi Code",
     icon_key: "moonshot",
     login_mode: AuthLoginMode::DeviceCode,
+    login_methods: &[AuthLoginMode::DeviceCode],
     supports_import: false,
     supports_export: false,
     supports_quota: false,
@@ -89,6 +109,10 @@ mod tests {
         assert_eq!(spec.display_name, "Codex");
         assert_eq!(spec.icon_key, "codex");
         assert_eq!(spec.login_mode, AuthLoginMode::BrowserCallback);
+        assert_eq!(
+            spec.login_methods,
+            &[AuthLoginMode::BrowserCallback, AuthLoginMode::DeviceCode]
+        );
         assert!(spec.supports_import);
         assert!(spec.supports_export);
         assert!(spec.supports_quota);
@@ -101,6 +125,7 @@ mod tests {
         assert_eq!(spec.display_name, "Kimi Code");
         assert_eq!(spec.icon_key, "moonshot");
         assert_eq!(spec.login_mode, AuthLoginMode::DeviceCode);
+        assert_eq!(spec.login_methods, &[AuthLoginMode::DeviceCode]);
         assert!(!spec.supports_import);
         assert!(!spec.supports_export);
         assert!(!spec.supports_quota);

--- a/src-tauri/src/auth_provider/types.rs
+++ b/src-tauri/src/auth_provider/types.rs
@@ -228,6 +228,7 @@ pub enum LoginTarget {
 /// with only the fields a provider legitimately needs.
 #[derive(Clone, Debug)]
 pub struct ProviderLoginContext {
+    pub login_method: crate::auth_provider::AuthLoginMode,
     pub replacement: Option<ReplacementContext>,
 }
 

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -405,6 +405,7 @@ fn login_error_code(error: &ProviderError) -> &'static str {
         ProviderError::LoginTimeout => "timeout",
         ProviderError::BrowserOpenFailed => "browser_open",
         ProviderError::CallbackFailed => "callback_state",
+        ProviderError::DeviceAuthorizationFailed => "device_authorization",
         ProviderError::TokenExchangeFailed => "token_exchange",
         ProviderError::AuthorizationDenied => "authorization_denied",
         _ => "login_failed",
@@ -417,6 +418,7 @@ fn login_error_message(error: &ProviderError) -> &'static str {
         "timeout" => "等待浏览器授权超时，请重新开始登录。",
         "browser_open" => "无法打开浏览器授权页，请检查默认浏览器后重试。",
         "callback_state" => "授权回调无效或被拒绝，请重新开始登录。",
+        "device_authorization" => "Device Code 不可用，请检查 ChatGPT 个人安全设置或 Workspace 管理员权限；也可导入 auth.json。",
         "token_exchange" => "授权完成，但令牌交换失败，请重新开始登录。",
         "authorization_denied" => "授权被拒绝，请重新开始登录。",
         _ => "登录未完成，请检查浏览器授权后重试。",
@@ -517,6 +519,7 @@ async fn run_provider_login_session(
     session_id: String,
     provider: ProviderKind,
     target: crate::auth_provider::LoginTarget,
+    login_method: crate::auth_provider::AuthLoginMode,
     cancellation: watch::Receiver<bool>,
     app: Option<tauri::AppHandle>,
     service: Arc<crate::auth_provider::service::AuthService>,
@@ -532,7 +535,10 @@ async fn run_provider_login_session(
         session_id: session_id.clone(),
         cancellation,
     };
-    let result = match service.authenticate(provider, target, &runtime).await {
+    let result = match service
+        .authenticate_with_method(provider, target, login_method, &runtime)
+        .await
+    {
         Ok(authenticated) => {
             // The commit gate: a cancel that races persistence (or that happened
             // before the OAuth finished) makes begin_save return false and the
@@ -686,6 +692,7 @@ pub struct AuthProviderDto {
     pub display_name: String,
     pub icon_key: String,
     pub login_mode: String,
+    pub login_methods: Vec<String>,
     pub supports_import: bool,
     pub supports_export: bool,
     pub supports_quota: bool,
@@ -700,11 +707,12 @@ pub async fn auth_providers_list() -> Result<Vec<AuthProviderDto>, String> {
             id: spec.kind.to_owned(),
             display_name: spec.display_name.to_owned(),
             icon_key: spec.icon_key.to_owned(),
-            login_mode: match spec.login_mode {
-                crate::auth_provider::AuthLoginMode::BrowserCallback => "browser_callback",
-                crate::auth_provider::AuthLoginMode::DeviceCode => "device_code",
-            }
-            .to_owned(),
+            login_mode: spec.login_mode.as_str().to_owned(),
+            login_methods: spec
+                .login_methods
+                .iter()
+                .map(|method| method.as_str().to_owned())
+                .collect(),
             supports_import: spec.supports_import,
             supports_export: spec.supports_export,
             supports_quota: spec.supports_quota,
@@ -716,9 +724,25 @@ pub async fn auth_providers_list() -> Result<Vec<AuthProviderDto>, String> {
 /// listener + system browser); device-code providers also work headless
 /// because the verification URL + user code travel through the polled
 /// session status instead.
-fn login_requires_desktop_shell(kind: &ProviderKind) -> bool {
-    crate::auth_provider::spec::provider_spec(kind)
-        .is_some_and(|spec| spec.login_mode == crate::auth_provider::AuthLoginMode::BrowserCallback)
+fn login_requires_desktop_shell(login_method: crate::auth_provider::AuthLoginMode) -> bool {
+    login_method == crate::auth_provider::AuthLoginMode::BrowserCallback
+}
+
+fn resolve_login_method(
+    kind: &ProviderKind,
+    requested: Option<&str>,
+) -> Result<crate::auth_provider::AuthLoginMode, String> {
+    let spec = crate::auth_provider::spec::provider_spec(kind)
+        .ok_or_else(|| "Unsupported auth provider".to_owned())?;
+    let method = match requested {
+        Some(value) => crate::auth_provider::AuthLoginMode::parse(value)
+            .ok_or_else(|| "不支持的登录方式".to_owned())?,
+        None => spec.login_mode,
+    };
+    if !spec.login_methods.contains(&method) {
+        return Err("当前服务商不支持所选登录方式".to_owned());
+    }
+    Ok(method)
 }
 
 /// Shared core behind the `auth_login_start` command and the headless admin
@@ -727,12 +751,17 @@ fn login_requires_desktop_shell(kind: &ProviderKind) -> bool {
 pub(crate) async fn auth_login_start_with(
     provider: String,
     replace_account_id: Option<String>,
+    login_method: Option<String>,
     app: Option<tauri::AppHandle>,
     state: &Arc<AppState>,
 ) -> Result<AuthLoginStart, String> {
     let kind = provider_kind(Some(provider))?;
-    if app.is_none() && login_requires_desktop_shell(&kind) {
-        return Err("OAuth 登录仅桌面版可用，请使用 auth.json 导入".to_string());
+    let login_method = resolve_login_method(&kind, login_method.as_deref())?;
+    if app.is_none() && login_requires_desktop_shell(login_method) {
+        return Err(
+            "浏览器 OAuth（localhost 回调）仅桌面端支持；请使用 Device Code 或导入 auth.json"
+                .to_string(),
+        );
     }
     // Validate the local account id syntactically before spawning so a bad id
     // fails the command (not a background task).  The payload is never touched.
@@ -751,8 +780,17 @@ pub(crate) async fn auth_login_start_with(
     let service = state.auth_service.clone();
     let task_id = session_id.clone();
     tauri::async_runtime::spawn(async move {
-        run_provider_login_session(sessions, task_id, kind, target, cancellation, app, service)
-            .await;
+        run_provider_login_session(
+            sessions,
+            task_id,
+            kind,
+            target,
+            login_method,
+            cancellation,
+            app,
+            service,
+        )
+        .await;
     });
     Ok(AuthLoginStart { session_id })
 }
@@ -761,10 +799,18 @@ pub(crate) async fn auth_login_start_with(
 pub async fn auth_login_start(
     provider: String,
     replace_account_id: Option<String>,
+    login_method: Option<String>,
     app: tauri::AppHandle,
     state: tauri::State<'_, Arc<AppState>>,
 ) -> Result<AuthLoginStart, String> {
-    auth_login_start_with(provider, replace_account_id, Some(app), state.inner()).await
+    auth_login_start_with(
+        provider,
+        replace_account_id,
+        login_method,
+        Some(app),
+        state.inner(),
+    )
+    .await
 }
 
 #[tauri::command]
@@ -1235,6 +1281,10 @@ mod tests {
         assert_eq!(codex.display_name, "Codex");
         assert_eq!(codex.icon_key, "codex");
         assert_eq!(codex.login_mode, "browser_callback");
+        assert_eq!(
+            codex.login_methods,
+            vec!["browser_callback".to_owned(), "device_code".to_owned()]
+        );
         assert!(codex.supports_import);
         assert!(codex.supports_export);
         assert!(codex.supports_quota);
@@ -1242,6 +1292,7 @@ mod tests {
         assert_eq!(kimi.display_name, "Kimi Code");
         assert_eq!(kimi.icon_key, "moonshot");
         assert_eq!(kimi.login_mode, "device_code");
+        assert_eq!(kimi.login_methods, vec!["device_code".to_owned()]);
         assert!(!kimi.supports_import);
         assert!(!kimi.supports_export);
         assert!(!kimi.supports_quota);
@@ -1266,8 +1317,30 @@ mod tests {
         // Device-code providers (Kimi) must be allowed headless (Docker/web
         // admin panel); browser-callback providers (Codex) still require the
         // desktop shell for the loopback listener + system browser.
-        assert!(!login_requires_desktop_shell(&ProviderKind::Kimi));
-        assert!(login_requires_desktop_shell(&ProviderKind::Codex));
+        assert!(!login_requires_desktop_shell(
+            crate::auth_provider::AuthLoginMode::DeviceCode
+        ));
+        assert!(login_requires_desktop_shell(
+            crate::auth_provider::AuthLoginMode::BrowserCallback
+        ));
+    }
+
+    #[test]
+    fn login_method_defaults_are_backward_compatible_and_capabilities_are_enforced() {
+        assert_eq!(
+            resolve_login_method(&ProviderKind::Codex, None).unwrap(),
+            crate::auth_provider::AuthLoginMode::BrowserCallback
+        );
+        assert_eq!(
+            resolve_login_method(&ProviderKind::Kimi, None).unwrap(),
+            crate::auth_provider::AuthLoginMode::DeviceCode
+        );
+        assert_eq!(
+            resolve_login_method(&ProviderKind::Codex, Some("device_code")).unwrap(),
+            crate::auth_provider::AuthLoginMode::DeviceCode
+        );
+        assert!(resolve_login_method(&ProviderKind::Kimi, Some("browser_callback")).is_err());
+        assert!(resolve_login_method(&ProviderKind::Codex, Some("unknown")).is_err());
     }
 
     #[tokio::test]

--- a/src-tauri/src/server/admin_routes.rs
+++ b/src-tauri/src/server/admin_routes.rs
@@ -541,6 +541,7 @@ async fn dispatch(shared: &SharedState, cmd: &str, args: Value) -> Result<Value,
                 commands::auth::auth_login_start_with(
                     arg(&args, "provider")?,
                     arg(&args, "replaceAccountId")?,
+                    arg(&args, "loginMethod")?,
                     app,
                     state.inner(),
                 )

--- a/src/components/auth/LoginModal.tsx
+++ b/src/components/auth/LoginModal.tsx
@@ -170,7 +170,8 @@ export function LoginModal({
       {needsChoice && !loginMethod && <div className="mt-5 space-y-3">
         <p className="text-sm font-medium">选择登录方式</p>
         <button type="button" disabled={!isDesktop} onClick={() => setLoginMethod("browser_callback")} className="w-full rounded-xl border border-border p-4 text-left hover:bg-muted disabled:cursor-not-allowed disabled:opacity-55"><span className="block text-sm font-semibold">浏览器 OAuth</span><span className="mt-1 block text-xs text-muted-foreground">{isDesktop ? "通过本机 localhost 回调完成授权" : "仅桌面端支持 localhost 回调"}</span></button>
-        <button type="button" onClick={() => setLoginMethod("device_code")} className="w-full rounded-xl border border-border p-4 text-left hover:bg-muted"><span className="block text-sm font-semibold">Device Code</span><span className="mt-1 block text-xs text-muted-foreground">在任意设备打开授权页并输入一次性代码，适用于 Web / Docker</span></button>
+        <button type="button" onClick={() => setLoginMethod("device_code")} className="w-full rounded-xl border border-border p-4 text-left hover:bg-muted"><span className="block text-sm font-semibold">设备代码授权（Device Code）</span><span className="mt-1 block text-xs text-muted-foreground">在任意设备打开授权页并输入一次性代码，适用于 Web / Docker</span></button>
+        <p className="rounded-xl bg-primary/10 px-3 py-2.5 text-xs leading-5 text-primary">首次使用前，请登录 ChatGPT Web，依次进入“设置 → 账户 → 安全与登录”，打开“为 Codex 启用设备代码授权”。</p>
       </div>}
       {loginMethod && <>
       <ol className="mt-5 space-y-3" aria-label="登录步骤">{steps.map((step, index) => { const complete = state === "done" || index < currentStep; const active = state === "running" && index === currentStep; return <li key={step} className="flex items-center gap-3 rounded-xl border border-border bg-muted/35 px-3 py-2.5 text-sm"><span className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold ${complete ? "bg-success text-white" : active ? "bg-primary text-primary-foreground" : "bg-card text-muted-foreground"}`}>{complete ? <Check size={14} /> : active ? <Loader2 size={14} className="animate-spin" /> : index + 1}</span><span className={active ? "font-medium" : "text-muted-foreground"}>{step}</span></li>; })}</ol>
@@ -184,7 +185,7 @@ export function LoginModal({
       {error && <p role="alert" className="mt-4 flex items-center gap-2 rounded-xl bg-destructive/10 px-3 py-2.5 text-sm text-destructive"><CircleAlert size={15} />{error}</p>}
       {state === "done" && <p className="mt-4 rounded-xl bg-success/10 px-3 py-2.5 text-sm text-success">账号已保存。{currentStep === 5 ? "模型同步已完成。" : ""}</p>}
       </>}
-      {error && isDevice && <p className="mt-2 text-xs leading-5 text-muted-foreground">若 Device Code 未启用，请检查 ChatGPT 个人安全设置或 Workspace 管理员权限；也可改用 auth.json 导入。</p>}
+      {error && isDevice && <p className="mt-2 text-xs leading-5 text-muted-foreground">请登录 ChatGPT Web，进入“设置 → 账户 → 安全与登录”，确认已打开“为 Codex 启用设备代码授权”。Workspace 用户可能还需联系管理员开启权限；也可改用 auth.json 导入。</p>}
       <div className="mt-6 flex justify-end gap-2">{state === "running" ? <button onClick={() => void cancel()} className="action-secondary">取消登录</button> : state !== "done" && <button onClick={onClose} className="action-secondary">取消</button>}{state === "done" ? <button onClick={onClose} className="action-primary">完成</button> : <button onClick={() => void login()} disabled={state === "running" || !loginMethod} className="action-primary">{state === "running" ? "登录中…" : "开始登录"}</button>}</div>
     </div>
   </div>;

--- a/src/components/auth/LoginModal.tsx
+++ b/src/components/auth/LoginModal.tsx
@@ -9,7 +9,9 @@ import {
   X,
 } from "lucide-react";
 import { authApi } from "../../lib/api";
+import { isTauriRuntime } from "../../lib/runtime";
 import type {
+  AuthLoginMethod,
   AuthLoginSessionStatus,
   AuthMutationResult,
   AuthProviderInfo,
@@ -28,6 +30,15 @@ const codexSteps = [
 const kimiSteps = [
   "申请设备授权",
   "打开 Kimi 授权页",
+  "等待确认",
+  "交换令牌",
+  "保存账号",
+  "同步模型",
+];
+
+const codexDeviceSteps = [
+  "申请设备授权",
+  "打开 OpenAI 授权页",
   "等待确认",
   "交换令牌",
   "保存账号",
@@ -70,8 +81,15 @@ export function LoginModal({
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [verification, setVerification] = useState<DeviceVerification | null>(null);
   const [copied, setCopied] = useState(false);
-  const isDevice = provider.loginMode === "device_code";
-  const steps = isDevice ? kimiSteps : codexSteps;
+  const needsChoice = provider.loginMethods.length > 1;
+  const [loginMethod, setLoginMethod] = useState<AuthLoginMethod | null>(
+    needsChoice ? null : (provider.loginMethods[0] ?? "device_code"),
+  );
+  const isDevice = loginMethod === "device_code";
+  const steps = isDevice
+    ? provider.id === "kimi" ? kimiSteps : codexDeviceSteps
+    : codexSteps;
+  const isDesktop = isTauriRuntime();
 
   useEffect(() => {
     if (!sessionId || state !== "running") return;
@@ -104,10 +122,12 @@ export function LoginModal({
   const login = async () => {
     setState("running"); setCurrentStep(0); setError(null);
     try {
-      const session = await authApi.loginStart(provider.id, replaceAccountId);
+      if (!loginMethod) return;
+      const session = await authApi.loginStart(provider.id, replaceAccountId, loginMethod);
       setSessionId(session.sessionId);
-    } catch (_) {
-      setState("error"); setError("无法启动登录，请重试。");
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : "无法启动登录，请重试。";
+      setState("error"); setError(message);
     }
   };
 
@@ -146,7 +166,13 @@ export function LoginModal({
   };
 
   return <div className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/35 p-4" role="dialog" aria-modal="true" aria-labelledby="login-auth-title">
-    <div className="surface w-full max-w-lg rounded-[24px] p-6 shadow-2xl"><div className="flex items-start justify-between"><div><h2 id="login-auth-title" className="text-lg font-semibold">登录 {provider.displayName} 账号</h2><p className="mt-1 text-sm text-muted-foreground">{isDevice ? "设备码授权 · 浏览器确认 · 消耗订阅额度" : "浏览器 OAuth 授权 · PKCE · 消耗订阅额度"}</p></div><button onClick={onClose} disabled={state === "running" && !isDevice} aria-label="关闭登录弹窗" className="rounded-lg p-1 text-muted-foreground hover:bg-muted"><X size={18} /></button></div>
+    <div className="surface w-full max-w-lg rounded-[24px] p-6 shadow-2xl"><div className="flex items-start justify-between"><div><h2 id="login-auth-title" className="text-lg font-semibold">登录 {provider.displayName} 账号</h2><p className="mt-1 text-sm text-muted-foreground">{isDevice ? "设备码授权 · 浏览器确认 · 消耗订阅额度" : "浏览器 OAuth 授权 · PKCE · 消耗订阅额度"}</p></div><button onClick={() => state === "running" ? void cancel() : onClose()} disabled={state === "running" && !isDevice} aria-label="关闭登录弹窗" className="rounded-lg p-1 text-muted-foreground hover:bg-muted"><X size={18} /></button></div>
+      {needsChoice && !loginMethod && <div className="mt-5 space-y-3">
+        <p className="text-sm font-medium">选择登录方式</p>
+        <button type="button" disabled={!isDesktop} onClick={() => setLoginMethod("browser_callback")} className="w-full rounded-xl border border-border p-4 text-left hover:bg-muted disabled:cursor-not-allowed disabled:opacity-55"><span className="block text-sm font-semibold">浏览器 OAuth</span><span className="mt-1 block text-xs text-muted-foreground">{isDesktop ? "通过本机 localhost 回调完成授权" : "仅桌面端支持 localhost 回调"}</span></button>
+        <button type="button" onClick={() => setLoginMethod("device_code")} className="w-full rounded-xl border border-border p-4 text-left hover:bg-muted"><span className="block text-sm font-semibold">Device Code</span><span className="mt-1 block text-xs text-muted-foreground">在任意设备打开授权页并输入一次性代码，适用于 Web / Docker</span></button>
+      </div>}
+      {loginMethod && <>
       <ol className="mt-5 space-y-3" aria-label="登录步骤">{steps.map((step, index) => { const complete = state === "done" || index < currentStep; const active = state === "running" && index === currentStep; return <li key={step} className="flex items-center gap-3 rounded-xl border border-border bg-muted/35 px-3 py-2.5 text-sm"><span className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold ${complete ? "bg-success text-white" : active ? "bg-primary text-primary-foreground" : "bg-card text-muted-foreground"}`}>{complete ? <Check size={14} /> : active ? <Loader2 size={14} className="animate-spin" /> : index + 1}</span><span className={active ? "font-medium" : "text-muted-foreground"}>{step}</span></li>; })}</ol>
       {isDevice && verification && state === "running" && <div className="mt-4 space-y-3 rounded-xl border border-border bg-muted/35 p-4">
         <div className="flex items-center justify-between gap-3"><div><p className="text-xs font-medium text-muted-foreground">授权码（请勿发送给他人）</p><p className="mt-1 font-mono text-2xl font-bold tracking-widest">{verification.userCode}</p></div><button onClick={() => void copyUserCode()} className="action-secondary px-2 py-2 text-xs">{copied ? <Check size={14} /> : <Copy size={14} />}{copied ? "已复制" : "复制授权码"}</button></div>
@@ -157,7 +183,9 @@ export function LoginModal({
       {state === "running" && !isDevice && <p className="mt-4 flex items-center gap-2 rounded-xl bg-primary/10 px-3 py-2.5 text-sm text-primary"><ExternalLink size={15} />已在浏览器打开授权页，请在浏览器完成登录</p>}
       {error && <p role="alert" className="mt-4 flex items-center gap-2 rounded-xl bg-destructive/10 px-3 py-2.5 text-sm text-destructive"><CircleAlert size={15} />{error}</p>}
       {state === "done" && <p className="mt-4 rounded-xl bg-success/10 px-3 py-2.5 text-sm text-success">账号已保存。{currentStep === 5 ? "模型同步已完成。" : ""}</p>}
-      <div className="mt-6 flex justify-end gap-2">{state === "running" ? <button onClick={() => void cancel()} className="action-secondary">取消登录</button> : state !== "done" && <button onClick={onClose} className="action-secondary">取消</button>}{state === "done" ? <button onClick={onClose} className="action-primary">完成</button> : <button onClick={() => void login()} disabled={state === "running"} className="action-primary">{state === "running" ? "登录中…" : "开始登录"}</button>}</div>
+      </>}
+      {error && isDevice && <p className="mt-2 text-xs leading-5 text-muted-foreground">若 Device Code 未启用，请检查 ChatGPT 个人安全设置或 Workspace 管理员权限；也可改用 auth.json 导入。</p>}
+      <div className="mt-6 flex justify-end gap-2">{state === "running" ? <button onClick={() => void cancel()} className="action-secondary">取消登录</button> : state !== "done" && <button onClick={onClose} className="action-secondary">取消</button>}{state === "done" ? <button onClick={onClose} className="action-primary">完成</button> : <button onClick={() => void login()} disabled={state === "running" || !loginMethod} className="action-primary">{state === "running" ? "登录中…" : "开始登录"}</button>}</div>
     </div>
   </div>;
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -15,7 +15,7 @@ import type {
   UpstreamModelsResult,
   AuthAccount, AuthLoginSessionStatus, AuthLoginStart, AuthMutationResult, AuthLogoutResult, AuthExportResult,
   AuthQuotaStatus, AuthUpdateInput,
-  AuthProviderInfo,
+  AuthProviderInfo, AuthLoginMethod,
 } from "../types";
 
 /**
@@ -119,10 +119,11 @@ export const authApi = {
    * for them before any network request.
    */
   login: (provider: string) => invoke<AuthMutationResult>("auth_login", { provider }),
-  loginStart: (provider: string, replaceAccountId?: string) =>
+  loginStart: (provider: string, replaceAccountId?: string, loginMethod?: AuthLoginMethod) =>
     invoke<AuthLoginStart>("auth_login_start", {
       provider,
       replaceAccountId: replaceAccountId ?? null,
+      loginMethod: loginMethod ?? null,
     }),
   loginStatus: (sessionId: string) => invoke<AuthLoginSessionStatus>("auth_login_status", { sessionId }),
   loginCancel: (sessionId: string) => invoke<AuthLoginSessionStatus>("auth_login_cancel", { sessionId }),

--- a/src/pages/AuthChannelsPage.tsx
+++ b/src/pages/AuthChannelsPage.tsx
@@ -104,6 +104,9 @@ export function AuthChannelsPage() {
     displayName: selectedProvider === "kimi" ? "Kimi Code" : "Codex",
     iconKey: selectedProvider === "kimi" ? "moonshot" : "codex",
     loginMode: selectedProvider === "kimi" ? "device_code" : "browser_callback",
+    loginMethods: selectedProvider === "kimi"
+      ? ["device_code" as const]
+      : ["browser_callback" as const, "device_code" as const],
     supportsImport: selectedProvider !== "kimi",
     supportsExport: selectedProvider !== "kimi",
     supportsQuota: selectedProvider !== "kimi",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -273,12 +273,14 @@ export interface AuthLoginStart {
 }
 
 export type AuthProviderId = "codex" | "kimi" | (string & {});
+export type AuthLoginMethod = "browser_callback" | "device_code";
 
 export interface AuthProviderInfo {
   id: AuthProviderId;
   displayName: string;
   iconKey: string;
   loginMode: "browser_callback" | "device_code" | (string & {});
+  loginMethods: AuthLoginMethod[];
   supportsImport: boolean;
   supportsExport: boolean;
   supportsQuota: boolean;


### PR DESCRIPTION
## 变更说明

- 保留现有 Codex 浏览器 OAuth + localhost callback 登录
- 新增 Codex Device Code 登录，支持 Web / Docker 等 headless 部署
- 桌面端登录和重新登录时选择登录方式，Web 端仅允许 Device Code
- Kimi 设备码流程及 auth.json 导入保持不变
- 增加面向新手的启用指引：ChatGPT Web → 设置 → 账户 → 安全与登录 → 打开“为 Codex 启用设备代码授权”
- 兼容 OpenAI 以 HTTP 403 + deviceauth_authorization_pending 表示等待授权的实际行为

## 验证

- pnpm build
- pnpm --filter waliapi-web build
- cargo build --bin waliapi-web --no-default-features --features embed-web
- Device Code 登录真实人工验证通过
- 协议与登录方式兼容测试通过

本 PR 基于 v0.3.1。