### PR TITLE
feat(quota): 配额 429 错误体按端点协议返回并携带 used/limit；两轨配额记账口径合一 + 递增封顶

### DIFF
--- a/src-tauri/src/core/proxy.rs
+++ b/src-tauri/src/core/proxy.rs
@@ -381,12 +381,12 @@ pub async fn handle_request(
                     eprintln!("[WARN] create_security_findings failed: {}", e);
                 }
 
-                if let Some(ref u) = usage {
-                    if let Err(e) = repo
-                        .increment_quota(api_key_id, u.total_tokens as i64)
-                        .await
-                    {
-                        eprintln!("[WARN] increment_quota failed: {}", e);
+                // 两轨口径统一（C-01）：上游未回 usage 时沿用与日志同源的本地
+                // 估算计入配额（total_tokens 已在上方做过 2xx+缺失 usage 的估算
+                // 兜底），与 endpoint_executor 轨一致；估算也为 0 时不累加。
+                if total_tokens > 0 {
+                    if let Err(e) = repo.increment_quota(api_key_id, total_tokens).await {
+                        tracing::warn!("increment_quota failed: {}", e);
                     }
                 }
 

--- a/src-tauri/src/core/route_plan.rs
+++ b/src-tauri/src/core/route_plan.rs
@@ -324,7 +324,9 @@ pub struct RoutePlan {
 pub enum PlanError {
     KeyDisabled,
     KeyExpired,
-    QuotaExceeded,
+    /// 配额用尽，携带 (quota_used, quota_limit)：错误文案直接给出差额信息，
+    /// 客户端与管理端无需再查库（C-01）。
+    QuotaExceeded(i64, i64),
     ModelNotAllowed(String),
     NoChannels,
     NoCandidateForModel(String),
@@ -340,7 +342,7 @@ impl PlanError {
         match self {
             PlanError::KeyDisabled => 401,
             PlanError::KeyExpired => 401,
-            PlanError::QuotaExceeded => 429,
+            PlanError::QuotaExceeded(..) => 429,
             PlanError::ModelNotAllowed(_) => 403,
             PlanError::NoChannels => 503,
             PlanError::NoCandidateForModel(_) => 503,
@@ -360,7 +362,9 @@ impl PlanError {
         match self {
             PlanError::KeyDisabled => "API key is disabled".to_string(),
             PlanError::KeyExpired => "API key has expired".to_string(),
-            PlanError::QuotaExceeded => "Quota exceeded".to_string(),
+            PlanError::QuotaExceeded(used, limit) => {
+                format!("Quota exceeded (used {} / limit {})", used, limit)
+            }
             PlanError::ModelNotAllowed(m) => {
                 format!("Model '{}' is not allowed for this API key", m)
             }
@@ -591,7 +595,10 @@ pub fn authorize_request(api_key: &ApiKey, model: &str) -> Result<(), PlanError>
         }
     }
     if api_key.quota_limit > 0 && api_key.quota_used >= api_key.quota_limit {
-        return Err(PlanError::QuotaExceeded);
+        return Err(PlanError::QuotaExceeded(
+            api_key.quota_used,
+            api_key.quota_limit,
+        ));
     }
     let allowed: Vec<String> = serde_json::from_str(&api_key.allowed_models).unwrap_or_default();
     if !allowed.is_empty() && !allowed.iter().any(|m| m == model) {
@@ -1469,7 +1476,10 @@ mod tests {
         let mut key = api_key(&[], &[]);
         key.quota_limit = 100;
         key.quota_used = 100;
-        assert_eq!(authorize_request(&key, "m"), Err(PlanError::QuotaExceeded));
+        assert_eq!(
+            authorize_request(&key, "m"),
+            Err(PlanError::QuotaExceeded(100, 100))
+        );
     }
 
     #[test]

--- a/src-tauri/src/db/repository.rs
+++ b/src-tauri/src/db/repository.rs
@@ -831,11 +831,18 @@ impl Repository {
     }
 
     pub async fn increment_quota(&self, id: &str, tokens: i64) -> Result<(), sqlx::Error> {
-        sqlx::query("UPDATE api_keys SET quota_used = quota_used + ? WHERE id = ?")
-            .bind(tokens)
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
+        // 配额递增带封顶（C-01）：quota_limit > 0 时 quota_used 不越过上限；
+        // -1/0 表示不限，纯加法。检查发生在请求前、递增在响应后，并发窗口内
+        // 多个在途请求可同时放行——封顶保证越界幅度有界，属已知可接受行为。
+        sqlx::query(
+            "UPDATE api_keys SET quota_used = CASE WHEN quota_limit > 0 \
+             THEN MIN(quota_used + ?, quota_limit) ELSE quota_used + ? END WHERE id = ?",
+        )
+        .bind(tokens)
+        .bind(tokens)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
         Ok(())
     }
 

--- a/src-tauri/src/rollout_integration_tests.rs
+++ b/src-tauri/src/rollout_integration_tests.rs
@@ -2137,6 +2137,92 @@ async fn security_quota_exceeded_zero_upstream() {
     assert_eq!(mock.call_count().await, 0);
 }
 
+/// C-01：递增封顶——quota_limit > 0 时 quota_used 不越界；0 视为不限纯加法。
+#[tokio::test]
+async fn quota_increment_caps_at_positive_limit() {
+    let pool = fresh_db().await;
+    let mut capped = api_key();
+    capped.id = "key-capped".into();
+    capped.quota_limit = 1000;
+    insert_api_key(&pool, &capped).await;
+    let mut unlimited = api_key();
+    unlimited.id = "key-unlimited".into();
+    unlimited.key = "sk-test-unlimited".into();
+    unlimited.quota_limit = 0;
+    insert_api_key(&pool, &unlimited).await;
+
+    let repo = Repository::new(pool.clone());
+    repo.increment_quota(&capped.id, 600).await.unwrap();
+    repo.increment_quota(&capped.id, 600).await.unwrap();
+    assert_eq!(
+        repo.get_api_key_by_id(&capped.id).await.unwrap().quota_used,
+        1000,
+        "capped at limit"
+    );
+
+    repo.increment_quota(&unlimited.id, 500).await.unwrap();
+    repo.increment_quota(&unlimited.id, 500).await.unwrap();
+    assert_eq!(
+        repo.get_api_key_by_id(&unlimited.id)
+            .await
+            .unwrap()
+            .quota_used,
+        1000,
+        "limit 0 means unlimited: plain sum"
+    );
+}
+
+/// C-01：legacy 轨上游 2xx 但不回 usage 时，配额按本地估算累加，
+/// 与 endpoint_executor 轨口径一致。
+#[tokio::test]
+async fn legacy_proxy_estimates_quota_when_upstream_omits_usage() {
+    let mock = MockUpstream::start_fixed(
+        br#"{"choices":[{"message":{"role":"assistant","content":"hello there friend"}}]}"#
+            .to_vec(),
+        200,
+    )
+    .await;
+    let pool = fresh_db().await;
+    let key = api_key();
+    insert_api_key(&pool, &key).await;
+    let ch = channel(
+        "n1",
+        "openai",
+        "openai",
+        &format!("http://{}", mock.addr),
+        &["chat_completions"],
+        &["m"],
+        1,
+        "{}",
+    );
+    insert_channel(&pool, &ch).await;
+
+    let settings = crate::settings_store::SettingsStore::file(
+        std::env::temp_dir().join(format!(
+            "waliapi-proxy-quota-test-{}.json",
+            uuid::Uuid::new_v4()
+        )),
+    );
+    let repo = Arc::new(Repository::new(pool.clone()));
+    let result = crate::core::proxy::handle_request(
+        &repo,
+        &settings,
+        &key.id,
+        "tester",
+        json!({"model":"m","messages":[{"role":"user","content":"hello world how are you today"}]}),
+        false,
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("proxy request");
+    assert_eq!(result.status, 200);
+
+    let used = repo.get_api_key_by_id(&key.id).await.unwrap().quota_used;
+    assert!(used > 0, "estimated usage must be recorded, got {}", used);
+}
+
 /// Model not allowed → PlanError::ModelNotAllowed; zero upstream.
 #[tokio::test]
 async fn security_model_not_allowed_zero_upstream() {

--- a/src-tauri/src/rollout_integration_tests.rs
+++ b/src-tauri/src/rollout_integration_tests.rs
@@ -2130,7 +2130,10 @@ async fn security_quota_exceeded_zero_upstream() {
     )
     .await
     .expect_err("quota");
-    assert_eq!(err, crate::core::route_plan::PlanError::QuotaExceeded);
+    assert_eq!(
+        err,
+        crate::core::route_plan::PlanError::QuotaExceeded(100, 100)
+    );
     assert_eq!(mock.call_count().await, 0);
 }
 

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -510,7 +510,13 @@ pub async fn handle_chat_completions(
     };
 
     if key_record.quota_limit > 0 && key_record.quota_used >= key_record.quota_limit {
-        return (StatusCode::TOO_MANY_REQUESTS, "Quota exceeded").into_response();
+        // 配额拒绝是 Key 维度终态：429 + OpenAI JSON 错误体（与其他端点一致），
+        // 不做渠道 failover（C-01）。
+        return openai_error(
+            StatusCode::TOO_MANY_REQUESTS,
+            quota_exceeded_message(key_record.quota_used, key_record.quota_limit),
+            "rate_limit_error",
+        );
     }
 
     // Extract Wali-Trace-Id from request headers
@@ -1193,6 +1199,12 @@ fn anthropic_error(status: StatusCode, kind: &str, message: impl Into<String>) -
         Json(serde_json::json!({"type":"error", "error":{"type":kind, "message":message.into()}})),
     )
         .into_response()
+}
+
+/// 配额用尽文案：携带 used/limit 数值，客户端与管理端可直接从错误体读取
+/// 差额，无需另查管理面（C-01）。五端点与规划期错误共用同一模板。
+fn quota_exceeded_message(used: i64, limit: i64) -> String {
+    format!("Quota exceeded (used {} / limit {})", used, limit)
 }
 
 /// Resolve a model name through the mapping: supports both single string and
@@ -2086,7 +2098,7 @@ pub async fn handle_messages(
         return anthropic_error(
             StatusCode::TOO_MANY_REQUESTS,
             "rate_limit_error",
-            "Quota exceeded",
+            quota_exceeded_message(key.quota_used, key.quota_limit),
         );
     }
     let model = match json
@@ -2807,7 +2819,7 @@ pub async fn handle_responses(
         return (
             StatusCode::TOO_MANY_REQUESTS,
             Json(serde_json::json!({
-                "error": {"message": "Quota exceeded", "type": "rate_limit_error"}
+                "error": {"message": quota_exceeded_message(key_record.quota_used, key_record.quota_limit), "type": "rate_limit_error"}
             })),
         )
             .into_response();
@@ -3487,7 +3499,7 @@ pub async fn handle_embeddings(
         return (
             StatusCode::TOO_MANY_REQUESTS,
             Json(serde_json::json!({
-                "error": {"message": "Quota exceeded", "type": "rate_limit_error"}
+                "error": {"message": quota_exceeded_message(key_record.quota_used, key_record.quota_limit), "type": "rate_limit_error"}
             })),
         )
             .into_response();
@@ -4086,7 +4098,7 @@ async fn list_models_impl(pool: SqlitePool, headers: &HeaderMap) -> Response {
             anthropic,
             StatusCode::TOO_MANY_REQUESTS,
             "rate_limit_error",
-            "Quota exceeded",
+            quota_exceeded_message(key.quota_used, key.quota_limit),
         );
     }
     let channels = match repo.get_enabled_channels().await {
@@ -4896,6 +4908,34 @@ mod list_models_tests {
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(json["error"]["type"], "rate_limit_error");
         assert_eq!(json["error"]["code"], "429");
+        // C-01：错误体携带 used/limit 数值，客户端可直接读取差额。
+        let msg = json["error"]["message"].as_str().unwrap();
+        assert!(msg.contains("Quota exceeded"), "message: {}", msg);
+        assert!(msg.contains("used "), "message: {}", msg);
+        assert!(msg.contains("limit 1000"), "message: {}", msg);
+    }
+
+    #[tokio::test]
+    async fn quota_exceeded_returns_429_anthropic_shape() {
+        let (pool, api_key) = seed_test_db().await;
+        Repository::new(pool.clone())
+            .increment_quota(&api_key.id, 2000)
+            .await
+            .unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert("x-api-key", api_key.key.parse().unwrap());
+        let resp = list_models_impl(pool, &headers).await;
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        // Anthropic 形态：{"type":"error","error":{...}}，message 同样携带数值。
+        assert_eq!(json["type"], "error");
+        assert_eq!(json["error"]["type"], "rate_limit_error");
+        let msg = json["error"]["message"].as_str().unwrap();
+        assert!(msg.contains("Quota exceeded"), "message: {}", msg);
+        assert!(msg.contains("limit 1000"), "message: {}", msg);
     }
 
     /// Insert an auth account directly via SQL (mirrors migration 019/021


### PR DESCRIPTION
Closes #83

## 开始原因

五端点 + `route_plan::authorize_request` 的配额拦截 v0.1.x 起就存在，本 PR 不引入拦截，只做四处硬化：429 错误体信息量、跨端点格式一致性、两轨记账口径、递增封顶。

## 方案

- 五端点 429 统一为**各自协议的既有错误构造器**，message 模板携带 `used X / limit Y`；不发明新错误结构；chat 端点不再是纯文本。
- `PlanError::QuotaExceeded` 携带 (used, limit)；429 与「Key 维度终态、不做渠道 failover」语义不变。
- legacy 轨递增条件改为「最终入账 total_tokens > 0」（含本地估算兜底），与新轨口径合一。
- `increment_quota` 加 `CASE WHEN` 封顶：limit > 0 时 `MIN(quota_used + ?, limit)`；`-1/0` 纯加法行为零变化。

## 已知行为声明

检查在请求前、递增在响应后，并发窗口内多请求可同时放行；封顶后越界幅度有界（本地单实例 + SQLite 单写者）。已在代码注释显式声明。

## 测试

五端点 429 协议形态断言；封顶三态；legacy 轨 mock 上游无 usage 估算入账集成测试；全量 `cargo test` 无新增失败。

开放点（见 issue）：quota_reset_period、Retry-After、chat 401 统一。