### PR TITLE
feat(observability): 数据面 X-Request-Id 标准化（兼容 Wali-Trace-Id）+ OTLP/HTTP JSON 导出器

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -59,6 +59,26 @@ pub struct Settings {
     pub ocr_concurrency: i32,
     #[serde(default = "default_ocr_dpi")]
     pub ocr_dpi: i32,
+    /// OTLP 导出开关（默认关）。关闭时后台导出循环零流量。
+    #[serde(default = "default_false")]
+    pub otlp_enabled: bool,
+    /// OTLP/HTTP JSON 端点（如 Langfuse 的 /api/public/otel/v1/traces）。
+    #[serde(default)]
+    pub otlp_endpoint: String,
+    /// OTLP 附加请求头，JSON 对象字符串（鉴权头从设置读取，不入源码）。
+    #[serde(default)]
+    pub otlp_headers: String,
+    #[serde(default = "default_otlp_interval_secs")]
+    pub otlp_interval_secs: u64,
+    #[serde(default = "default_otlp_batch_size")]
+    pub otlp_batch_size: u64,
+}
+
+fn default_otlp_interval_secs() -> u64 {
+    30
+}
+fn default_otlp_batch_size() -> u64 {
+    50
 }
 
 fn default_port() -> u16 {
@@ -135,6 +155,11 @@ impl Default for Settings {
             ocr_max_pages: default_ocr_max_pages(),
             ocr_concurrency: default_ocr_concurrency(),
             ocr_dpi: default_ocr_dpi(),
+            otlp_enabled: default_false(),
+            otlp_endpoint: String::new(),
+            otlp_headers: String::new(),
+            otlp_interval_secs: default_otlp_interval_secs(),
+            otlp_batch_size: default_otlp_batch_size(),
         }
     }
 }
@@ -218,6 +243,11 @@ pub async fn get_settings(state: tauri::State<'_, Arc<AppState>>) -> Result<Sett
         ocr_max_pages: get_u64(store, "ocr.max_pages", 200) as i32,
         ocr_concurrency: get_u64(store, "ocr.concurrency", 2) as i32,
         ocr_dpi: get_u64(store, "ocr.dpi", 200) as i32,
+        otlp_enabled: get_bool(store, "otlp.enabled", false),
+        otlp_endpoint: get_str(store, "otlp.endpoint", ""),
+        otlp_headers: get_str(store, "otlp.headers", ""),
+        otlp_interval_secs: get_u64(store, "otlp.export_interval_secs", 30),
+        otlp_batch_size: get_u64(store, "otlp.batch_size", 50),
     };
     Ok(settings)
 }
@@ -330,6 +360,26 @@ pub async fn save_settings(
             serde_json::json!(settings.ocr_concurrency),
         ),
         ("ocr.dpi".to_string(), serde_json::json!(settings.ocr_dpi)),
+        (
+            "otlp.enabled".to_string(),
+            serde_json::json!(settings.otlp_enabled),
+        ),
+        (
+            "otlp.endpoint".to_string(),
+            serde_json::json!(settings.otlp_endpoint),
+        ),
+        (
+            "otlp.headers".to_string(),
+            serde_json::json!(settings.otlp_headers),
+        ),
+        (
+            "otlp.export_interval_secs".to_string(),
+            serde_json::json!(settings.otlp_interval_secs),
+        ),
+        (
+            "otlp.batch_size".to_string(),
+            serde_json::json!(settings.otlp_batch_size),
+        ),
     ])?;
     crate::audit_log::apply_settings(&state.settings);
     // 缩短保留期后立即清理，避免等待后台维护周期。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ pub mod commands;
 pub mod core;
 pub mod db;
 mod endpoint_executor;
+mod otlp_exporter;
 mod protocol;
 #[cfg(test)]
 mod rollout_integration_tests;
@@ -238,6 +239,12 @@ pub fn run() {
 
                 crate::audit_log::apply_settings(&state.settings);
                 tauri::async_runtime::spawn(crate::audit_log::run_maintenance_loop(
+                    state.db.pool.clone(),
+                    state.settings.clone(),
+                ));
+
+                // OTLP 导出（默认关闭，开启后按 seq 游标增量导出 request_log）
+                tauri::async_runtime::spawn(crate::otlp_exporter::run_export_loop(
                     state.db.pool.clone(),
                     state.settings.clone(),
                 ));

--- a/src-tauri/src/otlp_exporter.rs
+++ b/src-tauri/src/otlp_exporter.rs
@@ -1,0 +1,508 @@
+//! OTLP/HTTP JSON 导出器：把 request_log 增量导出为 OTLP span。
+//!
+//! 设计取舍（对应 issue 叙事）：
+//! - **不引 opentelemetry SDK**——OTLP/HTTP JSON 是稳定的 protobuf-JSON 映射，
+//!   用既有 HTTP 客户端直发即可，避免为旁路功能引入全家桶依赖。
+//! - **seq 游标增量 + 断点续传**——游标持久化在设置存储，重启后从上次位置继续；
+//!   导出失败游标不推进（at-least-once 语义，接收端按 spanId 幂等去重，
+//!   spanId 由日志行 id 确定性派生）。
+//! - **纯旁路**——任何失败只记 tracing 并退避，绝不影响请求主链路。
+//! - 时间戳用 v0.3.0 的 `started_at`（无则回退 `created_at`）。
+
+use crate::settings_store::SettingsStore;
+use sqlx::{Row, SqlitePool};
+use std::time::Duration;
+
+const DEFAULT_INTERVAL_SECS: u64 = 30;
+const MAX_INTERVAL_SECS: u64 = 600;
+const DEFAULT_BATCH_SIZE: i64 = 50;
+const CURSOR_KEY: &str = "otlp.export_cursor";
+
+/// 导出循环读取的日志行（只取 span 映射需要的列，避免整行反序列化）。
+struct ExportLogRow {
+    seq: i64,
+    id: String,
+    trace_id: Option<String>,
+    started_at: Option<String>,
+    created_at: String,
+    model: String,
+    upstream_model: Option<String>,
+    prompt_tokens: i64,
+    completion_tokens: i64,
+    total_tokens: i64,
+    cached_tokens: i64,
+    duration_ms: i64,
+    status_code: i64,
+    is_stream: i64,
+    is_retry: i64,
+    channel_name: Option<String>,
+    api_key_name: Option<String>,
+}
+
+async fn fetch_rows_after(
+    pool: &SqlitePool,
+    after_seq: i64,
+    limit: i64,
+) -> sqlx::Result<Vec<ExportLogRow>> {
+    let rows = sqlx::query(
+        "SELECT seq, id, trace_id, started_at, created_at, model, upstream_model, \
+         prompt_tokens, completion_tokens, total_tokens, cached_tokens, duration_ms, \
+         status_code, is_stream, is_retry, channel_name, api_key_name \
+         FROM request_logs WHERE seq > ? ORDER BY seq ASC LIMIT ?",
+    )
+    .bind(after_seq)
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(|r| ExportLogRow {
+            seq: r.get("seq"),
+            id: r.get("id"),
+            trace_id: r.get("trace_id"),
+            started_at: r.get("started_at"),
+            created_at: r.get("created_at"),
+            model: r.get("model"),
+            upstream_model: r.get("upstream_model"),
+            prompt_tokens: r.get("prompt_tokens"),
+            completion_tokens: r.get("completion_tokens"),
+            total_tokens: r.get("total_tokens"),
+            cached_tokens: r.get("cached_tokens"),
+            duration_ms: r.get("duration_ms"),
+            status_code: r.get("status_code"),
+            is_stream: r.get("is_stream"),
+            is_retry: r.get("is_retry"),
+            channel_name: r.get("channel_name"),
+            api_key_name: r.get("api_key_name"),
+        })
+        .collect())
+}
+
+fn attribute(key: &str, string_value: &str) -> serde_json::Value {
+    serde_json::json!({"key": key, "value": {"stringValue": string_value}})
+}
+
+fn attribute_int(key: &str, value: i64) -> serde_json::Value {
+    attribute(key, &value.to_string())
+}
+
+/// traceId 派生：trace_id 是 UUID 则去连字符取 32 hex；
+/// 否则（遗留空值）用日志行 id 同法派生——两条路径都是确定性的，
+/// 重试重发时 traceId/spanId 稳定，接收端可幂等去重。
+fn trace_id_hex(row: &ExportLogRow) -> String {
+    let source = row.trace_id.as_deref().unwrap_or(&row.id);
+    let hex: String = source.chars().filter(|c| *c != '-').collect();
+    if hex.len() == 32 && hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        hex.to_lowercase()
+    } else {
+        // 非 UUID 形态：按字符折叠为 32 位 hex（确定性兜底，不追求密码学性质）
+        let mut out = String::with_capacity(32);
+        for (i, b) in source.bytes().enumerate() {
+            if out.len() >= 32 {
+                break;
+            }
+            out.push_str(&format!("{:02x}", b.wrapping_add(i as u8)));
+        }
+        while out.len() < 32 {
+            out.push('0');
+        }
+        out
+    }
+}
+
+fn span_id_hex(row: &ExportLogRow) -> String {
+    trace_id_hex(row).split_at(16).0.to_string()
+}
+
+fn unix_nanos(timestamp: &str) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc3339(timestamp)
+        .ok()?
+        .timestamp_nanos_opt()
+}
+
+/// 单行日志 → OTLP span JSON（纯函数，单测覆盖）。
+fn span_from_row(row: &ExportLogRow) -> serde_json::Value {
+    let start_ts = row
+        .started_at
+        .as_deref()
+        .and_then(unix_nanos)
+        .or_else(|| unix_nanos(&row.created_at));
+    let (start, end) = match start_ts {
+        Some(s) => (s, s + row.duration_ms * 1_000_000),
+        // 落库时间不可解析时仍要导出（时间戳缺省 0，属性里有原始字段兜底）
+        None => (0, row.duration_ms * 1_000_000),
+    };
+    let mut attributes = vec![
+        attribute("model", &row.model),
+        attribute(
+            "upstream_model",
+            row.upstream_model.as_deref().unwrap_or(""),
+        ),
+        attribute_int("prompt_tokens", row.prompt_tokens),
+        attribute_int("completion_tokens", row.completion_tokens),
+        attribute_int("total_tokens", row.total_tokens),
+        attribute_int("cached_tokens", row.cached_tokens),
+        attribute_int("duration_ms", row.duration_ms),
+        attribute_int("status_code", row.status_code),
+        attribute_int("is_stream", row.is_stream),
+        attribute_int("is_retry", row.is_retry),
+        attribute("channel", row.channel_name.as_deref().unwrap_or("")),
+        attribute("api_key", row.api_key_name.as_deref().unwrap_or("")),
+    ];
+    if let Some(started) = row.started_at.as_deref() {
+        attributes.push(attribute("started_at", started));
+    }
+    serde_json::json!({
+        "traceId": trace_id_hex(row),
+        "spanId": span_id_hex(row),
+        "name": format!("waliapi {}", row.model),
+        "kind": 2, // SERVER
+        "startTimeUnixNano": start.to_string(),
+        "endTimeUnixNano": end.to_string(),
+        "attributes": attributes,
+        "status": {"code": if row.status_code >= 400 { 2 } else { 1 }},
+    })
+}
+
+fn export_payload(rows: &[ExportLogRow]) -> serde_json::Value {
+    serde_json::json!({
+        "resourceSpans": [{
+            "resource": {
+                "attributes": [attribute("service.name", "waliapi")]
+            },
+            "scopeSpans": [{
+                "scope": {"name": "waliapi.otlp-exporter", "version": "1"},
+                "spans": rows.iter().map(span_from_row).collect::<Vec<_>>(),
+            }]
+        }]
+    })
+}
+
+fn parse_headers(raw: &str) -> Vec<(String, String)> {
+    serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(raw)
+        .map(|map| {
+            map.into_iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// 单步导出：读游标 → 拉一批 → POST → 成功才推进游标。
+/// 测试与循环共用；失败返回 Err 且游标不动。
+pub async fn export_once(
+    pool: &SqlitePool,
+    settings: &SettingsStore,
+    client: &reqwest::Client,
+) -> Result<u64, String> {
+    let endpoint = settings.get_str("otlp.endpoint", "");
+    if endpoint.trim().is_empty() {
+        return Err("otlp.endpoint 未配置".to_string());
+    }
+    let batch_size = settings.get_u64("otlp.batch_size", DEFAULT_BATCH_SIZE as u64) as i64;
+    let cursor = settings.get_u64(CURSOR_KEY, 0) as i64;
+    let rows = fetch_rows_after(pool, cursor, batch_size.max(1))
+        .await
+        .map_err(|e| format!("读取待导出行失败: {e}"))?;
+    if rows.is_empty() {
+        return Ok(0);
+    }
+    let payload = export_payload(&rows);
+    let mut request = client
+        .post(&endpoint)
+        .header("content-type", "application/json")
+        .json(&payload);
+    for (name, value) in parse_headers(&settings.get_str("otlp.headers", "")) {
+        request = request.header(&name, &value);
+    }
+    let response = request
+        .send()
+        .await
+        .map_err(|e| format!("OTLP 导出请求失败: {e}"))?;
+    if !response.status().is_success() {
+        return Err(format!("OTLP 端点返回 {}", response.status()));
+    }
+    let max_seq = rows.last().map(|r| r.seq).unwrap_or(cursor);
+    settings
+        .set_many(&[(CURSOR_KEY.to_string(), serde_json::json!(max_seq))])
+        .map_err(|e| format!("游标持久化失败: {e}"))?;
+    Ok(rows.len() as u64)
+}
+
+/// 后台导出循环：关闭时零流量；失败按连续失败次数指数退避（封顶 10 分钟）。
+pub async fn run_export_loop(pool: SqlitePool, settings: SettingsStore) {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .unwrap_or_default();
+    let base_interval = Duration::from_secs(
+        settings
+            .get_u64("otlp.export_interval_secs", DEFAULT_INTERVAL_SECS)
+            .max(5),
+    );
+    let mut consecutive_failures: u32 = 0;
+    loop {
+        let enabled = settings.get_bool("otlp.enabled", false);
+        if enabled {
+            match export_once(&pool, &settings, &client).await {
+                Ok(n) => {
+                    if n > 0 {
+                        tracing::info!("[OTLP] 导出 {n} 条 request_log span");
+                    }
+                    consecutive_failures = 0;
+                }
+                Err(e) => {
+                    // 纯旁路：只记日志并退避，绝不影响请求主链路
+                    consecutive_failures = consecutive_failures.saturating_add(1);
+                    tracing::warn!(
+                        "[OTLP] 导出失败（第 {consecutive_failures} 次，退避重试）: {e}"
+                    );
+                }
+            }
+        }
+        let backoff_secs = if consecutive_failures == 0 {
+            base_interval.as_secs()
+        } else {
+            (base_interval
+                .as_secs()
+                .saturating_mul(1u64 << consecutive_failures.min(6)))
+            .min(MAX_INTERVAL_SECS)
+        };
+        tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::routing::post;
+    use axum::Router;
+    use sqlx::Row;
+    use std::sync::{Arc, Mutex};
+    use tower::ServiceExt;
+
+    async fn memory_pool() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    fn test_row(seq_offset: i64) -> (i64, serde_json::Value) {
+        // 返回 (期望 seq, 插入用的 JSON 全字段)
+        let id = uuid::Uuid::new_v4().to_string();
+        let trace = uuid::Uuid::new_v4().to_string();
+        (
+            seq_offset,
+            serde_json::json!({
+                "id": id, "seq": seq_offset, "trace_id": trace,
+                "started_at": "2026-09-09T08:00:00+00:00",
+                "created_at": "2026-09-09T08:00:01+00:00",
+                "model": "gpt-test", "upstream_model": "gpt-up",
+                "prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15,
+                "cached_tokens": 2, "duration_ms": 1200, "status_code": 200,
+                "is_stream": 1, "is_retry": 0,
+                "channel_name": "ch-a", "api_key_name": "key-b",
+            }),
+        )
+    }
+
+    async fn insert_row(pool: &SqlitePool, seq: i64, fields: &serde_json::Value) {
+        sqlx::query(
+            "INSERT INTO request_logs (id, seq, model, mode, status_code, prompt_tokens, \
+             completion_tokens, total_tokens, cached_tokens, duration_ms, is_stream, is_retry, \
+             created_at, risk_level, security_action, upstream_type, trace_id, started_at, \
+             upstream_model, channel_name, api_key_name) \
+             VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        )
+        .bind(fields["id"].as_str().unwrap())
+        .bind(seq)
+        .bind(fields["model"].as_str().unwrap())
+        .bind("chat")
+        .bind(fields["status_code"].as_i64().unwrap())
+        .bind(fields["prompt_tokens"].as_i64().unwrap())
+        .bind(fields["completion_tokens"].as_i64().unwrap())
+        .bind(fields["total_tokens"].as_i64().unwrap())
+        .bind(fields["cached_tokens"].as_i64().unwrap())
+        .bind(fields["duration_ms"].as_i64().unwrap())
+        .bind(fields["is_stream"].as_i64().unwrap())
+        .bind(fields["is_retry"].as_i64().unwrap())
+        .bind(fields["created_at"].as_str().unwrap())
+        .bind("low")
+        .bind("audit")
+        .bind("channel")
+        .bind(fields["trace_id"].as_str())
+        .bind(fields["started_at"].as_str())
+        .bind(fields["upstream_model"].as_str())
+        .bind(fields["channel_name"].as_str())
+        .bind(fields["api_key_name"].as_str())
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn span_mapping_carries_all_attributes_and_deterministic_ids() {
+        let pool = memory_pool().await;
+        let (_, fields) = test_row(1);
+        insert_row(&pool, 1, &fields).await;
+        let rows = fetch_rows_after(&pool, 0, 10).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        let span = span_from_row(&rows[0]);
+
+        // traceId/spanId 确定性派生自 UUID（去连字符）
+        let expected_trace = fields["trace_id"].as_str().unwrap().replace('-', "");
+        assert_eq!(span["traceId"], serde_json::json!(expected_trace));
+        assert_eq!(span["spanId"], serde_json::json!(expected_trace[..16]));
+
+        assert_eq!(span["kind"], serde_json::json!(2));
+        // started_at(08:00:00) + 1200ms
+        let start: i64 = span["startTimeUnixNano"].as_str().unwrap().parse().unwrap();
+        let end: i64 = span["endTimeUnixNano"].as_str().unwrap().parse().unwrap();
+        assert_eq!(end - start, 1_200_000_000);
+        assert_eq!(span["status"]["code"], serde_json::json!(1));
+
+        let attrs = span["attributes"].as_array().unwrap();
+        let get = |k: &str| {
+            attrs
+                .iter()
+                .find(|a| a["key"] == k)
+                .map(|a| a["value"]["stringValue"].as_str().unwrap().to_string())
+                .unwrap()
+        };
+        assert_eq!(get("model"), "gpt-test");
+        assert_eq!(get("upstream_model"), "gpt-up");
+        assert_eq!(get("total_tokens"), "15");
+        assert_eq!(get("cached_tokens"), "2");
+        assert_eq!(get("channel"), "ch-a");
+        assert_eq!(get("api_key"), "key-b");
+        assert_eq!(get("status_code"), "200");
+    }
+
+    #[tokio::test]
+    async fn error_status_maps_to_error_code() {
+        let pool = memory_pool().await;
+        let (seq, mut fields) = test_row(1);
+        fields["status_code"] = serde_json::json!(502);
+        insert_row(&pool, seq, &fields).await;
+        let rows = fetch_rows_after(&pool, 0, 10).await.unwrap();
+        assert_eq!(
+            span_from_row(&rows[0])["status"]["code"],
+            serde_json::json!(2)
+        );
+    }
+
+    /// 极简 mock OTLP 接收端：捕获请求体。
+    async fn mock_otlp_endpoint() -> (String, Arc<Mutex<Vec<serde_json::Value>>>) {
+        let captured: Arc<Mutex<Vec<serde_json::Value>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = captured.clone();
+        let app = Router::new().route(
+            "/v1/traces",
+            post(move |body: String| {
+                let sink = sink.clone();
+                async move {
+                    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&body) {
+                        sink.lock().unwrap().push(value);
+                    }
+                    axum::http::StatusCode::OK
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{addr}/v1/traces"), captured)
+    }
+
+    fn test_settings(dir: &std::path::Path, endpoint: &str) -> SettingsStore {
+        let store = SettingsStore::file(dir.join("settings.json"));
+        store
+            .set_many(&[
+                ("otlp.endpoint".to_string(), serde_json::json!(endpoint)),
+                (
+                    "otlp.headers".to_string(),
+                    serde_json::json!({"Authorization": "test-only-token"}),
+                ),
+            ])
+            .unwrap();
+        store
+    }
+
+    #[tokio::test]
+    async fn export_once_sends_spans_and_advances_cursor() {
+        let pool = memory_pool().await;
+        let (endpoint, captured) = mock_otlp_endpoint().await;
+        let dir = std::env::temp_dir().join(format!("waliapi-otlp-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let settings = test_settings(&dir, &endpoint);
+
+        let (seq, fields) = test_row(1);
+        insert_row(&pool, seq, &fields).await;
+
+        let client = reqwest::Client::new();
+        let exported = export_once(&pool, &settings, &client).await.unwrap();
+        assert_eq!(exported, 1);
+        assert_eq!(settings.get_u64(CURSOR_KEY, 0), 1, "游标应推进到已导出 seq");
+
+        let bodies = captured.lock().unwrap();
+        assert_eq!(bodies.len(), 1, "应恰好 POST 一次");
+        let spans = bodies[0]["resourceSpans"][0]["scopeSpans"][0]["spans"]
+            .as_array()
+            .unwrap();
+        assert_eq!(spans.len(), 1);
+        assert_eq!(
+            spans[0]["traceId"],
+            serde_json::json!(fields["trace_id"].as_str().unwrap().replace('-', ""))
+        );
+
+        // 无新行：零发送、零错误
+        drop(bodies);
+        assert_eq!(export_once(&pool, &settings, &client).await.unwrap(), 0);
+        assert_eq!(captured.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn export_failure_keeps_cursor_for_retry() {
+        let pool = memory_pool().await;
+        // 端口占一个不存在的地址模拟不可达
+        let dir = std::env::temp_dir().join(format!("waliapi-otlp-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let settings = test_settings(&dir, "http://127.0.0.1:9/v1/traces");
+
+        let (seq, fields) = test_row(1);
+        insert_row(&pool, seq, &fields).await;
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(500))
+            .build()
+            .unwrap();
+        let result = export_once(&pool, &settings, &client).await;
+        assert!(result.is_err(), "端点不可达应报错");
+        assert_eq!(settings.get_u64(CURSOR_KEY, 0), 0, "失败时游标不得推进");
+    }
+
+    #[tokio::test]
+    async fn legacy_row_without_trace_derives_stable_ids() {
+        let pool = memory_pool().await;
+        let (_, mut fields) = test_row(1);
+        fields["trace_id"] = serde_json::Value::Null;
+        insert_row(&pool, 1, &fields).await;
+        let rows = fetch_rows_after(&pool, 0, 10).await.unwrap();
+        let span = span_from_row(&rows[0]);
+        let derived = span["traceId"].as_str().unwrap().to_string();
+        assert_eq!(derived.len(), 32);
+        // 确定性：同一行再派生一次结果一致
+        assert_eq!(
+            span_from_row(&rows[0])["traceId"].as_str().unwrap(),
+            derived
+        );
+    }
+
+    #[test]
+    fn parse_headers_ignores_invalid_json() {
+        assert!(parse_headers("not json").is_empty());
+        let headers = parse_headers(r#"{"A": "b", "N": 1}"#);
+        assert_eq!(headers, vec![("A".to_string(), "b".to_string())]);
+    }
+}

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -513,11 +513,10 @@ pub async fn handle_chat_completions(
         return (StatusCode::TOO_MANY_REQUESTS, "Quota exceeded").into_response();
     }
 
-    // Extract Wali-Trace-Id from request headers
-    let trace_id = headers
-        .get("Wali-Trace-Id")
-        .and_then(|h| h.to_str().ok())
-        .map(|s| s.to_string());
+    // 请求关联键：X-Request-Id（兼容 Wali-Trace-Id，缺省生成 UUIDv4）。
+    // 中间件已统一解析并回写请求头，此处调用同一 resolve 保证取到同一值；
+    // 直调（测试/内部路径）时无中间件，resolve 自行解析兜底。
+    let trace_id = Some(crate::server::request_id::resolve(&headers));
 
     // Unified security audit gate — audits the ORIGINAL protocol JSON full
     // tree before any routing/codec.  Fail-closed (Confirm/budget) returns
@@ -1383,6 +1382,8 @@ struct StreamLogContext {
     /// FIX-16：请求准入时的安全设置快照——响应侧扫描沿用同一口径。
     security_settings: security::SecuritySettings,
     is_stream: bool,
+    /// 请求关联键（X-Request-Id），随落账行写 trace_id。
+    trace_id: Option<String>,
 }
 
 const MAX_NATIVE_SSE_RECORD_BYTES: usize = 64 * 1024;
@@ -1402,6 +1403,8 @@ struct NativeStreamFinalizer {
     /// FIX-16：与转发循环共享的响应扫描累积器——断开/中断行扫半程内容。
     scan_buffer: std::sync::Arc<std::sync::Mutex<ResponseScanBuffer>>,
     is_stream: bool,
+    /// 请求关联键（X-Request-Id），随 499/502 落账行写 trace_id。
+    trace_id: Option<String>,
     done: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
@@ -1421,6 +1424,7 @@ impl NativeStreamFinalizer {
             security_settings: ctx.security_settings.clone(),
             scan_buffer,
             is_stream: ctx.is_stream,
+            trace_id: ctx.trace_id.clone(),
             done: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
@@ -1458,6 +1462,7 @@ impl NativeStreamFinalizer {
             502,
             Some("native upstream stream interrupted".to_string()),
             usage,
+            self.trace_id.clone(),
         )
         .await;
     }
@@ -1486,6 +1491,7 @@ impl Drop for NativeStreamFinalizer {
                 let security = self.merged_security();
                 let is_stream = self.is_stream;
                 let usage = self.estimated_usage();
+                let trace_id = self.trace_id.clone();
                 handle.spawn(async move {
                     record_anthropic_outcome(
                         repo,
@@ -1499,6 +1505,7 @@ impl Drop for NativeStreamFinalizer {
                         499,
                         Some("client_cancelled".to_string()),
                         usage,
+                        trace_id,
                     )
                     .await;
                 });
@@ -1753,7 +1760,7 @@ fn native_response(response: reqwest::Response, accounting: Option<StreamLogCont
                     non_sse_observed.clone()
                 };
                 scan_bytes_into(&mut merged_security, &scan_bytes, &context.security_settings);
-                record_anthropic_success(context.repo, &context.key, &context.channel, &context.model, context.upstream_model.clone(), &context.request, &merged_security, context.is_stream, usage).await;
+                record_anthropic_success(context.repo, &context.key, &context.channel, &context.model, context.upstream_model.clone(), &context.request, &merged_security, context.is_stream, usage, context.trace_id.clone()).await;
             } else if let Some(f) = finalizer.as_ref() {
                 // 上游中断：502 行 + 已解析的部分用量（估算兜底同取消路径）。
                 let partial = {
@@ -1923,6 +1930,7 @@ async fn record_anthropic_outcome(
     status_code: i64,
     error_message: Option<String>,
     usage: Option<(i64, i64, i64)>,
+    trace_id: Option<String>,
 ) {
     let (prompt_tokens, completion_tokens, cached_tokens) = usage.unwrap_or((0, 0, 0));
     let mut total_tokens = prompt_tokens + completion_tokens;
@@ -1976,7 +1984,7 @@ async fn record_anthropic_outcome(
         security_action: security_result.action.as_str().to_string(),
         sanitized: i64::from(log_sanitized || security_result.sanitized),
         blocked_reason: security_result.blocked_reason.clone(),
-        trace_id: None,
+        trace_id,
         // T09: native/OpenAI-compat Messages path.  downstream is the Messages
         // endpoint; the other observability fields (route_group / upstream
         // protocol/endpoint / codec / failure class) are populated by the
@@ -2016,6 +2024,7 @@ async fn record_anthropic_success(
     security_result: &security::SecurityScanResult,
     is_stream: bool,
     usage: Option<(i64, i64, i64)>,
+    trace_id: Option<String>,
 ) {
     record_anthropic_outcome(
         repo,
@@ -2029,6 +2038,7 @@ async fn record_anthropic_success(
         200,
         None,
         usage,
+        trace_id,
     )
     .await;
 }
@@ -2111,12 +2121,14 @@ pub async fn handle_messages(
     // full tree before any routing/codec.  The raw query string is audited as
     // part of the envelope so the native executor can forward it safely.
     let query = uri.query().map(|s| s.to_string());
+    // 请求关联键：X-Request-Id（兼容 Wali-Trace-Id，缺省生成 UUIDv4）。
+    let trace_id = Some(crate::server::request_id::resolve(&headers));
     let audited = match audit_original(
         security::gate::DownstreamProtocol::Messages,
         "/v1/messages",
         json.clone(),
         query.clone(),
-        None,
+        trace_id.clone(),
         &shared,
     )
     .await
@@ -2140,6 +2152,7 @@ pub async fn handle_messages(
             451,
             security_result.blocked_reason.clone(),
             None,
+            trace_id.clone(),
         )
         .await;
         return anthropic_error(
@@ -2162,7 +2175,7 @@ pub async fn handle_messages(
         "anthropic",
         &safe_headers,
         &sanitized_log_body,
-        None,
+        trace_id.clone(),
     )
     .await
     {
@@ -2227,6 +2240,7 @@ pub async fn handle_messages(
                             security: security_result.clone(),
                             security_settings: audited.security_settings.clone(),
                             is_stream: stream,
+                            trace_id: trace_id.clone(),
                         }),
                     )
                 }
@@ -2257,6 +2271,7 @@ pub async fn handle_messages(
                                 status.as_u16() as i64,
                                 Some(format!("Native upstream returned HTTP {status}")),
                                 None,
+                                trace_id.clone(),
                             )
                             .await;
                             // An upstream 401/403 is a channel-credential
@@ -2291,6 +2306,7 @@ pub async fn handle_messages(
                         502,
                         Some(last_error.clone()),
                         None,
+                        trace_id.clone(),
                     )
                     .await;
                 }
@@ -2327,6 +2343,7 @@ pub async fn handle_messages(
                         security: security_result.clone(),
                         security_settings: audited.security_settings.clone(),
                         is_stream: true,
+                        trace_id: trace_id.clone(),
                     },
                 )
             }
@@ -2372,6 +2389,7 @@ pub async fn handle_messages(
                             &merged_security,
                             false,
                             usage,
+                            trace_id.clone(),
                         )
                         .await;
                         (StatusCode::OK, Json(value)).into_response()
@@ -2399,6 +2417,7 @@ pub async fn handle_messages(
                             502,
                             Some(message),
                             None,
+                            trace_id.clone(),
                         )
                         .await;
                         upstream_attempts = upstream_attempts.saturating_sub(1);
@@ -2437,6 +2456,7 @@ pub async fn handle_messages(
                             status.as_u16() as i64,
                             Some(last_error.clone()),
                             None,
+                            trace_id.clone(),
                         )
                         .await;
                         // openai_error_response already maps an upstream
@@ -2459,6 +2479,7 @@ pub async fn handle_messages(
                     502,
                     Some(last_error.clone()),
                     None,
+                    trace_id.clone(),
                 )
                 .await;
             }
@@ -2483,6 +2504,7 @@ pub async fn handle_messages(
             400,
             Some(last_error.clone()),
             None,
+            trace_id.clone(),
         )
         .await;
         return anthropic_error(StatusCode::BAD_REQUEST, "invalid_request_error", last_error);
@@ -2499,6 +2521,7 @@ pub async fn handle_messages(
         502,
         Some(last_error.clone()),
         None,
+        trace_id.clone(),
     )
     .await;
     anthropic_error(
@@ -2535,7 +2558,7 @@ fn openai_sse_response(
                         failed = true;
                         let mut merged = accounting.security.clone();
                         scan_bytes_into(&mut merged, &scan_buffer.buf, &accounting.security_settings);
-                        record_anthropic_outcome(accounting.repo.clone(), &accounting.key, Some(&accounting.channel), &accounting.model, None, &accounting.request, &merged, true, 502, Some(format!("OpenAI stream conversion failed: {message}")), None).await;
+                        record_anthropic_outcome(accounting.repo.clone(), &accounting.key, Some(&accounting.channel), &accounting.model, None, &accounting.request, &merged, true, 502, Some(format!("OpenAI stream conversion failed: {message}")), None, accounting.trace_id.clone()).await;
                         yield Ok::<_, std::io::Error>(bytes::Bytes::from(format!("event: error\ndata: {{\"type\":\"error\",\"error\":{{\"type\":\"api_error\",\"message\":{}}}}}\n\n", serde_json::to_string(&message).unwrap()).into_bytes()));
                         break;
                     }
@@ -2546,7 +2569,7 @@ fn openai_sse_response(
                     let message = format!("OpenAI stream interrupted: {error}");
                     let mut merged = accounting.security.clone();
                     scan_bytes_into(&mut merged, &scan_buffer.buf, &accounting.security_settings);
-                    record_anthropic_outcome(accounting.repo.clone(), &accounting.key, Some(&accounting.channel), &accounting.model, None, &accounting.request, &merged, true, 502, Some(message.clone()), None).await;
+                    record_anthropic_outcome(accounting.repo.clone(), &accounting.key, Some(&accounting.channel), &accounting.model, None, &accounting.request, &merged, true, 502, Some(message.clone()), None, accounting.trace_id.clone()).await;
                     yield Ok::<_, std::io::Error>(bytes::Bytes::from(format!("event: error\ndata: {{\"type\":\"error\",\"error\":{{\"type\":\"api_error\",\"message\":{}}}}}\n\n", serde_json::to_string(&message).unwrap()).into_bytes()));
                     break;
                 }
@@ -2559,12 +2582,12 @@ fn openai_sse_response(
                     let usage = state.usage();
                     let mut merged = accounting.security.clone();
                     scan_bytes_into(&mut merged, &scan_buffer.buf, &accounting.security_settings);
-                    record_anthropic_success(accounting.repo, &accounting.key, &accounting.channel, &accounting.model, None, &accounting.request, &merged, true, Some(usage)).await;
+                    record_anthropic_success(accounting.repo, &accounting.key, &accounting.channel, &accounting.model, None, &accounting.request, &merged, true, Some(usage), accounting.trace_id.clone()).await;
                 },
                 Err(message) => {
                     let mut merged = accounting.security.clone();
                     scan_bytes_into(&mut merged, &scan_buffer.buf, &accounting.security_settings);
-                    record_anthropic_outcome(accounting.repo.clone(), &accounting.key, Some(&accounting.channel), &accounting.model, None, &accounting.request, &merged, true, 502, Some(format!("OpenAI stream conversion failed: {message}")), None).await;
+                    record_anthropic_outcome(accounting.repo.clone(), &accounting.key, Some(&accounting.channel), &accounting.model, None, &accounting.request, &merged, true, 502, Some(format!("OpenAI stream conversion failed: {message}")), None, accounting.trace_id.clone()).await;
                     yield Ok::<_, std::io::Error>(bytes::Bytes::from(format!("event: error\ndata: {{\"type\":\"error\",\"error\":{{\"type\":\"api_error\",\"message\":{}}}}}\n\n", serde_json::to_string(&message).unwrap()).into_bytes()))
                 },
             }
@@ -2637,12 +2660,13 @@ pub async fn handle_messages_count_tokens(
     };
     // Unified security audit gate — audits the ORIGINAL Count Tokens JSON.
     let query = uri.query().map(|s| s.to_string());
+    let trace_id = Some(crate::server::request_id::resolve(&headers));
     let audited = match audit_original(
         security::gate::DownstreamProtocol::CountTokens,
         "/v1/messages/count_tokens",
         json.clone(),
         query.clone(),
-        None,
+        trace_id.clone(),
         &shared,
     )
     .await
@@ -2673,7 +2697,7 @@ pub async fn handle_messages_count_tokens(
         "anthropic_count_tokens",
         &safe_headers,
         &sanitized_log_body,
-        None,
+        trace_id.clone(),
     )
     .await
     {
@@ -2813,10 +2837,7 @@ pub async fn handle_responses(
             .into_response();
     }
 
-    let trace_id = headers
-        .get("Wali-Trace-Id")
-        .and_then(|h| h.to_str().ok())
-        .map(|s| s.to_string());
+    let trace_id = Some(crate::server::request_id::resolve(&headers));
     // Unified security audit gate — audits the ORIGINAL Responses protocol
     // JSON full tree (built-in tools, image URLs, files, unknown blocks)
     // before any Responses→Chat conversion.
@@ -3498,10 +3519,7 @@ pub async fn handle_embeddings(
         .and_then(|m| m.as_str())
         .unwrap_or("")
         .to_string();
-    let trace_id = headers
-        .get("Wali-Trace-Id")
-        .and_then(|h| h.to_str().ok())
-        .map(|s| s.to_string());
+    let trace_id = Some(crate::server::request_id::resolve(&headers));
     // Unified security audit gate — audits the ORIGINAL Embeddings JSON.
     let audited = match audit_original(
         security::gate::DownstreamProtocol::Embeddings,

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -3,6 +3,7 @@ pub mod admin_auth;
 pub mod admin_routes;
 pub mod event_bridge;
 pub mod handlers;
+pub mod request_id;
 pub mod router;
 pub mod static_assets;
 

--- a/src-tauri/src/server/request_id.rs
+++ b/src-tauri/src/server/request_id.rs
@@ -80,7 +80,10 @@ mod tests {
         assert_eq!(sanitize(""), None);
         assert_eq!(sanitize("   "), None);
         assert_eq!(sanitize(&"a".repeat(129)), None);
-        assert_eq!(sanitize(&"a".repeat(128)).as_deref(), Some("a".repeat(128).as_str()));
+        assert_eq!(
+            sanitize(&"a".repeat(128)).as_deref(),
+            Some("a".repeat(128).as_str())
+        );
     }
 
     #[test]
@@ -105,7 +108,10 @@ mod tests {
     #[test]
     fn resolve_generates_uuid_when_absent() {
         let id = resolve(&headers(&[]));
-        assert!(uuid::Uuid::parse_str(&id).is_ok(), "应生成合法 UUIDv4：{id}");
+        assert!(
+            uuid::Uuid::parse_str(&id).is_ok(),
+            "应生成合法 UUIDv4：{id}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/server/request_id.rs
+++ b/src-tauri/src/server/request_id.rs
@@ -1,0 +1,119 @@
+//! 数据面请求关联键：X-Request-Id 标准化。
+//!
+//! 上游此前仅有自定义 `Wali-Trace-Id` 头（仅部分端点读取、缺省不生成、不回显）。
+//! 本模块统一为：标准 `X-Request-Id` 优先（`Wali-Trace-Id` 继续兼容），缺省生成
+//! UUIDv4，响应头回显，值随既有 `request_logs.trace_id` 列落库。
+//!
+//! 中间件 resolve 后把结果**回写请求头**，handler 侧调用同一 `resolve` 读到的
+//! 即同一值——两级解析天然一致，不依赖请求扩展传递。
+
+use axum::extract::Request;
+use axum::http::{HeaderMap, HeaderValue};
+use axum::middleware::Next;
+use axum::response::Response;
+
+/// 关联键长度上限（对齐 nginx `X-Request-Id` 的 128 惯例）。
+const MAX_REQUEST_ID_LEN: usize = 128;
+
+/// 校验候选值：非空、长度受限、全部为 ASCII 可见字符（0x21..=0x7E）。
+/// 拒绝空格与控制字符可防止头注入/折行注入；拒绝非 ASCII 避免编码歧义。
+/// 非法值视为「未携带」，由上层生成新 UUID。
+pub fn sanitize(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed.len() > MAX_REQUEST_ID_LEN {
+        return None;
+    }
+    if !trimmed.bytes().all(|b| (0x21..=0x7E).contains(&b)) {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+/// 解析请求关联键：`X-Request-Id` 优先 → `Wali-Trace-Id` 兼容回退 → 生成 UUIDv4。
+pub fn resolve(headers: &HeaderMap) -> String {
+    for name in ["x-request-id", "wali-trace-id"] {
+        if let Some(value) = headers.get(name).and_then(|h| h.to_str().ok()) {
+            if let Some(valid) = sanitize(value) {
+                return valid;
+            }
+        }
+    }
+    uuid::Uuid::new_v4().to_string()
+}
+
+/// 数据面中间件：统一解析关联键 → 回写请求头（供 handler 与日志读取）→ 响应头回显。
+pub async fn middleware(mut req: Request, next: Next) -> Response {
+    let id = resolve(req.headers());
+    if let Ok(value) = HeaderValue::from_str(&id) {
+        req.headers_mut().insert("x-request-id", value.clone());
+        let mut response = next.run(req).await;
+        response.headers_mut().insert("x-request-id", value);
+        return response;
+    }
+    // sanitize 产出的值必为合法 HeaderValue，此分支仅为防御性兜底。
+    next.run(req).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderName;
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (name, value) in pairs {
+            map.insert(
+                HeaderName::from_bytes(name.as_bytes()).unwrap(),
+                HeaderValue::from_str(value).unwrap(),
+            );
+        }
+        map
+    }
+
+    #[test]
+    fn sanitize_accepts_plain_ascii() {
+        assert_eq!(sanitize("abc-123_XYZ.09"), Some("abc-123_XYZ.09".into()));
+    }
+
+    #[test]
+    fn sanitize_rejects_empty_and_oversize() {
+        assert_eq!(sanitize(""), None);
+        assert_eq!(sanitize("   "), None);
+        assert_eq!(sanitize(&"a".repeat(129)), None);
+        assert_eq!(sanitize(&"a".repeat(128)).as_deref(), Some("a".repeat(128).as_str()));
+    }
+
+    #[test]
+    fn sanitize_rejects_space_control_and_non_ascii() {
+        assert_eq!(sanitize("abc def"), None);
+        assert_eq!(sanitize("abc\tdef"), None);
+        assert_eq!(sanitize("请求id"), None);
+    }
+
+    #[test]
+    fn resolve_prefers_x_request_id_over_wali_trace_id() {
+        let map = headers(&[("x-request-id", "std-1"), ("wali-trace-id", "legacy-1")]);
+        assert_eq!(resolve(&map), "std-1");
+    }
+
+    #[test]
+    fn resolve_falls_back_to_wali_trace_id() {
+        let map = headers(&[("wali-trace-id", "legacy-2")]);
+        assert_eq!(resolve(&map), "legacy-2");
+    }
+
+    #[test]
+    fn resolve_generates_uuid_when_absent() {
+        let id = resolve(&headers(&[]));
+        assert!(uuid::Uuid::parse_str(&id).is_ok(), "应生成合法 UUIDv4：{id}");
+    }
+
+    #[test]
+    fn resolve_treats_invalid_value_as_absent() {
+        // 非法 X-Request-Id 不透传，回退兼容头；都非法则生成新值
+        let map = headers(&[("x-request-id", "bad value"), ("wali-trace-id", "ok-1")]);
+        assert_eq!(resolve(&map), "ok-1");
+        let map = headers(&[("x-request-id", &"x".repeat(200))]);
+        assert!(uuid::Uuid::parse_str(&resolve(&map)).is_ok());
+    }
+}

--- a/src-tauri/src/server/router.rs
+++ b/src-tauri/src/server/router.rs
@@ -415,6 +415,87 @@ mod tests {
         );
     }
 
+    /// 验收核心断言（HTTP 层端到端）：客户端携带 X-Request-Id 的值 ==
+    /// 响应头回显值 == 落库 chat 日志行的 trace_id。本地 axum mock 充当
+    /// 上游渠道，请求经真实 router → 中间件 → handler → proxy → mock 全链。
+    #[tokio::test]
+    async fn request_id_echoed_header_equals_persisted_trace_id() {
+        // 本地 mock 上游：合法 chat completion 响应
+        let mock_app = axum::Router::new().route(
+            "/chat/completions",
+            axum::routing::post(|| async {
+                axum::Json(serde_json::json!({
+                    "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+                }))
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, mock_app).await.unwrap();
+        });
+
+        let state = test_state().await;
+        sqlx::query(
+            "INSERT INTO api_keys (id, name, key, created_at, updated_at) \
+             VALUES ('rid-key', 'rid-test', 'sk-rid-1', '2026-09-09T00:00:00+00:00', '2026-09-09T00:00:00+00:00')",
+        )
+        .execute(&state.db.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO channels (id, name, type, base_url, api_key, models, status, priority, \
+             weight, config, model_mapping, timeout_secs, protocol, provider, native_base_url, \
+             native_endpoints, preset_revision, identity_revision, created_at, updated_at) \
+             VALUES ('rid-ch', 'rid-ch', 'openai', ?, 'sk-up', '[\"m\"]', 1, 1, 1, '{}', '{}', 60, \
+             'openai', 'openai', ?, '[\"chat_completions\"]', '2026-08-04', 1, \
+             '2026-09-09T00:00:00+00:00', '2026-09-09T00:00:00+00:00')",
+        )
+        .bind(format!("http://{addr}"))
+        .bind(format!("http://{addr}"))
+        .execute(&state.db.pool)
+        .await
+        .unwrap();
+
+        let shared = test_shared(&state, Some(ADMIN_TOKEN), Some(MCP_TOKEN));
+        let app = build_router(state.clone(), shared);
+
+        let body = serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": false
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .header("authorization", "Bearer sk-rid-1")
+            .header("x-request-id", "req-e2e-42")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(
+            res.headers()
+                .get("x-request-id")
+                .and_then(|v| v.to_str().ok()),
+            Some("req-e2e-42"),
+            "响应头应原值回显"
+        );
+
+        let stored: Option<String> =
+            sqlx::query_scalar("SELECT trace_id FROM request_logs WHERE mode = 'chat' AND status_code = 200 ORDER BY seq DESC LIMIT 1")
+                .fetch_one(&state.db.pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            stored.as_deref(),
+            Some("req-e2e-42"),
+            "落库 trace_id 必须与响应头回显值一致（关联键闭环）"
+        );
+    }
+
     #[tokio::test]
     async fn cors_only_covers_data_plane_not_service_routes() {
         let state = test_state().await;

--- a/src-tauri/src/server/router.rs
+++ b/src-tauri/src/server/router.rs
@@ -126,7 +126,10 @@ fn build_router(state: Arc<AppState>, shared: SharedState) -> Router {
         )
         // Health check
         .route("/health", get(handle_health))
-        .layer(cors);
+        .layer(cors)
+        // 请求关联键：X-Request-Id 标准化（最外层，早于 CORS 之后的所有处理）——
+        // 统一解析（X-Request-Id > Wali-Trace-Id > 生成 UUIDv4）、回写请求头、响应头回显。
+        .layer(middleware::from_fn(super::request_id::middleware));
 
     let gateway_router = data_plane_router.merge(kb_wiki_router).merge(mcp_router);
 
@@ -324,6 +327,92 @@ mod tests {
         // 数据面 /health 不受服务 token 影响
         let res = app.oneshot(request("GET", "/health", None)).await.unwrap();
         assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn request_id_generated_and_echoed_when_absent() {
+        let state = test_state().await;
+        let shared = test_shared(&state, Some(ADMIN_TOKEN), Some(MCP_TOKEN));
+        let app = build_router(state, shared);
+
+        let res = app.oneshot(request("GET", "/health", None)).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let echoed = res
+            .headers()
+            .get("x-request-id")
+            .and_then(|v| v.to_str().ok())
+            .expect("缺省时应生成并回显 X-Request-Id");
+        assert!(
+            uuid::Uuid::parse_str(echoed).is_ok(),
+            "生成的关联键应为 UUIDv4：{echoed}"
+        );
+    }
+
+    #[tokio::test]
+    async fn request_id_client_value_is_echoed_verbatim() {
+        let state = test_state().await;
+        let shared = test_shared(&state, Some(ADMIN_TOKEN), Some(MCP_TOKEN));
+        let app = build_router(state, shared);
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/health")
+            .header("x-request-id", "client-req-42")
+            .body(Body::empty())
+            .unwrap();
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            res.headers()
+                .get("x-request-id")
+                .and_then(|v| v.to_str().ok()),
+            Some("client-req-42"),
+            "客户端携带合法 X-Request-Id 时应原值回显"
+        );
+    }
+
+    #[tokio::test]
+    async fn request_id_invalid_value_replaced_with_generated() {
+        let state = test_state().await;
+        let shared = test_shared(&state, Some(ADMIN_TOKEN), Some(MCP_TOKEN));
+        let app = build_router(state, shared);
+
+        let oversize = "x".repeat(200);
+        let req = Request::builder()
+            .method("GET")
+            .uri("/health")
+            .header("x-request-id", oversize.clone())
+            .body(Body::empty())
+            .unwrap();
+        let res = app.oneshot(req).await.unwrap();
+        let echoed = res
+            .headers()
+            .get("x-request-id")
+            .and_then(|v| v.to_str().ok())
+            .expect("非法值也应回显（替换后的生成值）");
+        assert_ne!(echoed, oversize);
+        assert!(uuid::Uuid::parse_str(echoed).is_ok());
+    }
+
+    #[tokio::test]
+    async fn request_id_wali_trace_id_still_honored() {
+        let state = test_state().await;
+        let shared = test_shared(&state, Some(ADMIN_TOKEN), Some(MCP_TOKEN));
+        let app = build_router(state, shared);
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/health")
+            .header("wali-trace-id", "legacy-trace-7")
+            .body(Body::empty())
+            .unwrap();
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            res.headers()
+                .get("x-request-id")
+                .and_then(|v| v.to_str().ok()),
+            Some("legacy-trace-7"),
+            "仅带旧头 Wali-Trace-Id 时应兼容采纳并以 X-Request-Id 回显"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -120,6 +120,12 @@ pub async fn run(cfg: WebServerConfig) -> Result<(), String> {
         state.settings.clone(),
     ));
 
+    // OTLP 导出（默认关闭，开启后按 seq 游标增量导出 request_log）
+    tauri::async_runtime::spawn(crate::otlp_exporter::run_export_loop(
+        state.db.pool.clone(),
+        state.settings.clone(),
+    ));
+
     tauri::async_runtime::spawn(crate::auth_provider::maintenance::run_maintenance_loop(
         auth_service,
     ));

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -610,6 +610,67 @@ export function SettingsPage() {
             </div>
           </div>
           <div>
+            <h3 className="mb-3 text-sm font-medium text-muted-foreground">OTLP 导出</h3>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <label className="surface-soft flex items-center justify-between rounded-2xl px-4 py-4">
+                <div>
+                  <div className="text-sm font-medium">启用 OTLP 导出</div>
+                  <p className="text-xs text-muted-foreground">把请求日志增量导出为 OTLP span（Langfuse 等 OTLP 兼容端可直接接入）；默认关闭，关闭时零后台流量。</p>
+                </div>
+                <input
+                  type="checkbox"
+                  checked={settings.otlp_enabled}
+                  onChange={e => setSettings({ ...settings, otlp_enabled: e.target.checked })}
+                  className="h-5 w-5"
+                />
+              </label>
+              <div>
+                <label className="mb-2 block text-sm font-medium">OTLP/HTTP 端点</label>
+                <input
+                  type="text"
+                  value={settings.otlp_endpoint}
+                  onChange={e => setSettings({ ...settings, otlp_endpoint: e.target.value })}
+                  placeholder="https://langfuse.example.com/api/public/otel/v1/traces"
+                  className={inputCls}
+                />
+                <p className="mt-1 text-xs text-muted-foreground">OTLP/HTTP JSON 端点地址；导出失败自动退避重试，不影响请求主链路。</p>
+              </div>
+              <div>
+                <label className="mb-2 block text-sm font-medium">附加请求头（JSON）</label>
+                <input
+                  type="text"
+                  value={settings.otlp_headers}
+                  onChange={e => setSettings({ ...settings, otlp_headers: e.target.value })}
+                  placeholder='{"Authorization": "Basic …"}'
+                  className={inputCls}
+                />
+                <p className="mt-1 text-xs text-muted-foreground">JSON 对象字符串，鉴权头仅保存在本地设置存储中。</p>
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="mb-2 block text-sm font-medium">导出间隔（秒）</label>
+                  <input
+                    type="number"
+                    min={5}
+                    value={settings.otlp_interval_secs}
+                    onChange={e => setSettings({ ...settings, otlp_interval_secs: Number(e.target.value) })}
+                    className={inputCls}
+                  />
+                </div>
+                <div>
+                  <label className="mb-2 block text-sm font-medium">每批条数</label>
+                  <input
+                    type="number"
+                    min={1}
+                    value={settings.otlp_batch_size}
+                    onChange={e => setSettings({ ...settings, otlp_batch_size: Number(e.target.value) })}
+                    className={inputCls}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div>
             <h3 className="mb-3 text-sm font-medium text-muted-foreground">路由设置</h3>
             <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
               <label className="surface-soft flex items-center justify-between rounded-2xl px-4 py-4">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -432,6 +432,12 @@ export interface Settings {
   ocr_dpi: number;
   log_detail_level: "basic" | "detailed" | string;
   log_retention_days: number;
+  // OTLP 导出（request_log → OTLP/HTTP JSON span，默认关闭）
+  otlp_enabled: boolean;
+  otlp_endpoint: string;
+  otlp_headers: string;
+  otlp_interval_secs: number;
+  otlp_batch_size: number;
 }
 
 // Security rule types


### PR DESCRIPTION
Closes #85

## 开始原因

`Wali-Trace-Id`→trace_id 机制已存在（3 端点、不生成、不回显），本 PR 做标准化与补全；request_log 数据齐备但无导出器。

## 方案

- 数据面最外层中间件：`X-Request-Id` 优先（`Wali-Trace-Id` 兼容）→ 缺省 UUIDv4 → 回写请求头 + 响应头回显；非法值（>128 字符/含空格控制符/非 ASCII）视为未携带。
- messages / count_tokens 补接；messages 全部落账路径携带 trace_id；**复用既有 trace_id 列，零迁移**，不受日志级别策略剥离。
- OTLP 导出器：seq 游标增量（设置存储持久化断点续传）→ OTLP/HTTP JSON span（started_at 起、属性齐全）→ POST 用户端点；**不引 opentelemetry SDK**；失败指数退避、纯旁路；默认关闭；鉴权头从设置读取。
- 设置页 OTLP 导出区（runtime.ts 统一命令层）。

## 测试

resolve/sanitize 纯函数 7 例；router 回显 4 例 + 关联键闭环端到端（mock 上游全链：回显头 == 落库 trace_id）；mock OTLP 端点集成 6 例（span 结构/游标推进/失败保持）；`pnpm build` 过。