### PR TITLE
feat(stream): 流式生成内容持久化（stream_segments）+ Responses 断线续传回放

### DIFF
--- a/src-tauri/migrations/032_stream_segments.sql
+++ b/src-tauri/migrations/032_stream_segments.sql
@@ -1,0 +1,11 @@
+-- 流式生成内容段（溢出表）：大文本不入 request_logs 主表，避免拖慢日志列表查询。
+-- detail_level=detailed 时随流式落账写入（受日志策略门控）；保留期清理与主表同步。
+CREATE TABLE IF NOT EXISTS stream_segments (
+    log_id TEXT NOT NULL,
+    seq INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (log_id, seq)
+);
+
+CREATE INDEX IF NOT EXISTS idx_stream_segments_created ON stream_segments(created_at);

--- a/src-tauri/migrations/032_stream_segments.sql
+++ b/src-tauri/migrations/032_stream_segments.sql
@@ -1,11 +1,15 @@
 -- 流式生成内容段（溢出表）：大文本不入 request_logs 主表，避免拖慢日志列表查询。
 -- detail_level=detailed 时随流式落账写入（受日志策略门控）；保留期清理与主表同步。
+-- response_id：Responses 协议逐帧持久化路径的续传锚点（上游 response.id 透传），
+-- 其余协议为 NULL（整段内容模式）。
 CREATE TABLE IF NOT EXISTS stream_segments (
     log_id TEXT NOT NULL,
     seq INTEGER NOT NULL,
+    response_id TEXT,
     content TEXT NOT NULL,
     created_at TEXT NOT NULL,
     PRIMARY KEY (log_id, seq)
 );
 
 CREATE INDEX IF NOT EXISTS idx_stream_segments_created ON stream_segments(created_at);
+CREATE INDEX IF NOT EXISTS idx_stream_segments_response ON stream_segments(response_id, seq);

--- a/src-tauri/src/audit_log.rs
+++ b/src-tauri/src/audit_log.rs
@@ -119,6 +119,13 @@ pub async fn cleanup_expired_logs(
         .bind(&cutoff)
         .execute(&mut *tx)
         .await?;
+        let segments = sqlx::query(
+            "DELETE FROM stream_segments WHERE log_id IN \
+             (SELECT id FROM request_logs WHERE created_at < ? LIMIT 500)",
+        )
+        .bind(&cutoff)
+        .execute(&mut *tx)
+        .await?;
         let rows = sqlx::query(
             "DELETE FROM request_logs WHERE id IN \
              (SELECT id FROM request_logs WHERE created_at < ? LIMIT 500)",
@@ -128,10 +135,10 @@ pub async fn cleanup_expired_logs(
         .await?;
         tx.commit().await?;
         deleted += rows.rows_affected();
+        let _ = (findings, segments);
         if rows.rows_affected() == 0 {
             break;
         }
-        let _ = findings;
     }
     Ok(deleted)
 }

--- a/src-tauri/src/commands/log.rs
+++ b/src-tauri/src/commands/log.rs
@@ -318,6 +318,36 @@ pub async fn get_log_security_findings_impl(
         .map(|fs| fs.into_iter().map(Into::into).collect())
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StreamSegmentDto {
+    pub seq: i64,
+    pub content: String,
+}
+
+#[tauri::command]
+pub async fn get_log_stream_segments(
+    log_id: String,
+    state: tauri::State<'_, std::sync::Arc<AppState>>,
+) -> Result<Vec<StreamSegmentDto>, String> {
+    get_log_stream_segments_impl(&log_id, &*state).await
+}
+
+pub async fn get_log_stream_segments_impl(
+    log_id: &str,
+    state: &std::sync::Arc<AppState>,
+) -> Result<Vec<StreamSegmentDto>, String> {
+    let repo = Repository::new(state.db.pool.clone());
+    repo.get_stream_segments(log_id)
+        .await
+        .map_err(|e| e.to_string())
+        .map(|segments| {
+            segments
+                .into_iter()
+                .map(|(seq, content)| StreamSegmentDto { seq, content })
+                .collect()
+        })
+}
+
 #[tauri::command]
 pub async fn delete_log(
     id: String,

--- a/src-tauri/src/db/repository.rs
+++ b/src-tauri/src/db/repository.rs
@@ -1,5 +1,5 @@
 use super::models::*;
-use sqlx::SqlitePool;
+use sqlx::{Row, SqlitePool};
 
 /// Parse the stored JSON endpoint list back into a Vec, or None when empty/absent.
 fn parse_eps(raw: &Option<String>) -> Option<Vec<String>> {
@@ -1256,7 +1256,44 @@ impl Repository {
         })
         .execute(&self.pool)
         .await?;
+        // 流式内容段（迁移 032）：detailed 策略下把流式累计内容同步落入溢出表，
+        // 日志详情与后续续传能力按 log_id 寻址；basic 尊重用户存储选择不落段。
+        // best-effort：段写入失败仅告警，不使主日志落账失败（主表行是权威记录）。
+        if log.is_stream == 1 && policy.detail_level == crate::audit_log::LogDetailLevel::Detailed {
+            if let Some(content) = log.response_choices.as_deref() {
+                if !content.is_empty() {
+                    if let Err(error) = sqlx::query(
+                        "INSERT INTO stream_segments (log_id, seq, content, created_at) VALUES (?, 1, ?, ?)",
+                    )
+                    .bind(&log.id)
+                    .bind(content)
+                    .bind(&log.created_at)
+                    .execute(&self.pool)
+                    .await
+                    {
+                        tracing::warn!("[流式段] 写入失败（不影响主日志）: {error}");
+                    }
+                }
+            }
+        }
         Ok(())
+    }
+
+    /// 读取某次流式请求的全部已生成内容段（按 seq 升序拼接即完整内容）。
+    pub async fn get_stream_segments(
+        &self,
+        log_id: &str,
+    ) -> Result<Vec<(i64, String)>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT seq, content FROM stream_segments WHERE log_id = ? ORDER BY seq ASC",
+        )
+        .bind(log_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|row| (row.get::<i64, _>("seq"), row.get::<String, _>("content")))
+            .collect())
     }
 
     pub async fn create_security_findings(
@@ -1313,6 +1350,10 @@ impl Repository {
             .bind(before_date)
             .execute(&self.pool)
             .await?;
+        sqlx::query("DELETE FROM stream_segments WHERE log_id IN (SELECT id FROM request_logs WHERE created_at < ?)")
+            .bind(before_date)
+            .execute(&self.pool)
+            .await?;
         let result = sqlx::query("DELETE FROM request_logs WHERE created_at < ?")
             .bind(before_date)
             .execute(&self.pool)
@@ -1324,6 +1365,9 @@ impl Repository {
         sqlx::query("DELETE FROM request_security_findings")
             .execute(&self.pool)
             .await?;
+        sqlx::query("DELETE FROM stream_segments")
+            .execute(&self.pool)
+            .await?;
         let result = sqlx::query("DELETE FROM request_logs")
             .execute(&self.pool)
             .await?;
@@ -1332,6 +1376,10 @@ impl Repository {
 
     pub async fn delete_log(&self, id: &str) -> Result<(), sqlx::Error> {
         sqlx::query("DELETE FROM request_security_findings WHERE log_id = ?")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        sqlx::query("DELETE FROM stream_segments WHERE log_id = ?")
             .bind(id)
             .execute(&self.pool)
             .await?;

--- a/src-tauri/src/db/repository.rs
+++ b/src-tauri/src/db/repository.rs
@@ -1259,7 +1259,12 @@ impl Repository {
         // 流式内容段（迁移 032）：detailed 策略下把流式累计内容同步落入溢出表，
         // 日志详情与后续续传能力按 log_id 寻址；basic 尊重用户存储选择不落段。
         // best-effort：段写入失败仅告警，不使主日志落账失败（主表行是权威记录）。
-        if log.is_stream == 1 && policy.detail_level == crate::audit_log::LogDetailLevel::Detailed {
+        // Responses 协议除外：driver 轨对该协议做**逐帧渐进持久化**（携带
+        // response_id 续传锚点），本漏斗跳过以免同一流写两份内容。
+        if log.is_stream == 1
+            && log.mode != "responses"
+            && policy.detail_level == crate::audit_log::LogDetailLevel::Detailed
+        {
             if let Some(content) = log.response_choices.as_deref() {
                 if !content.is_empty() {
                     if let Err(error) = sqlx::query(
@@ -1294,6 +1299,71 @@ impl Repository {
             .into_iter()
             .map(|row| (row.get::<i64, _>("seq"), row.get::<String, _>("content")))
             .collect())
+    }
+
+    /// Responses 逐帧持久化：追加一帧下游 SSE 字节（best-effort，失败仅告警）。
+    pub async fn append_stream_frame(
+        &self,
+        log_id: &str,
+        seq: i64,
+        response_id: Option<&str>,
+        content: &str,
+        created_at: &str,
+    ) {
+        let mut query = sqlx::query(
+            "INSERT INTO stream_segments (log_id, seq, response_id, content, created_at) \
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(log_id)
+        .bind(seq);
+        query = match response_id {
+            Some(id) => query.bind(id),
+            None => query.bind(Option::<String>::None),
+        };
+        query = query.bind(content).bind(created_at);
+        if let Err(error) = query.execute(&self.pool).await {
+            tracing::warn!("[流式段] 逐帧写入失败（不影响流转发）: {error}");
+        }
+    }
+
+    /// 按续传锚点（上游 response.id）取未消费帧：seq > offset 升序。
+    pub async fn get_stream_frames_after(
+        &self,
+        response_id: &str,
+        offset: i64,
+    ) -> Result<Vec<(i64, String)>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT seq, content FROM stream_segments \
+             WHERE response_id = ? AND seq > ? ORDER BY seq ASC",
+        )
+        .bind(response_id)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|row| (row.get::<i64, _>("seq"), row.get::<String, _>("content")))
+            .collect())
+    }
+
+    /// 续传锚点 → 首帧时间（TTL 判定）与关联日志行 id（完成状态判定）。
+    pub async fn find_stream_anchor(
+        &self,
+        response_id: &str,
+    ) -> Result<Option<(String, String)>, sqlx::Error> {
+        let row = sqlx::query(
+            "SELECT log_id, created_at FROM stream_segments \
+             WHERE response_id = ? ORDER BY seq ASC LIMIT 1",
+        )
+        .bind(response_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|r| {
+            (
+                r.get::<String, _>("log_id"),
+                r.get::<String, _>("created_at"),
+            )
+        }))
     }
 
     pub async fn create_security_findings(

--- a/src-tauri/src/endpoint_executor/driver.rs
+++ b/src-tauri/src/endpoint_executor/driver.rs
@@ -1237,6 +1237,9 @@ fn update_stream_snapshot(
 #[derive(Clone)]
 struct StreamLogFinalizer {
     repo: Arc<Repository>,
+    /// 预生成的日志行 id：Responses 逐帧持久化在流开始前就用它写段表，
+    /// 落账行必须与段表同一个 id（续传回放按它关联完成状态）。
+    log_id: String,
     key: ApiKey,
     audited: AuditedRequest,
     model: String,
@@ -1290,7 +1293,7 @@ impl StreamLogFinalizer {
         }
         let duration_ms = self.started.elapsed().as_millis() as i64;
         let log = RequestLog {
-            id: utils::id::new_id(),
+            id: self.log_id.clone(),
             seq: None,
             api_key_id: Some(self.key.id.clone()),
             api_key_name: Some(self.key.name.clone()),
@@ -1485,8 +1488,16 @@ fn stream_response_body(
 ) -> impl futures_util::Stream<Item = Result<bytes::Bytes, std::io::Error>> {
     let mode_for_error = mode.clone();
     let snapshot = std::sync::Arc::new(std::sync::Mutex::new(StreamSnapshot::default()));
+    // Responses 逐帧持久化（续传锚点）：detailed 策略下，下游每帧 SSE 字节
+    // 顺序落段表（seq 递增，response.id 从 response.created 帧提取）。
+    // 客户端中途断开时已生成帧自然保留——「丢了」变成「可回放」。
+    let resume_frames_enabled = mode_for_error == "responses"
+        && crate::audit_log::current_policy().detail_level
+            == crate::audit_log::LogDetailLevel::Detailed;
+    let resume_log_id = utils::id::new_id();
     let finalizer = StreamLogFinalizer {
-        repo,
+        repo: repo.clone(),
+        log_id: resume_log_id.clone(),
         key,
         audited,
         model,
@@ -1515,6 +1526,9 @@ fn stream_response_body(
         let mut error_message: Option<String> = None;
         // 终止帧 / 错误帧交给下游之前就已经落库时为 true，函数末尾不再重复写日志。
         let mut finalized = false;
+        // Responses 逐帧持久化状态：帧序号 + 续传锚点（response.created 提取）
+        let mut frame_seq: i64 = 0;
+        let mut anchor_response_id: Option<String> = None;
 
         let upstream_bytes = upstream.body;
         tokio::pin!(upstream_bytes);
@@ -1530,6 +1544,16 @@ fn stream_response_body(
                 // 否则取消行丢内容、FIX-16 响应扫描拿到空快照。
                 update_stream_snapshot(&snapshot, &pump);
                 if !first.is_empty() {
+                    if resume_frames_enabled {
+                        persist_resume_frame(
+                            &repo,
+                            &resume_log_id,
+                            &mut frame_seq,
+                            &mut anchor_response_id,
+                            &first,
+                        )
+                        .await;
+                    }
                     if !finalized && downstream_terminal_frame(&mode_for_error, &first) {
                         finalized = true;
                         write_stream_log(
@@ -1579,6 +1603,16 @@ fn stream_response_body(
                         // 每帧后同步取消路径要用的落账快照（#57）。
                         update_stream_snapshot(&snapshot, &pump);
                         if !out.is_empty() {
+                            if resume_frames_enabled {
+                                persist_resume_frame(
+                                    &repo,
+                                    &resume_log_id,
+                                    &mut frame_seq,
+                                    &mut anchor_response_id,
+                                    &out,
+                                )
+                                .await;
+                            }
                             if !finalized && downstream_terminal_frame(&mode_for_error, &out) {
                                 finalized = true;
                                 write_stream_log(
@@ -1782,6 +1816,54 @@ fn downstream_terminal_frame(mode: &str, out: &[u8]) -> bool {
                 .is_some_and(|payload| payload.trim() == "[DONE]")
         }
     })
+}
+
+/// 从下游 SSE 帧字节中提取续传锚点（response.created 事件里的 response.id）。
+/// 纯函数：只认 `data:` 行的 JSON，`type == "response.created"` 时取 `response.id`。
+fn extract_response_id(frame: &str) -> Option<String> {
+    for line in frame.lines() {
+        let Some(payload) = line.strip_prefix("data:") else {
+            continue;
+        };
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(payload.trim()) else {
+            continue;
+        };
+        if value.get("type").and_then(|t| t.as_str()) == Some("response.created") {
+            if let Some(id) = value
+                .get("response")
+                .and_then(|r| r.get("id"))
+                .and_then(|id| id.as_str())
+            {
+                return Some(id.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Responses 逐帧持久化：一帧下游 SSE 字节顺序写入段表（best-effort）。
+/// 首次见到 response.created 帧时提取锚点；此前已写入的帧锚点为 NULL
+/// （实际首帧即 response.created，NULL 帧仅出现在上游乱序的病态场景）。
+async fn persist_resume_frame(
+    repo: &Repository,
+    log_id: &str,
+    seq: &mut i64,
+    anchor: &mut Option<String>,
+    frame: &[u8],
+) {
+    let text = String::from_utf8_lossy(frame);
+    if anchor.is_none() {
+        *anchor = extract_response_id(&text);
+    }
+    *seq += 1;
+    repo.append_stream_frame(
+        log_id,
+        *seq,
+        anchor.as_deref(),
+        &text,
+        &crate::utils::time::now_iso(),
+    )
+    .await;
 }
 
 /// Walk an error's `source()` chain to its root and return it as a string.
@@ -2372,6 +2454,191 @@ mod tests {
             created_at: now(),
             updated_at: now(),
         }
+    }
+
+    // ─── C-03 第二档：Responses 逐帧持久化（续传锚点）────────────────────
+
+    fn responses_upstream(terminated: bool) -> UpstreamStream {
+        let mut chunks: Vec<Result<bytes::Bytes, std::io::Error>> = vec![Ok(
+            bytes::Bytes::from_static(
+                b"event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_test_42\",\"status\":\"in_progress\"}}\n\n",
+            ),
+        )];
+        let mut second = String::from(
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"你好\"}\n\n",
+        );
+        if terminated {
+            second.push_str("event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_test_42\",\"status\":\"completed\"}}\n\n");
+        }
+        chunks.push(Ok(bytes::Bytes::from(second)));
+        let body = futures_util::stream::iter(chunks)
+            .chain(futures_util::stream::pending::<
+                Result<bytes::Bytes, std::io::Error>,
+            >())
+            .boxed();
+        UpstreamStream {
+            content_type: "text/event-stream".to_string(),
+            headers: vec![],
+            body,
+        }
+    }
+
+    async fn pump_for_responses(upstream: &mut UpstreamStream) -> StreamPumpCore {
+        let (first_frame, carry) = buffer_first_record(upstream).await.unwrap();
+        let mut sup = crate::core::stream_supervisor::StreamSupervisor::new();
+        sup.begin_connect().unwrap();
+        sup.on_upstream_headers().unwrap();
+        sup.on_first_frame_validated().unwrap();
+        let prepared = crate::protocol::codec::CodecRegistry::prepare_pair(
+            crate::protocol::codec::Protocol::Responses,
+            crate::protocol::codec::Protocol::Responses,
+            "up-model",
+            &json!({"model":"up-model", "input":"hi"}),
+        )
+        .unwrap();
+        StreamPumpCore::new(sup, prepared.codec.new_stream_decoder(), first_frame, carry).unwrap()
+    }
+
+    /// 正常完成的 Responses 流：全部帧按序落段，锚点（response.id）可反查，
+    /// 段表 log_id 与落账行 id 一致（续传回放据此判定完成状态）。
+    #[tokio::test]
+    async fn responses_stream_persists_frames_progressively() {
+        let repo = Arc::new(Repository::new(fresh_db().await));
+        let mut upstream = responses_upstream(true);
+        let pump = pump_for_responses(&mut upstream).await;
+
+        let mut stream = Box::pin(stream_response_body(
+            pump,
+            upstream,
+            repo.clone(),
+            api_key(),
+            audited_request(),
+            "m".to_string(),
+            "up-model".to_string(),
+            "responses".to_string(),
+            false,
+            full_request_body(),
+            None,
+            "ch-1".to_string(),
+            "ch".to_string(),
+            "openai".to_string(),
+            1,
+            "responses_g1_native".to_string(),
+            None,
+            "responses".to_string(),
+            "responses".to_string(),
+            "channel".to_string(),
+            StreamTimeouts::default(),
+        ));
+        while let Some(item) = stream.next().await {
+            item.unwrap();
+        }
+
+        let frames = repo
+            .get_stream_frames_after("resp_test_42", 0)
+            .await
+            .unwrap();
+        assert!(!frames.is_empty(), "完成流应落全部帧");
+        let joined: String = frames.iter().map(|(_, f)| f.as_str()).collect();
+        assert!(joined.contains("response.created"));
+        assert!(joined.contains("response.output_text.delta"));
+        assert!(joined.contains("response.completed"), "终止帧应已持久化");
+
+        // 锚点反查 → 段表 log_id == 落账行 id
+        let (anchor_log_id, _) = repo
+            .find_stream_anchor("resp_test_42")
+            .await
+            .unwrap()
+            .expect("锚点应可反查");
+        let logs = repo.get_logs(10, 0).await.unwrap();
+        let row = logs.first().expect("完成流应有落账行");
+        assert_eq!(row.id, anchor_log_id, "段表与落账行必须同一 log_id");
+
+        // offset 语义：跳过 seq<=1 的帧
+        let tail = repo
+            .get_stream_frames_after("resp_test_42", 1)
+            .await
+            .unwrap();
+        assert!(!tail.iter().any(|(_, f)| f.contains("response.created")));
+    }
+
+    /// 客户端中断的 Responses 流：已生成帧保留（回放可用），无终止帧，
+    /// 499 取消行照常落账（既有取消语义不变）。
+    #[tokio::test]
+    async fn responses_cancel_keeps_persisted_frames_for_replay() {
+        let repo = Arc::new(Repository::new(fresh_db().await));
+        let mut upstream = responses_upstream(false);
+        let pump = pump_for_responses(&mut upstream).await;
+
+        let mut stream = Box::pin(stream_response_body(
+            pump,
+            upstream,
+            repo.clone(),
+            api_key(),
+            audited_request(),
+            "m".to_string(),
+            "up-model".to_string(),
+            "responses".to_string(),
+            false,
+            full_request_body(),
+            None,
+            "ch-1".to_string(),
+            "ch".to_string(),
+            "openai".to_string(),
+            1,
+            "responses_g1_native".to_string(),
+            None,
+            "responses".to_string(),
+            "responses".to_string(),
+            "channel".to_string(),
+            StreamTimeouts::default(),
+        ));
+        stream.next().await.unwrap().unwrap();
+        stream.next().await.unwrap().unwrap();
+        drop(stream);
+
+        // 499 取消行（Drop spawn 异步写）
+        let mut cancelled = false;
+        for _ in 0..100 {
+            let logs = repo.get_logs(10, 0).await.unwrap();
+            if logs.first().is_some_and(|row| row.status_code == 499) {
+                cancelled = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        assert!(cancelled, "取消行必须照常落账");
+
+        let frames = repo
+            .get_stream_frames_after("resp_test_42", 0)
+            .await
+            .unwrap();
+        let joined: String = frames.iter().map(|(_, f)| f.as_str()).collect();
+        assert!(
+            joined.contains("response.output_text.delta"),
+            "中断前帧应保留"
+        );
+        assert!(
+            !joined.contains("response.completed"),
+            "中断流不应有终止帧（回放端点据此合成 incomplete 收尾）"
+        );
+    }
+
+    #[test]
+    fn extract_response_id_parses_created_event_only() {
+        let created =
+            "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_x\",\"status\":\"in_progress\"}}\n\n";
+        assert_eq!(extract_response_id(created), Some("resp_x".to_string()));
+        // 非 created 事件不提取；data 无空格前缀可解析；坏 JSON 跳过
+        let delta = "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"x\",\"response\":{\"id\":\"resp_y\"}}\n\n";
+        assert_eq!(extract_response_id(delta), None);
+        assert_eq!(extract_response_id("data: not-json\n\n"), None);
+        assert_eq!(
+            extract_response_id(
+                "event: response.created\ndata: {\"type\":\"response.created\"}\n\n"
+            ),
+            None
+        );
     }
 
     /// C-1: the FULL `stream_response_body` emission seam.  The first upstream

--- a/src-tauri/src/endpoint_executor/driver.rs
+++ b/src-tauri/src/endpoint_executor/driver.rs
@@ -2624,6 +2624,66 @@ mod tests {
         );
     }
 
+    /// 第一档端到端（真实路径）：chat SSE 流（带终止帧、有累计内容）完整走完
+    /// stream_response_body → 落账行 → create_log 漏斗 → 段表出现内容段。
+    /// 此前段测试直接构造 log 调漏斗，未覆盖 driver 真实累计内容到段的链路。
+    #[tokio::test]
+    async fn chat_stream_accumulated_content_reaches_segments() {
+        let repo = Arc::new(Repository::new(fresh_db().await));
+        let mut upstream = hanging_after_terminal_upstream(true, true);
+        let pump = pump_for(&mut upstream).await;
+
+        let mut stream = Box::pin(stream_response_body(
+            pump,
+            upstream,
+            repo.clone(),
+            api_key(),
+            audited_request(),
+            "m".to_string(),
+            "up-model".to_string(),
+            "chat".to_string(),
+            false,
+            full_request_body(),
+            None,
+            "ch-1".to_string(),
+            "ch".to_string(),
+            "anthropic".to_string(),
+            1,
+            "messages_g1_native".to_string(),
+            None,
+            "anthropic".to_string(),
+            "messages".to_string(),
+            "channel".to_string(),
+            StreamTimeouts::default(),
+        ));
+        while let Some(item) = stream.next().await {
+            item.unwrap();
+        }
+
+        // 落账行存在且为流式
+        let row = repo
+            .get_logs(10, 0)
+            .await
+            .unwrap()
+            .into_iter()
+            .next()
+            .expect("完成流应落账");
+        assert_eq!(row.is_stream, 1);
+
+        // 段表出现该 log_id 的内容段（detailed 默认策略 + 流式 + 有累计内容）
+        let segments = repo.get_stream_segments(&row.id).await.unwrap();
+        assert!(
+            !segments.is_empty(),
+            "chat SSE 累计内容应经漏斗落段（log {}）",
+            row.id
+        );
+        let joined: String = segments.into_iter().map(|(_, c)| c).collect();
+        assert!(
+            joined.contains("hi"),
+            "段内容应来自真实累计（含上游 delta 文本），实际: {joined}"
+        );
+    }
+
     #[test]
     fn extract_response_id_parses_created_event_only() {
         let created =

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -306,6 +306,7 @@ pub fn run() {
             commands::log::count_logs,
             commands::log::get_log,
             commands::log::get_log_security_findings,
+            commands::log::get_log_stream_segments,
             commands::log::delete_log,
             commands::log::delete_logs_before,
             commands::log::delete_all_logs,

--- a/src-tauri/src/server/admin_routes.rs
+++ b/src-tauri/src/server/admin_routes.rs
@@ -505,6 +505,9 @@ async fn dispatch(shared: &SharedState, cmd: &str, args: Value) -> Result<Value,
         "get_log_security_findings" => {
             to_json(commands::log::get_log_security_findings(arg(&args, "logId")?, state).await)
         }
+        "get_log_stream_segments" => {
+            to_json(commands::log::get_log_stream_segments(arg(&args, "logId")?, state).await)
+        }
         "get_log_stats" => to_json(commands::log::get_log_stats(arg(&args, "days")?, state).await),
         "delete_log" => to_json(commands::log::delete_log(arg(&args, "id")?, state).await),
         "delete_logs_before" => {

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -10,7 +10,7 @@ use crate::protocol;
 use crate::security;
 use axum::{
     body::Body,
-    extract::{OriginalUri, State},
+    extract::{OriginalUri, Path, Query, State},
     http::{header, HeaderMap, StatusCode},
     response::{IntoResponse, Json, Response},
 };
@@ -2750,6 +2750,115 @@ pub async fn handle_messages_count_tokens(
 // ─── OpenAI Responses API: POST /v1/responses ────────────────────────────────
 // Accepts Responses API format and proxies to upstream channels via Chat Completions.
 // Converts: Responses input → OpenAI messages → upstream → OpenAI response → Responses output.
+
+/// Responses 断线续传回放：`GET /v1/responses/{response_id}/events?offset=N`。
+///
+/// 锚点为上游 response.id（逐帧持久化时透传提取）。回放 offset 之后的全部已存帧；
+/// 原流被客户端中断（无终止帧）时补一帧合成的 `response.completed`
+/// （status=incomplete）使客户端状态机干净收尾。TTL 过期返回 410 明确错误。
+/// 说明：客户端断开时上游即终止（与既有取消语义一致），本端点回放的是
+/// 断开前已生成的全部内容；「上游继续生成 + 活桥接」涉及流生命周期重构，
+/// 列为上游 issue 开放点。
+pub async fn handle_responses_events(
+    State(shared): State<SharedState>,
+    Path(response_id): Path<String>,
+    Query(params): Query<std::collections::HashMap<String, String>>,
+    headers: HeaderMap,
+) -> Response {
+    let api_key = match protocol::extract_api_key(&headers) {
+        Some(key) => key,
+        None => {
+            return openai_auth_error(StatusCode::UNAUTHORIZED, "Missing API key");
+        }
+    };
+    let repo = Repository::new(shared.state.db.pool.clone());
+    let _key_record = match repo.get_api_key_by_key(&api_key).await {
+        Ok(key) => key,
+        Err(e) if is_key_lookup_storage_error(&e) => {
+            return openai_auth_error(StatusCode::INTERNAL_SERVER_ERROR, "Key lookup failed");
+        }
+        Err(_) => return openai_auth_error(StatusCode::UNAUTHORIZED, "Invalid API key"),
+    };
+
+    let Some((log_id, first_created_at)) = (match repo.find_stream_anchor(&response_id).await {
+        Ok(anchor) => anchor,
+        Err(_) => return openai_auth_error(StatusCode::INTERNAL_SERVER_ERROR, "Storage failure"),
+    }) else {
+        return openai_auth_error(StatusCode::NOT_FOUND, "Unknown response id");
+    };
+
+    // TTL：段可回放窗口（默认 24h，0 = 不限）
+    let ttl_secs = shared
+        .state
+        .settings
+        .get_u64("stream.resume_ttl_secs", 86_400);
+    if ttl_secs > 0 {
+        let expired = chrono::DateTime::parse_from_rfc3339(&first_created_at)
+            .ok()
+            .and_then(|t| t.timestamp_nanos_opt())
+            .map(|nanos| {
+                chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default() - nanos
+                    > ttl_secs as i64 * 1_000_000_000
+            })
+            .unwrap_or(false);
+        if expired {
+            return openai_auth_error(StatusCode::GONE, "Resume window expired");
+        }
+    }
+
+    let offset: i64 = params
+        .get("offset")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let frames = match repo.get_stream_frames_after(&response_id, offset).await {
+        Ok(frames) => frames,
+        Err(_) => return openai_auth_error(StatusCode::INTERNAL_SERVER_ERROR, "Storage failure"),
+    };
+
+    let mut body = String::new();
+    for (_, frame) in &frames {
+        body.push_str(frame);
+    }
+    // 原流被中断（无终止帧）→ 合成 incomplete 完成帧收尾，客户端可干净终止。
+    let terminated = frames
+        .last()
+        .is_some_and(|(_, frame)| frame.contains("response.completed"));
+    if !terminated && !frames.is_empty() {
+        let synthesized = serde_json::json!({
+            "type": "response.completed",
+            "response": {
+                "id": response_id,
+                "status": "incomplete",
+                "incomplete_details": {"reason": "client_disconnected"},
+            }
+        });
+        body.push_str(&format!(
+            "event: response.completed\ndata: {}\n\n",
+            synthesized
+        ));
+        tracing::debug!(
+            "[续传] {response_id} 原流未完成（log {log_id}），回放补合成 incomplete 终止帧"
+        );
+    }
+
+    (
+        [(header::CONTENT_TYPE, "text/event-stream")],
+        [(header::CACHE_CONTROL, "no-cache")],
+        body,
+    )
+        .into_response()
+}
+
+/// OpenAI 风格的错误响应（续传端点用；独立于转发路径的错误构造器）。
+fn openai_auth_error(status: StatusCode, message: &str) -> Response {
+    (
+        status,
+        Json(serde_json::json!({
+            "error": {"message": message, "type": "invalid_request_error"}
+        })),
+    )
+        .into_response()
+}
 
 pub async fn handle_responses(
     State(shared): State<SharedState>,

--- a/src-tauri/src/server/router.rs
+++ b/src-tauri/src/server/router.rs
@@ -103,6 +103,11 @@ fn build_router(state: Arc<AppState>, shared: SharedState) -> Router {
         .route("/v1/completions", post(handle_completions))
         // OpenAI Responses API
         .route("/v1/responses", post(handle_responses))
+        // Responses 断线续传回放（逐帧持久化的已生成内容，offset 起回放）
+        .route(
+            "/v1/responses/{id}/events",
+            get(super::handlers::handle_responses_events),
+        )
         // OpenAI Embeddings
         .route("/v1/embeddings", post(handle_embeddings))
         // OpenAI Models
@@ -324,6 +329,154 @@ mod tests {
         // 数据面 /health 不受服务 token 影响
         let res = app.oneshot(request("GET", "/health", None)).await.unwrap();
         assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    // ─── C-03 第二档：Responses 续传回放端点 ─────────────────────────────
+
+    async fn seed_replay_state(
+        state: &Arc<AppState>,
+        key: &str,
+        response_id: &str,
+        created_at: &str,
+        with_frames: bool,
+    ) {
+        sqlx::query(
+            "INSERT INTO api_keys (id, name, key, created_at, updated_at) \
+             VALUES ('rk-1', 'replay-test', ?, ?, ?)",
+        )
+        .bind(key)
+        .bind(created_at)
+        .bind(created_at)
+        .execute(&state.db.pool)
+        .await
+        .unwrap();
+        if with_frames {
+            let repo = crate::db::repository::Repository::new(state.db.pool.clone());
+            repo.append_stream_frame(
+                "log-rt-1",
+                1,
+                Some(response_id),
+                "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp\",\"status\":\"in_progress\"}}\n\n",
+                created_at,
+            )
+            .await;
+            repo.append_stream_frame(
+                "log-rt-1",
+                2,
+                Some(response_id),
+                "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"部分\"}\n\n",
+                created_at,
+            )
+            .await;
+        }
+    }
+
+    fn replay_request(uri: &str, key: &str) -> Request<Body> {
+        Request::builder()
+            .method("GET")
+            .uri(uri)
+            .header("x-api-key", key)
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    async fn body_string(res: axum::response::Response) -> String {
+        let bytes = axum::body::to_bytes(res.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        String::from_utf8_lossy(&bytes).to_string()
+    }
+
+    #[tokio::test]
+    async fn responses_replay_replays_frames_and_synthesizes_incomplete_tail() {
+        let state = test_state().await;
+        seed_replay_state(
+            &state,
+            "sk-rt-1",
+            "resp_rt_1",
+            "2026-09-09T00:00:00+00:00",
+            true,
+        )
+        .await;
+        let shared = test_shared(&state, Some(ADMIN_TOKEN), Some(MCP_TOKEN));
+        let app = build_router(state, shared);
+
+        // 未带 key → 401
+        let res = app
+            .clone()
+            .oneshot(replay_request(
+                "/v1/responses/resp_rt_1/events",
+                "wrong-key",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+
+        // 回放：两帧 + 合成 incomplete 终止帧（原流无终止帧）
+        let res = app
+            .clone()
+            .oneshot(replay_request("/v1/responses/resp_rt_1/events", "sk-rt-1"))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(
+            res.headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok()),
+            Some("text/event-stream")
+        );
+        let body = body_string(res).await;
+        assert!(body.contains("response.created"));
+        assert!(body.contains("response.output_text.delta"));
+        assert!(
+            body.contains("\"status\":\"incomplete\"") && body.contains("response.completed"),
+            "中断流回放应合成 incomplete 完成帧收尾"
+        );
+
+        // offset 语义：跳过 seq<=1
+        let res = app
+            .clone()
+            .oneshot(replay_request(
+                "/v1/responses/resp_rt_1/events?offset=1",
+                "sk-rt-1",
+            ))
+            .await
+            .unwrap();
+        let body = body_string(res).await;
+        assert!(!body.contains("response.created"), "offset=1 应跳过首帧");
+        assert!(body.contains("response.output_text.delta"));
+    }
+
+    #[tokio::test]
+    async fn responses_replay_unknown_id_and_expired_window() {
+        let state = test_state().await;
+        seed_replay_state(
+            &state,
+            "sk-rt-2",
+            "resp_rt_2",
+            "2020-01-01T00:00:00+00:00",
+            true,
+        )
+        .await;
+        let shared = test_shared(&state, Some(ADMIN_TOKEN), Some(MCP_TOKEN));
+        let app = build_router(state, shared);
+
+        // 未知 id → 404
+        let res = app
+            .clone()
+            .oneshot(replay_request("/v1/responses/nope/events", "sk-rt-2"))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+
+        // 首帧时间超出 TTL（默认 24h）→ 410 明确「续传已过期」
+        let res = app
+            .oneshot(replay_request("/v1/responses/resp_rt_2/events", "sk-rt-2"))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::GONE);
+        let body = body_string(res).await;
+        assert!(body.contains("expired"), "错误体应说明续传过期：{body}");
     }
 
     #[tokio::test]

--- a/src-tauri/tests/request_log.rs
+++ b/src-tauri/tests/request_log.rs
@@ -430,3 +430,102 @@ async fn request_log_cleanup_removes_expired_rows_and_findings() {
         0
     );
 }
+
+// ─── Stream segments（迁移 032：流式内容段溢出表）────────────────────────────
+
+fn detailed_policy() -> waliapi_lib::audit_log::LogPolicy {
+    waliapi_lib::audit_log::LogPolicy {
+        detail_level: waliapi_lib::audit_log::LogDetailLevel::Detailed,
+        retention_days: 7,
+    }
+}
+
+#[tokio::test]
+async fn stream_segments_persisted_only_under_detailed_policy_for_streams() {
+    let pool = fresh_db().await;
+    let repo = Repository::new(pool);
+
+    // detailed + 流式 + 有内容 → 落段
+    let mut log = full_log(None, Some("seg-1"));
+    log.id = "stream-detailed".into();
+    log.response_choices = Some("{\"choices\":[{\"message\":{\"content\":\"部分生成内容\"}}]}".into());
+    repo.create_log_with_policy(&log, detailed_policy()).await.unwrap();
+    let segments = repo.get_stream_segments("stream-detailed").await.unwrap();
+    assert_eq!(segments.len(), 1, "detailed 流式应落一段");
+    assert_eq!(segments[0].0, 1);
+    assert!(segments[0].1.contains("部分生成内容"));
+
+    // basic + 流式 + 有内容 → 不落段（尊重用户存储选择）
+    let mut log = full_log(None, Some("seg-2"));
+    log.id = "stream-basic".into();
+    log.response_choices = Some("{\"choices\":[]}".into());
+    repo.create_log_with_policy(
+        &log,
+        waliapi_lib::audit_log::LogPolicy {
+            detail_level: waliapi_lib::audit_log::LogDetailLevel::Basic,
+            retention_days: 7,
+        },
+    )
+    .await
+    .unwrap();
+    assert!(
+        repo.get_stream_segments("stream-basic").await.unwrap().is_empty(),
+        "basic 不落段"
+    );
+
+    // detailed + 非流式 → 不落段
+    let mut log = full_log(None, Some("seg-3"));
+    log.id = "non-stream".into();
+    log.is_stream = 0;
+    log.response_choices = Some("{\"choices\":[]}".into());
+    repo.create_log_with_policy(&log, detailed_policy()).await.unwrap();
+    assert!(
+        repo.get_stream_segments("non-stream").await.unwrap().is_empty(),
+        "非流式不落段"
+    );
+
+    // detailed + 流式 + 内容为空 → 不落段
+    let mut log = full_log(None, Some("seg-4"));
+    log.id = "stream-empty".into();
+    log.response_choices = None;
+    repo.create_log_with_policy(&log, detailed_policy()).await.unwrap();
+    assert!(
+        repo.get_stream_segments("stream-empty").await.unwrap().is_empty(),
+        "无累计内容不落段"
+    );
+}
+
+#[tokio::test]
+async fn stream_segments_purged_by_all_delete_paths() {
+    let pool = fresh_db().await;
+    let repo = Repository::new(pool);
+
+    // 一条“过期”日志与一条“新”日志，均带段
+    let mut old = full_log(None, Some("old"));
+    old.id = "old-log".into();
+    old.created_at = "2020-01-01T00:00:00+00:00".into();
+    old.response_choices = Some("old-content".into());
+    let mut new = full_log(None, Some("new"));
+    new.id = "new-log".into();
+    new.created_at = now();
+    new.response_choices = Some("new-content".into());
+    repo.create_log_with_policy(&old, detailed_policy()).await.unwrap();
+    repo.create_log_with_policy(&new, detailed_policy()).await.unwrap();
+
+    // 按日期清理：只清旧的（段随主行走）
+    repo.delete_logs_before("2021-01-01T00:00:00+00:00").await.unwrap();
+    assert!(repo.get_stream_segments("old-log").await.unwrap().is_empty());
+    assert_eq!(repo.get_stream_segments("new-log").await.unwrap().len(), 1);
+
+    // 单条删除：段随行走
+    repo.delete_log("new-log").await.unwrap();
+    assert!(repo.get_stream_segments("new-log").await.unwrap().is_empty());
+
+    // 全量清空
+    let mut again = full_log(None, Some("again"));
+    again.id = "again-log".into();
+    again.response_choices = Some("again-content".into());
+    repo.create_log_with_policy(&again, detailed_policy()).await.unwrap();
+    repo.delete_all_logs().await.unwrap();
+    assert!(repo.get_stream_segments("again-log").await.unwrap().is_empty());
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -102,6 +102,8 @@ export const logApi = {
   count: (input?: GetLogsInput) => invoke<number>("count_logs", { input: input || {} }),
   get: (id: string) => invoke<RequestLog>("get_log", { id }),
   getSecurityFindings: (logId: string) => invoke<SecurityFinding[]>("get_log_security_findings", { logId }),
+  /** 流式请求的已生成内容段（detailed 策略下落库；按 seq 升序拼接即完整内容）。 */
+  getStreamSegments: (logId: string) => invoke<Array<{ seq: number; content: string }>>("get_log_stream_segments", { logId }),
   getStats: (days?: number) => invoke<LogStats[]>("get_log_stats", { days }),
   delete: (id: string) => invoke<void>("delete_log", { id }),
   deleteBefore: (beforeDate: string) => invoke<number>("delete_logs_before", { beforeDate }),

--- a/src/pages/LogsPage.tsx
+++ b/src/pages/LogsPage.tsx
@@ -798,6 +798,7 @@ function LogDetail({ log }: { log: RequestLog }) {
   const [expandedToolCalls, setExpandedToolCalls] = useState<Set<string>>(new Set());
   const [copyingTool, setCopyingTool] = useState<string | null>(null);
   const [copiedJsonKey, setCopiedJsonKey] = useState<string | null>(null);
+  const [streamSegments, setStreamSegments] = useState<Array<{ seq: number; content: string }>>([]);
 
   useEffect(() => {
     if (log.risk_score > 0) {
@@ -806,6 +807,16 @@ function LogDetail({ log }: { log: RequestLog }) {
       setFindings([]);
     }
   }, [log.id, log.risk_score]);
+
+  // 流式请求懒加载已生成内容段（detailed 策略下由服务端随落账写入溢出表）
+  useEffect(() => {
+    if (log.is_stream) {
+      logApi.getStreamSegments(log.id).then(setStreamSegments).catch(() => setStreamSegments([]));
+    } else {
+      setStreamSegments([]);
+    }
+  }, [log.id, log.is_stream]);
+  const streamSegmentsText = streamSegments.map(s => s.content).join("");
 
   // Parse request body
   let parsed: Record<string, unknown> | null = null;
@@ -1794,6 +1805,31 @@ function LogDetail({ log }: { log: RequestLog }) {
           ) : (
             <div className="text-xs text-slate-500">点击「展开全部」查看原始 JSON</div>
           )}
+        </div>
+      ) : streamSegmentsText ? (
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs font-medium text-slate-500">流式生成内容（含中断前已生成部分，{streamSegments.length} 段）</span>
+            <button
+              onClick={async () => {
+                try {
+                  await writeClipboard(streamSegmentsText);
+                  setCopiedJsonKey('stream-segments');
+                  setTimeout(() => setCopiedJsonKey(null), 1500);
+                } catch {}
+              }}
+              className={`text-[10px] px-1.5 py-0.5 rounded-full transition-all shadow-sm ${
+                copiedJsonKey === 'stream-segments'
+                  ? 'bg-emerald-100 border-emerald-300 text-emerald-700'
+                  : 'bg-white/90 border border-slate-200 text-slate-600 hover:bg-blue-50 hover:text-blue-600 hover:border-blue-300'
+              }`}
+            >
+              {copiedJsonKey === 'stream-segments' ? '✅ 已复制' : '📋 复制'}
+            </button>
+          </div>
+          <pre className="max-h-[420px] w-full max-w-full overflow-y-auto overflow-x-hidden rounded-xl bg-slate-50 border border-slate-200 p-3 text-xs font-mono whitespace-pre-wrap break-all [overflow-wrap:anywhere] text-slate-700">
+            {streamSegmentsText}
+          </pre>
         </div>
       ) : (
         <div className="flex flex-col items-center justify-center py-8 text-center">


### PR DESCRIPTION
Closes #86

## 开始原因

流式守卫已完整但生成内容随连接消亡——「丢了」不可查；Responses 协议天然可续传语义未被利用。

## 方案

**第一档（全协议）**：`stream_segments` 溢出表（迁移 032），detailed 日志策略下落账时同步落段（basic 不落，尊重 v0.3.0 存储选择）；挂 `create_log_with_policy` 单一漏斗；三条清理路径同步清段；日志详情页展示「含中断前已生成部分」。

**第二档（仅 Responses）**：逐帧渐进持久化（每帧 SSE 字节顺序落段，`response.id` 提取为锚点，段表与落账行同 id）；回放端点 `GET /v1/responses/{id}/events?offset=N`（回放未消费帧，无终止帧时合成 `response.completed` status=incomplete 收尾；TTL 默认 24h，过期 410）。Chat/Anthropic 上游无 resume 语义，不做。

## 覆盖面如实声明

第一档覆盖现状有累计的路径（driver 轨 chat SSE、messages 原生/codec）；Responses 由第二档逐帧独占；legacy 流当前不累计内容，本 PR 不新增累计器。

## 测试

段策略门控四象限 + 清理路径；chat SSE 端到端落段（真实 driver 路径）；逐帧持久化/锚点/中断保留/499 照常；回放端点 401/回放+合成收尾/offset/404/410。

## 开放点

「分离续跑 + 活桥接」需流泵循环重构（与 Drop finalizer 取消语义纠缠），本 PR 不含（见 issue）。