### PR TITLE
feat(routing): 渠道主动健康探测——后台 GET /models + 候选排序沉底 + 用量口径隔离

### DIFF
--- a/src-tauri/migrations/033_channel_probe.sql
+++ b/src-tauri/migrations/033_channel_probe.sql
@@ -1,0 +1,7 @@
+-- 渠道主动健康探测（C-04）：
+-- channels 三列为探测状态（NULL = 从未探测，视为健康参与正常排序）；
+-- request_logs.is_probe 标记探测流量，统计/用量口径排除，避免污染用户账单。
+ALTER TABLE channels ADD COLUMN last_probe_at TEXT;
+ALTER TABLE channels ADD COLUMN last_probe_ok INTEGER;
+ALTER TABLE channels ADD COLUMN probe_latency_ms INTEGER;
+ALTER TABLE request_logs ADD COLUMN is_probe INTEGER NOT NULL DEFAULT 0;

--- a/src-tauri/src/commands/channel.rs
+++ b/src-tauri/src/commands/channel.rs
@@ -46,6 +46,10 @@ pub struct ChannelDto {
     pub updated_at: String,
     pub last_test_at: Option<String>,
     pub last_test_ok: Option<i64>,
+    /// 主动健康探测（迁移 033）：探测列优先展示，无探测数据回退手动测试列。
+    pub last_probe_at: Option<String>,
+    pub last_probe_ok: Option<i64>,
+    pub probe_latency_ms: Option<i64>,
     // --- Multi-key: extra API keys for load balancing (migration 023) ---
     pub extra_keys: Vec<ChannelKeyDto>,
 }
@@ -104,6 +108,9 @@ impl From<Channel> for ChannelDto {
             updated_at: c.updated_at,
             last_test_at: c.last_test_at,
             last_test_ok: c.last_test_ok,
+            last_probe_at: c.last_probe_at,
+            last_probe_ok: c.last_probe_ok,
+            probe_latency_ms: c.probe_latency_ms,
             extra_keys: Vec::new(), // populated by to_dto_with_keys
         }
     }

--- a/src-tauri/src/commands/import_export.rs
+++ b/src-tauri/src/commands/import_export.rs
@@ -1022,6 +1022,9 @@ mod tests {
             updated_at: "2026-08-01T00:00:00.000Z".into(),
             last_test_at: Some("2026-08-01T00:00:00.000Z".into()),
             last_test_ok: Some(1),
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 
@@ -1052,6 +1055,9 @@ mod tests {
             updated_at: "2026-07-01T00:00:00.000Z".into(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -59,6 +59,15 @@ pub struct Settings {
     pub ocr_concurrency: i32,
     #[serde(default = "default_ocr_dpi")]
     pub ocr_dpi: i32,
+    /// 渠道主动健康探测开关（默认开）。关闭时零后台流量。
+    #[serde(default = "default_true")]
+    pub probe_enabled: bool,
+    #[serde(default = "default_probe_interval_secs")]
+    pub probe_interval_secs: u64,
+}
+
+fn default_probe_interval_secs() -> u64 {
+    300
 }
 
 fn default_port() -> u16 {
@@ -135,6 +144,8 @@ impl Default for Settings {
             ocr_max_pages: default_ocr_max_pages(),
             ocr_concurrency: default_ocr_concurrency(),
             ocr_dpi: default_ocr_dpi(),
+            probe_enabled: default_true(),
+            probe_interval_secs: default_probe_interval_secs(),
         }
     }
 }
@@ -218,6 +229,8 @@ pub async fn get_settings(state: tauri::State<'_, Arc<AppState>>) -> Result<Sett
         ocr_max_pages: get_u64(store, "ocr.max_pages", 200) as i32,
         ocr_concurrency: get_u64(store, "ocr.concurrency", 2) as i32,
         ocr_dpi: get_u64(store, "ocr.dpi", 200) as i32,
+        probe_enabled: get_bool(store, "probe.enabled", true),
+        probe_interval_secs: get_u64(store, "probe.interval_secs", 300),
     };
     Ok(settings)
 }
@@ -330,6 +343,14 @@ pub async fn save_settings(
             serde_json::json!(settings.ocr_concurrency),
         ),
         ("ocr.dpi".to_string(), serde_json::json!(settings.ocr_dpi)),
+        (
+            "probe.enabled".to_string(),
+            serde_json::json!(settings.probe_enabled),
+        ),
+        (
+            "probe.interval_secs".to_string(),
+            serde_json::json!(settings.probe_interval_secs),
+        ),
     ])?;
     crate::audit_log::apply_settings(&state.settings);
     // 缩短保留期后立即清理，避免等待后台维护周期。

--- a/src-tauri/src/core/attempt.rs
+++ b/src-tauri/src/core/attempt.rs
@@ -627,6 +627,9 @@ mod tests {
             updated_at: "2026-01-01T00:00:00Z".into(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 

--- a/src-tauri/src/core/dispatcher.rs
+++ b/src-tauri/src/core/dispatcher.rs
@@ -96,6 +96,9 @@ mod tests {
             updated_at: "2026-01-01T00:00:00Z".into(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 

--- a/src-tauri/src/core/plan_executor.rs
+++ b/src-tauri/src/core/plan_executor.rs
@@ -324,6 +324,9 @@ mod tests {
             updated_at: "2026-01-01T00:00:00Z".into(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 

--- a/src-tauri/src/core/proxy.rs
+++ b/src-tauri/src/core/proxy.rs
@@ -390,6 +390,10 @@ pub async fn handle_request(
                     }
                 }
 
+                // 被动反哺（C-04）：真实请求成功 → 恢复该渠道的主动探测健康标记
+                // （best-effort，与日志/配额递增同级的旁路更新）。
+                repo.mark_probe_ok(&channel.id);
+
                 return Ok(ProxyResult {
                     status,
                     body: resp_body,

--- a/src-tauri/src/core/route_plan.rs
+++ b/src-tauri/src/core/route_plan.rs
@@ -1336,6 +1336,9 @@ mod tests {
             updated_at: "2026-01-01T00:00:00Z".into(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 
@@ -1381,6 +1384,9 @@ mod tests {
             updated_at: "2026-01-01T00:00:00Z".into(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -52,6 +52,10 @@ pub struct Channel {
     pub updated_at: String,
     pub last_test_at: Option<String>,
     pub last_test_ok: Option<i64>,
+    /// 主动健康探测（迁移 033）：NULL = 从未探测（排序视为健康）。
+    pub last_probe_at: Option<String>,
+    pub last_probe_ok: Option<i64>,
+    pub probe_latency_ms: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src-tauri/src/db/repository.rs
+++ b/src-tauri/src/db/repository.rs
@@ -43,11 +43,70 @@ impl Repository {
     }
 
     pub async fn get_enabled_channels(&self) -> Result<Vec<Channel>, sqlx::Error> {
+        // 主动探测（C-04）：探测失败的渠道沉底不剔除（NULL=从未探测，视为健康）。
+        // 同健康档内保持既有优先级/权重序；两轨候选查询共用此排序语义。
         sqlx::query_as::<_, Channel>(
-            "SELECT * FROM channels WHERE status = 1 ORDER BY priority DESC, weight DESC",
+            "SELECT * FROM channels WHERE status = 1 \
+             ORDER BY COALESCE(last_probe_ok, 1) DESC, priority DESC, weight DESC",
         )
         .fetch_all(&self.pool)
         .await
+    }
+
+    /// 记录一次主动探测结果：更新渠道探测三列 + 写 is_probe=1 日志行
+    /// （统计口径排除，避免污染用户用量）。直接 SQL 最小列集，不走
+    /// create_log 漏斗（探测行无正文、不受明细级别影响）。
+    pub async fn record_channel_probe(
+        &self,
+        channel_id: &str,
+        channel_name: &str,
+        outcome: crate::health_probe::ProbeOutcome,
+        now: &str,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "UPDATE channels SET last_probe_at = ?, last_probe_ok = ?, probe_latency_ms = ?, \
+             updated_at = ? WHERE id = ?",
+        )
+        .bind(now)
+        .bind(i64::from(outcome.ok))
+        .bind(outcome.latency_ms)
+        .bind(now)
+        .bind(channel_id)
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            "INSERT INTO request_logs (id, seq, channel_id, channel_name, model, mode, \
+             status_code, duration_ms, is_stream, is_retry, created_at, risk_level, \
+             security_action, upstream_type, is_probe) \
+             VALUES (?, (SELECT COALESCE(MAX(seq), 0) + 1 FROM request_logs), ?, ?, ?, 'probe', \
+             ?, ?, 0, 0, ?, 'low', 'audit', 'channel', 1)",
+        )
+        .bind(crate::utils::id::new_id())
+        .bind(channel_id)
+        .bind(channel_name)
+        .bind(channel_name)
+        .bind(if outcome.ok { 200 } else { 502 })
+        .bind(outcome.latency_ms)
+        .bind(now)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// 被动反哺：真实请求成功后立即恢复该渠道的探测健康标记
+    /// （与 mode_health 的成功清除相互独立、各管各的表）。
+    pub async fn mark_probe_ok(&self, channel_id: &str) {
+        let result = sqlx::query(
+            "UPDATE channels SET last_probe_ok = 1, last_probe_at = ?, updated_at = ? WHERE id = ?",
+        )
+        .bind(crate::db::models::now_iso())
+        .bind(crate::db::models::now_iso())
+        .bind(channel_id)
+        .execute(&self.pool)
+        .await;
+        if let Err(error) = result {
+            tracing::warn!("[探测] 被动反哺失败（channel {channel_id}）: {error}");
+        }
     }
 
     /// Return channels that are enabled and not cooling down for this exact
@@ -69,7 +128,7 @@ impl Repository {
               AND h.is_stream = ?
              WHERE c.status = 1
                AND (h.cooldown_until IS NULL OR h.cooldown_until <= ?)
-             ORDER BY c.priority DESC, c.weight DESC",
+             ORDER BY COALESCE(c.last_probe_ok, 1) DESC, c.priority DESC, c.weight DESC",
         )
         .bind(endpoint)
         .bind(i64::from(is_stream))
@@ -1595,15 +1654,16 @@ impl Repository {
         let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
         let today_prefix = format!("{}%", today);
 
-        let today_requests: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM request_logs WHERE created_at LIKE ?")
-                .bind(&today_prefix)
-                .fetch_one(&self.pool)
-                .await
-                .unwrap_or(0);
+        let today_requests: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM request_logs WHERE created_at LIKE ? AND is_probe = 0",
+        )
+        .bind(&today_prefix)
+        .fetch_one(&self.pool)
+        .await
+        .unwrap_or(0);
 
         let today_total_tokens: i64 = sqlx::query_scalar(
-            "SELECT COALESCE(SUM(total_tokens), 0) FROM request_logs WHERE created_at LIKE ?",
+            "SELECT COALESCE(SUM(total_tokens), 0) FROM request_logs WHERE created_at LIKE ? AND is_probe = 0",
         )
         .bind(&today_prefix)
         .fetch_one(&self.pool)
@@ -1611,7 +1671,7 @@ impl Repository {
         .unwrap_or(0);
 
         let today_cached_tokens: i64 = sqlx::query_scalar(
-            "SELECT COALESCE(SUM(cached_tokens), 0) FROM request_logs WHERE created_at LIKE ?",
+            "SELECT COALESCE(SUM(cached_tokens), 0) FROM request_logs WHERE created_at LIKE ? AND is_probe = 0",
         )
         .bind(&today_prefix)
         .fetch_one(&self.pool)
@@ -1619,24 +1679,26 @@ impl Repository {
         .unwrap_or(0);
 
         let today_prompt_tokens: i64 = sqlx::query_scalar(
-            "SELECT COALESCE(SUM(prompt_tokens), 0) FROM request_logs WHERE created_at LIKE ?",
+            "SELECT COALESCE(SUM(prompt_tokens), 0) FROM request_logs WHERE created_at LIKE ? AND is_probe = 0",
         )
         .bind(&today_prefix)
         .fetch_one(&self.pool)
         .await
         .unwrap_or(0);
 
-        let total_cached_tokens: i64 =
-            sqlx::query_scalar("SELECT COALESCE(SUM(cached_tokens), 0) FROM request_logs")
-                .fetch_one(&self.pool)
-                .await
-                .unwrap_or(0);
+        let total_cached_tokens: i64 = sqlx::query_scalar(
+            "SELECT COALESCE(SUM(cached_tokens), 0) FROM request_logs WHERE is_probe = 0",
+        )
+        .fetch_one(&self.pool)
+        .await
+        .unwrap_or(0);
 
-        let total_prompt_tokens: i64 =
-            sqlx::query_scalar("SELECT COALESCE(SUM(prompt_tokens), 0) FROM request_logs")
-                .fetch_one(&self.pool)
-                .await
-                .unwrap_or(0);
+        let total_prompt_tokens: i64 = sqlx::query_scalar(
+            "SELECT COALESCE(SUM(prompt_tokens), 0) FROM request_logs WHERE is_probe = 0",
+        )
+        .fetch_one(&self.pool)
+        .await
+        .unwrap_or(0);
 
         let active_channels: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM channels WHERE status = 1")
@@ -1668,19 +1730,21 @@ impl Repository {
             .await
             .unwrap_or(0);
 
-        let total_requests: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM request_logs")
-            .fetch_one(&self.pool)
-            .await
-            .unwrap_or(0);
-
-        let total_tokens: i64 =
-            sqlx::query_scalar("SELECT COALESCE(SUM(total_tokens), 0) FROM request_logs")
+        let total_requests: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM request_logs WHERE is_probe = 0")
                 .fetch_one(&self.pool)
                 .await
                 .unwrap_or(0);
 
+        let total_tokens: i64 = sqlx::query_scalar(
+            "SELECT COALESCE(SUM(total_tokens), 0) FROM request_logs WHERE is_probe = 0",
+        )
+        .fetch_one(&self.pool)
+        .await
+        .unwrap_or(0);
+
         let avg_latency: f64 = sqlx::query_scalar(
-            "SELECT COALESCE(AVG(duration_ms), 0) FROM request_logs WHERE created_at LIKE ?",
+            "SELECT COALESCE(AVG(duration_ms), 0) FROM request_logs WHERE created_at LIKE ? AND is_probe = 0",
         )
         .bind(&today_prefix)
         .fetch_one(&self.pool)
@@ -1738,7 +1802,7 @@ impl Repository {
 
     pub async fn get_channel_stats(&self) -> Result<Vec<ChannelStats>, sqlx::Error> {
         sqlx::query_as::<_, ChannelStats>(
-            "SELECT\n                r.channel_id as channel_id,\n                COUNT(*) as total_calls,\n                SUM(CASE WHEN r.status_code >= 200 AND r.status_code < 300 THEN 1 ELSE 0 END) as success_calls,\n                SUM(CASE WHEN r.status_code >= 200 AND r.status_code < 300 THEN 0 ELSE 1 END) as failed_calls,\n                COALESCE(SUM(r.total_tokens), 0) as total_tokens,\n                COALESCE(SUM(r.prompt_tokens), 0) as prompt_tokens,\n                COALESCE(SUM(r.completion_tokens), 0) as completion_tokens,\n                COALESCE(AVG(r.duration_ms), 0) as avg_latency_ms,\n                MAX(r.created_at) as last_call_at\n            FROM request_logs r\n            WHERE r.channel_id IS NOT NULL\n            GROUP BY r.channel_id"
+            "SELECT\n                r.channel_id as channel_id,\n                COUNT(*) as total_calls,\n                SUM(CASE WHEN r.status_code >= 200 AND r.status_code < 300 THEN 1 ELSE 0 END) as success_calls,\n                SUM(CASE WHEN r.status_code >= 200 AND r.status_code < 300 THEN 0 ELSE 1 END) as failed_calls,\n                COALESCE(SUM(r.total_tokens), 0) as total_tokens,\n                COALESCE(SUM(r.prompt_tokens), 0) as prompt_tokens,\n                COALESCE(SUM(r.completion_tokens), 0) as completion_tokens,\n                COALESCE(AVG(r.duration_ms), 0) as avg_latency_ms,\n                MAX(r.created_at) as last_call_at\n            FROM request_logs r\n            WHERE r.channel_id IS NOT NULL AND r.is_probe = 0\n            GROUP BY r.channel_id"
         )
         .fetch_all(&self.pool)
         .await
@@ -1746,7 +1810,7 @@ impl Repository {
 
     pub async fn get_api_key_stats(&self) -> Result<Vec<ApiKeyStats>, sqlx::Error> {
         sqlx::query_as::<_, ApiKeyStats>(
-            "SELECT\n                r.api_key_id as api_key_id,\n                COUNT(*) as total_calls,\n                SUM(CASE WHEN r.status_code >= 200 AND r.status_code < 300 THEN 1 ELSE 0 END) as success_calls,\n                SUM(CASE WHEN r.status_code >= 200 AND r.status_code < 300 THEN 0 ELSE 1 END) as failed_calls,\n                COALESCE(SUM(r.total_tokens), 0) as total_tokens,\n                COALESCE(SUM(r.prompt_tokens), 0) as prompt_tokens,\n                COALESCE(SUM(r.completion_tokens), 0) as completion_tokens,\n                COALESCE(SUM(r.cached_tokens), 0) as cached_tokens,\n                COALESCE(AVG(r.duration_ms), 0) as avg_latency_ms,\n                MAX(r.created_at) as last_call_at\n            FROM request_logs r\n            WHERE r.api_key_id IS NOT NULL\n            GROUP BY r.api_key_id"
+            "SELECT\n                r.api_key_id as api_key_id,\n                COUNT(*) as total_calls,\n                SUM(CASE WHEN r.status_code >= 200 AND r.status_code < 300 THEN 1 ELSE 0 END) as success_calls,\n                SUM(CASE WHEN r.status_code >= 200 AND r.status_code < 300 THEN 0 ELSE 1 END) as failed_calls,\n                COALESCE(SUM(r.total_tokens), 0) as total_tokens,\n                COALESCE(SUM(r.prompt_tokens), 0) as prompt_tokens,\n                COALESCE(SUM(r.completion_tokens), 0) as completion_tokens,\n                COALESCE(SUM(r.cached_tokens), 0) as cached_tokens,\n                COALESCE(AVG(r.duration_ms), 0) as avg_latency_ms,\n                MAX(r.created_at) as last_call_at\n            FROM request_logs r\n            WHERE r.api_key_id IS NOT NULL AND r.is_probe = 0\n            GROUP BY r.api_key_id"
         )
         .fetch_all(&self.pool)
         .await
@@ -1762,7 +1826,7 @@ impl Repository {
         sqlx::query_as::<_, LogStats>(
             "SELECT substr(created_at, 1, 10) as date, COUNT(*) as count, COALESCE(SUM(total_tokens), 0) as total_tokens
              FROM request_logs
-             WHERE created_at >= ?
+             WHERE created_at >= ? AND is_probe = 0
              GROUP BY date
              ORDER BY date DESC"
         )
@@ -1784,6 +1848,7 @@ impl Repository {
                 ROUND(CAST(SUM(CASE WHEN status_code >= 200 AND status_code < 300 THEN 1.0 ELSE 0.0 END) AS REAL) / COUNT(*), 4) as success_rate,
                 COALESCE(AVG(duration_ms), 0) as avg_latency_ms
             FROM request_logs
+            WHERE is_probe = 0
             GROUP BY model
             ORDER BY total_tokens DESC
         "#;
@@ -1809,7 +1874,7 @@ impl Repository {
                 COALESCE(SUM(total_tokens), 0) as total_tokens,
                 COUNT(*) as request_count
             FROM request_logs
-            WHERE created_at >= ?
+            WHERE created_at >= ? AND is_probe = 0
             GROUP BY hour, model
             ORDER BY hour ASC
         "#;

--- a/src-tauri/src/endpoint_executor/driver.rs
+++ b/src-tauri/src/endpoint_executor/driver.rs
@@ -161,6 +161,9 @@ async fn record_channel_mode_outcome(
 ) {
     let outcome = match result {
         crate::core::attempt::AttemptResult::Success(_) => {
+            // 被动反哺（C-04）：真实请求传输成功 → 立即恢复渠道的主动探测
+            // 健康标记（与 mode_health 的成功清除正交，各管各的表）。
+            repo.mark_probe_ok(channel_id);
             repo.record_channel_mode_success(channel_id, endpoint, is_stream)
                 .await
         }
@@ -2046,6 +2049,9 @@ mod tests {
             updated_at: "2026-01-01T00:00:00Z".into(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 

--- a/src-tauri/src/endpoint_executor/integration_tests.rs
+++ b/src-tauri/src/endpoint_executor/integration_tests.rs
@@ -104,6 +104,9 @@ fn channel(
         updated_at: now(),
         last_test_at: None,
         last_test_ok: None,
+        last_probe_at: None,
+        last_probe_ok: None,
+        probe_latency_ms: None,
     }
 }
 

--- a/src-tauri/src/endpoint_executor/mock_tests.rs
+++ b/src-tauri/src/endpoint_executor/mock_tests.rs
@@ -182,6 +182,9 @@ fn channel(base_url: &str, api_key: &str) -> Channel {
         updated_at: "2026-01-01T00:00:00Z".into(),
         last_test_at: None,
         last_test_ok: None,
+        last_probe_at: None,
+        last_probe_ok: None,
+        probe_latency_ms: None,
     }
 }
 

--- a/src-tauri/src/health_probe.rs
+++ b/src-tauri/src/health_probe.rs
@@ -1,0 +1,305 @@
+//! 渠道主动健康探测（C-04）：后台循环对启用中的 API 渠道发廉价探测
+//! （GET {base_url}/models，带渠道 Key，短超时），结果落渠道探测列并记
+//! `is_probe=1` 请求日志。探测失败的渠道在候选排序中**沉底不剔除**——
+//! 保守策略，误杀渠道的代价高于排序损失。OAuth/Auth 账号渠道零探测
+//! （账号表不参与本循环，成本与配额敏感）。
+//!
+//! 与既有 `channel_mode_health` 被动冷却**正交**：那是请求驱动的
+//! （渠道×端点×流式）模式级冷却；本模块是渠道级的主动信号，
+//! GET /models 可达 ≠ 聊天模式健康，互不写对方的表。
+
+use crate::db::repository::Repository;
+use crate::settings_store::SettingsStore;
+use sqlx::SqlitePool;
+use std::time::Duration;
+
+const DEFAULT_INTERVAL_SECS: u64 = 300;
+/// 探测超时：比普通请求更严——探测的意义就是快速判定可达性。
+const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// 单渠道探测结果。
+#[derive(Debug, Clone, Copy)]
+pub struct ProbeOutcome {
+    pub ok: bool,
+    pub latency_ms: i64,
+}
+
+/// 对单个渠道发一次廉价探测。GET {base_url}/models（2xx 即健康）。
+pub async fn probe_channel(
+    client: &reqwest::Client,
+    base_url: &str,
+    api_key: &str,
+) -> ProbeOutcome {
+    let url = format!("{}/models", base_url.trim_end_matches('/'));
+    let started = std::time::Instant::now();
+    let ok = client
+        .get(&url)
+        .bearer_auth(api_key)
+        .timeout(PROBE_TIMEOUT)
+        .send()
+        .await
+        .map(|response| response.status().is_success())
+        .unwrap_or(false);
+    ProbeOutcome {
+        ok,
+        latency_ms: started.elapsed().as_millis() as i64,
+    }
+}
+
+/// 单轮探测步骤（测试与循环共用）：探测全部启用渠道 → 写探测列 + is_probe 日志行。
+/// 探测关闭（`probe.enabled=false`）时零网络请求零写库。
+pub async fn probe_step(
+    pool: &SqlitePool,
+    settings: &SettingsStore,
+) -> Vec<(String, ProbeOutcome)> {
+    if !settings.get_bool("probe.enabled", true) {
+        return Vec::new();
+    }
+    let repo = Repository::new(pool.clone());
+    let channels = match repo.get_enabled_channels().await {
+        Ok(channels) => channels,
+        Err(error) => {
+            tracing::warn!("[探测] 拉取启用渠道失败: {error}");
+            return Vec::new();
+        }
+    };
+    let client = reqwest::Client::new();
+    let mut outcomes = Vec::new();
+    for channel in channels {
+        let outcome = probe_channel(&client, &channel.base_url, &channel.api_key).await;
+        tracing::debug!(
+            "[探测] 渠道 {} ({}) -> ok={} latency={}ms",
+            channel.name,
+            channel.id,
+            outcome.ok,
+            outcome.latency_ms
+        );
+        if let Err(error) = repo
+            .record_channel_probe(
+                &channel.id,
+                &channel.name,
+                outcome,
+                &crate::db::models::now_iso(),
+            )
+            .await
+        {
+            tracing::warn!("[探测] 写入渠道 {} 探测结果失败: {error}", channel.id);
+        }
+        outcomes.push((channel.id, outcome));
+    }
+    outcomes
+}
+
+/// 后台探测循环：默认 300s 一轮，可整体关闭（关闭时零后台流量）。
+pub async fn run_probe_loop(pool: SqlitePool, settings: SettingsStore) {
+    loop {
+        let interval = Duration::from_secs(
+            settings
+                .get_u64("probe.interval_secs", DEFAULT_INTERVAL_SECS)
+                .max(30),
+        );
+        let outcomes = probe_step(&pool, &settings).await;
+        if !outcomes.is_empty() {
+            let failed = outcomes.iter().filter(|(_, o)| !o.ok).count();
+            if failed > 0 {
+                tracing::info!(
+                    "[探测] 本轮 {} 渠道，{} 个不健康（排序沉底）",
+                    outcomes.len(),
+                    failed
+                );
+            }
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn memory_db() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    fn settings_at(dir: &std::path::Path, enabled: bool) -> SettingsStore {
+        let store = SettingsStore::file(dir.join("settings.json"));
+        store
+            .set_many(&[("probe.enabled".to_string(), serde_json::json!(enabled))])
+            .unwrap();
+        store
+    }
+
+    async fn seed_channel(pool: &SqlitePool, id: &str, base_url: &str) {
+        sqlx::query(
+            "INSERT INTO channels (id, name, type, base_url, api_key, models, status, priority, \
+             weight, config, model_mapping, timeout_secs, identity_revision, created_at, updated_at) \
+             VALUES (?, ?, 'openai', ?, 'sk-x', '[]', 1, 1, 1, '{}', '{}', 60, 0, ?, ?)",
+        )
+        .bind(id)
+        .bind(id)
+        .bind(base_url)
+        .bind(crate::db::models::now_iso())
+        .bind(crate::db::models::now_iso())
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn mock_models_endpoint() -> String {
+        let app = axum::Router::new().route("/models", axum::routing::get(|| async { "[]" }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn probe_step_updates_columns_and_writes_probe_logs() {
+        let pool = memory_db().await;
+        let dir = std::env::temp_dir().join(format!("waliapi-probe-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let settings = settings_at(&dir, true);
+
+        let healthy_base = mock_models_endpoint().await;
+        seed_channel(&pool, "ch-ok", &healthy_base).await;
+        // 不可达端口（保留地址，必然连接失败）
+        seed_channel(&pool, "ch-bad", "http://127.0.0.1:1").await;
+        let outcomes = probe_step(&pool, &settings).await;
+        assert_eq!(outcomes.len(), 2, "两个启用渠道都应被探测");
+
+        let row = sqlx::query_as::<_, (Option<i64>, Option<i64>)>(
+            "SELECT last_probe_ok, probe_latency_ms FROM channels WHERE id = 'ch-ok'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0, Some(1), "健康渠道 last_probe_ok=1");
+
+        let row = sqlx::query_as::<_, (Option<i64>, Option<i64>)>(
+            "SELECT last_probe_ok, probe_latency_ms FROM channels WHERE id = 'ch-bad'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0, Some(0), "不可达渠道 last_probe_ok=0");
+
+        // is_probe 日志行：每渠道一条
+        let probes: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM request_logs WHERE is_probe = 1")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(probes, 2, "每个被探测渠道应记一条 is_probe 日志");
+        let mode: String =
+            sqlx::query_scalar("SELECT mode FROM request_logs WHERE is_probe = 1 LIMIT 1")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(mode, "probe");
+    }
+
+    #[tokio::test]
+    async fn probe_disabled_means_zero_traffic_and_writes() {
+        let pool = memory_db().await;
+        let dir = std::env::temp_dir().join(format!("waliapi-probe-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let settings = settings_at(&dir, false);
+
+        let base = mock_models_endpoint().await;
+        seed_channel(&pool, "ch-x", &base).await;
+
+        let outcomes = probe_step(&pool, &settings).await;
+        assert!(outcomes.is_empty(), "关闭时零探测");
+        let probes: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM request_logs WHERE is_probe = 1")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(probes, 0, "关闭时零日志写入");
+        let never: Option<i64> =
+            sqlx::query_scalar("SELECT last_probe_ok FROM channels WHERE id = 'ch-x'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(never.is_none(), "关闭时探测列保持 NULL（从未探测）");
+    }
+
+    #[tokio::test]
+    async fn unhealthy_channels_sink_in_candidate_ordering() {
+        let pool = memory_db().await;
+        let repo = Repository::new(pool.clone());
+        // 高优先级但探测失败 / 中优先级从未探测 / 低优先级探测健康
+        for (id, priority) in [("sink", 9), ("mid", 5), ("ok", 1)] {
+            sqlx::query(
+                "INSERT INTO channels (id, name, type, base_url, api_key, models, status, priority, \
+                 weight, config, model_mapping, timeout_secs, identity_revision, created_at, updated_at) \
+                 VALUES (?, ?, 'openai', 'http://127.0.0.1:1', 'sk-x', '[]', 1, ?, 1, '{}', '{}', 60, 0, ?, ?)",
+            )
+            .bind(id)
+            .bind(id)
+            .bind(priority)
+            .bind(crate::db::models::now_iso())
+            .bind(crate::db::models::now_iso())
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+        sqlx::query("UPDATE channels SET last_probe_ok = 0 WHERE id = 'sink'")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE channels SET last_probe_ok = 1 WHERE id = 'ok'")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let ordered = repo.get_enabled_channels().await.unwrap();
+        let ids: Vec<&str> = ordered.iter().map(|c| c.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["mid", "ok", "sink"],
+            "探测失败渠道沉底（不剔除）；健康档内按优先级/权重，从未探测视为健康"
+        );
+    }
+
+    #[tokio::test]
+    async fn usage_stats_exclude_probe_rows() {
+        let pool = memory_db().await;
+        let repo = Repository::new(pool.clone());
+        let now = crate::db::models::now_iso();
+        // 一条正常请求行 + 一条探测行（model 都为 m）
+        for (model, is_probe) in [("m", 0), ("m", 1)] {
+            sqlx::query(
+                "INSERT INTO request_logs (id, seq, model, mode, status_code, duration_ms, \
+                 is_stream, is_retry, created_at, risk_level, security_action, upstream_type, \
+                 is_probe, total_tokens) \
+                 VALUES (?, (SELECT COALESCE(MAX(seq), 0) + 1 FROM request_logs), ?, 'chat', 200, \
+                 10, 0, 0, ?, 'low', 'audit', 'channel', ?, 100)",
+            )
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(model)
+            .bind(&now)
+            .bind(is_probe)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let model_stats = repo.get_model_stats().await.unwrap();
+        let row = model_stats
+            .iter()
+            .find(|s| s.model == "m")
+            .expect("正常行应计入模型统计");
+        assert_eq!(
+            row.request_count, 1,
+            "探测行不计入用量统计（is_probe=0 过滤）"
+        );
+
+        let dashboard = repo.get_dashboard_stats().await.unwrap();
+        assert_eq!(dashboard.total_requests, 1, "仪表盘请求数排除探测行");
+    }
+}

--- a/src-tauri/src/health_probe.rs
+++ b/src-tauri/src/health_probe.rs
@@ -302,4 +302,90 @@ mod tests {
         let dashboard = repo.get_dashboard_stats().await.unwrap();
         assert_eq!(dashboard.total_requests, 1, "仪表盘请求数排除探测行");
     }
+
+    /// 被动反哺：探测失败的渠道经一次 mark_probe_ok 立即恢复排序位
+    /// （验收标准「一次真实请求成功 → 恢复正常排序」）。
+    #[tokio::test]
+    async fn mark_probe_ok_recovers_ordering_after_real_success() {
+        let pool = memory_db().await;
+        let repo = Repository::new(pool.clone());
+        for (id, priority) in [("sink", 9), ("healthy", 1)] {
+            sqlx::query(
+                "INSERT INTO channels (id, name, type, base_url, api_key, models, status, priority, \
+                 weight, config, model_mapping, timeout_secs, identity_revision, created_at, updated_at) \
+                 VALUES (?, ?, 'openai', 'http://127.0.0.1:1', 'sk-x', '[]', 1, ?, 1, '{}', '{}', 60, 0, ?, ?)",
+            )
+            .bind(id)
+            .bind(id)
+            .bind(priority)
+            .bind(crate::db::models::now_iso())
+            .bind(crate::db::models::now_iso())
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+        sqlx::query("UPDATE channels SET last_probe_ok = 0 WHERE id = 'sink'")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // 反哺前：sink 沉底
+        let ids: Vec<String> = repo
+            .get_enabled_channels()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
+        assert_eq!(ids, vec!["healthy", "sink"]);
+
+        // 真实请求成功路径调用的反哺 → 立即恢复高优先级位
+        repo.mark_probe_ok("sink").await;
+        let ids: Vec<String> = repo
+            .get_enabled_channels()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
+        assert_eq!(ids, vec!["sink", "healthy"], "被动反哺后应恢复优先级排序");
+    }
+
+    /// 两轨覆盖：driver 轨入口的 get_enabled_channels_for_mode 同样吃沉底排序键
+    /// （且与 mode_health 冷却并存时，冷却剔除优先、健康排序作用于剩余候选）。
+    #[tokio::test]
+    async fn mode_query_also_sinks_unhealthy_candidates() {
+        let pool = memory_db().await;
+        let repo = Repository::new(pool.clone());
+        for (id, priority, probe_ok) in [("hot", 9, 0), ("mid", 5, 1), ("low", 1, 1)] {
+            sqlx::query(
+                "INSERT INTO channels (id, name, type, base_url, api_key, models, status, priority, \
+                 weight, config, model_mapping, timeout_secs, identity_revision, created_at, updated_at, \
+                 last_probe_ok) \
+                 VALUES (?, ?, 'openai', 'http://127.0.0.1:1', 'sk-x', '[]', 1, ?, 1, '{}', '{}', 60, 0, ?, ?, ?)",
+            )
+            .bind(id)
+            .bind(id)
+            .bind(priority)
+            .bind(crate::db::models::now_iso())
+            .bind(crate::db::models::now_iso())
+            .bind(probe_ok)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let ids: Vec<String> = repo
+            .get_enabled_channels_for_mode("chat_completions", false, &crate::db::models::now_iso())
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["mid", "low", "hot"],
+            "for_mode 查询同样沉底探测失败渠道（两轨一致的排序语义）"
+        );
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ pub mod commands;
 pub mod core;
 pub mod db;
 mod endpoint_executor;
+pub mod health_probe;
 mod protocol;
 #[cfg(test)]
 mod rollout_integration_tests;
@@ -238,6 +239,12 @@ pub fn run() {
 
                 crate::audit_log::apply_settings(&state.settings);
                 tauri::async_runtime::spawn(crate::audit_log::run_maintenance_loop(
+                    state.db.pool.clone(),
+                    state.settings.clone(),
+                ));
+
+                // 渠道主动健康探测（默认开启 300s 一轮，可整体关闭）
+                tauri::async_runtime::spawn(crate::health_probe::run_probe_loop(
                     state.db.pool.clone(),
                     state.settings.clone(),
                 ));

--- a/src-tauri/src/rollout_integration_tests.rs
+++ b/src-tauri/src/rollout_integration_tests.rs
@@ -360,6 +360,9 @@ fn channel(
         updated_at: now_iso(),
         last_test_at: None,
         last_test_ok: None,
+        last_probe_at: None,
+        last_probe_ok: None,
+        probe_latency_ms: None,
     }
 }
 

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -4502,6 +4502,9 @@ mod list_models_tests {
             updated_at: "2026-01-01T00:00:00.000Z".to_string(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 

--- a/src-tauri/src/services/channel_test.rs
+++ b/src-tauri/src/services/channel_test.rs
@@ -514,6 +514,9 @@ fn draft_channel(input: &DraftChannelTestInput, api_key: &str, timeout_secs: i64
         updated_at: now_iso(),
         last_test_at: None,
         last_test_ok: None,
+        last_probe_at: None,
+        last_probe_ok: None,
+        probe_latency_ms: None,
     }
 }
 
@@ -1868,6 +1871,9 @@ data: {"type":"message_stop"}
             updated_at: now_iso(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 
@@ -1994,6 +2000,9 @@ data: {"type":"message_stop"}
             updated_at: now_iso(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         };
         insert_channel(&pool, &channel).await;
         let repo = Repository::new(pool);

--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -120,6 +120,12 @@ pub async fn run(cfg: WebServerConfig) -> Result<(), String> {
         state.settings.clone(),
     ));
 
+    // 渠道主动健康探测（默认开启 300s 一轮，可整体关闭）
+    tauri::async_runtime::spawn(crate::health_probe::run_probe_loop(
+        state.db.pool.clone(),
+        state.settings.clone(),
+    ));
+
     tauri::async_runtime::spawn(crate::auth_provider::maintenance::run_maintenance_loop(
         auth_service,
     ));

--- a/src/pages/ChannelsPage.tsx
+++ b/src/pages/ChannelsPage.tsx
@@ -593,6 +593,18 @@ export function ChannelsPage() {
                     )}
 
                     {/* 最近测试 */}
+                    {ch.last_probe_ok !== null && (
+                      <div className="flex items-center gap-2 text-xs text-slate-500">
+                        <span className="text-slate-400">健康探测:</span>
+                        <span
+                          className={`inline-block h-2 w-2 rounded-full ${ch.last_probe_ok ? "bg-emerald-500" : "bg-red-500"}`}
+                          title={ch.last_probe_ok ? "探测正常" : "探测失败（候选排序沉底）"}
+                        />
+                        <span>{ch.last_probe_ok ? "正常" : "异常"}</span>
+                        {ch.probe_latency_ms !== null && <span className="text-slate-400">{ch.probe_latency_ms}ms</span>}
+                        {ch.last_probe_at && <span>{formatTime(ch.last_probe_at)}</span>}
+                      </div>
+                    )}
                     {ch.last_test_at && (
                       <div className="flex items-center gap-2 text-xs text-slate-500">
                         <span className="text-slate-400">最近测试:</span>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -610,6 +610,34 @@ export function SettingsPage() {
             </div>
           </div>
           <div>
+            <h3 className="mb-3 text-sm font-medium text-muted-foreground">渠道健康探测</h3>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <label className="surface-soft flex items-center justify-between rounded-2xl px-4 py-4">
+                <div>
+                  <div className="text-sm font-medium">启用主动探测</div>
+                  <p className="text-xs text-muted-foreground">后台定期对启用渠道发 GET /models 廉价探测；失败渠道候选排序沉底（不剔除）；关闭时零后台流量。Auth 账号渠道永不探测。</p>
+                </div>
+                <input
+                  type="checkbox"
+                  checked={settings.probe_enabled}
+                  onChange={e => setSettings({ ...settings, probe_enabled: e.target.checked })}
+                  className="h-5 w-5"
+                />
+              </label>
+              <div>
+                <label className="mb-2 block text-sm font-medium">探测间隔（秒）</label>
+                <input
+                  type="number"
+                  min={30}
+                  value={settings.probe_interval_secs}
+                  onChange={e => setSettings({ ...settings, probe_interval_secs: Number(e.target.value) })}
+                  className={inputCls}
+                />
+                <p className="mt-1 text-xs text-muted-foreground">默认 300 秒；最短 30 秒。探测请求记入请求日志（is_probe 标记），不计入用量统计。</p>
+              </div>
+            </div>
+          </div>
+          <div>
             <h3 className="mb-3 text-sm font-medium text-muted-foreground">路由设置</h3>
             <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
               <label className="surface-soft flex items-center justify-between rounded-2xl px-4 py-4">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,6 +43,10 @@ export interface Channel {
   updated_at: string;
   last_test_at: string | null;
   last_test_ok: number | null;
+  /** 主动健康探测（迁移 033）：探测列优先展示，无探测数据回退手动测试列。 */
+  last_probe_at: string | null;
+  last_probe_ok: number | null;
+  probe_latency_ms: number | null;
   /** Multi-key: extra API keys (masked in DTO, use getChannelExtraKeys for full). */
   extra_keys: ChannelKey[];
 }
@@ -432,6 +436,9 @@ export interface Settings {
   ocr_dpi: number;
   log_detail_level: "basic" | "detailed" | string;
   log_retention_days: number;
+  // 渠道主动健康探测
+  probe_enabled: boolean;
+  probe_interval_secs: number;
 }
 
 // Security rule types


### PR DESCRIPTION
Closes #87

## 开始原因

mode_health（020）被动冷却已存在，本 PR 补**主动**探测：上游恢复后不再拿第一个用户请求试错。冷却语义零改动（GET /models 可达 ≠ 聊天模式健康，正交）。

## 方案

- 后台循环（默认 300s、`probe.enabled` 可关、最短 30s）：仅 API 渠道 `GET {base_url}/models`（带 Key、10s 超时）；**Auth 账号渠道零探测**。
- 迁移 033：channels 探测三列（NULL=从未探测视为健康）+ `request_logs.is_probe`。
- **沉底不剔除**：两轨候选查询统一 `COALESCE(last_probe_ok, 1) DESC`（如实列出：legacy 轨不受 mode_health 冷却是上游既有现状，本 PR 排序已在两轨生效）。
- 被动反哺：真实请求成功 `mark_probe_ok` 立即恢复排序。
- 统计口径：仪表盘/日志/模型/渠道/Key/趋势全部排除 is_probe 行。
- 设置页探测区 + 渠道卡片健康点（探测优先、手动测试兜底）。

## 测试

探测步骤（mock 端点 + 不可达端口）、关闭零流量零写入、三渠道排序沉底、for_mode 沉底（两轨一致）、被动反哺恢复排序、统计排除。