### PR TITLE
feat(kb): KB 混合检索 RRF 融合（默认）+ 可选 LLM listwise 重排

### DIFF
--- a/src-tauri/src/services/knowledge/rag.rs
+++ b/src-tauri/src/services/knowledge/rag.rs
@@ -55,6 +55,8 @@ pub async fn ask_with_config(
 ) -> Result<RagAnswer, String> {
     let repo = Repository::new(pool.clone());
     let kb_repo = KbRepository::new(pool.clone());
+    // 融合模式（C-06/R3）：RRF 默认（消量纲），weighted 保留可配回退
+    let fusion_mode = retriever::FusionMode::parse(&settings.get_str("kb.fusion_mode", "rrf"));
 
     // 1. Embed the query (needed for vector and hybrid modes)
     let query_emb_opt = if search_mode != "keyword" {
@@ -86,6 +88,7 @@ pub async fn ask_with_config(
                 top_k,
                 vector_weight,
                 keyword_weight,
+                fusion_mode,
             )
             .await?
         } else {
@@ -151,10 +154,21 @@ pub async fn ask_with_config(
                 top_k,
                 vector_weight,
                 keyword_weight,
+                fusion_mode,
             )
             .await?
         }
     };
+
+    // C-06/R3 第二步：可选 LLM listwise 重排（`kb.rerank_enabled`，默认关）。
+    // 走网关自身的渠道跑渠道（proxy::handle_request，kb-internal 路由组），
+    // 重排调用的 token 消耗自动计入请求日志；失败静默回退原序（best-effort）。
+    let scored_results =
+        if settings.get_bool("kb.rerank_enabled", false) && scored_results.len() > 1 {
+            rerank_with_llm(pool, settings, kb_id, chat_model, query, scored_results).await
+        } else {
+            scored_results
+        };
 
     // Extract plain results for context building
     let results: Vec<super::models::SearchResult> =
@@ -764,5 +778,129 @@ pub async fn deep_research(
             })
         }
         Err((code, msg)) => Err(format!("Final synthesis failed ({}): {}", code, msg)),
+    }
+}
+
+// ─── C-06/R3 第二步：LLM listwise 重排 ─────────────────────────────────────
+
+/// 解析重排回复为候选顺序（纯函数）：
+/// 容忍前后杂文（截取首个 [ 到最后一个 ]）；编号越界/重复丢弃；
+/// 未出现的候选按原序补尾——保证输出恒为原候选的全排列。
+fn parse_rerank_order(reply: &str, len: usize) -> Option<Vec<usize>> {
+    let start = reply.find('[')?;
+    let end = reply.rfind(']')?;
+    if end <= start {
+        return None;
+    }
+    let parsed: Vec<i64> = serde_json::from_str(&reply[start..=end]).ok()?;
+    let mut order: Vec<usize> = Vec::with_capacity(len);
+    for index in parsed {
+        let index = index as usize;
+        if index < len && !order.contains(&index) {
+            order.push(index);
+        }
+    }
+    for i in 0..len {
+        if !order.contains(&i) {
+            order.push(i);
+        }
+    }
+    Some(order)
+}
+
+/// 可选 LLM 重排：把 top 候选拼给渠道模型打分重排（用渠道跑渠道）。
+/// 失败/关闭不影响主流程——原序返回，仅 tracing 告警。
+async fn rerank_with_llm(
+    pool: &SqlitePool,
+    settings: &crate::settings_store::SettingsStore,
+    kb_id: &str,
+    chat_model: &str,
+    query: &str,
+    candidates: Vec<retriever::ScoredSearchResult>,
+) -> Vec<retriever::ScoredSearchResult> {
+    let mut listing = String::new();
+    for (i, c) in candidates.iter().enumerate() {
+        let excerpt: String = c
+            .result
+            .content
+            .chars()
+            .take(200)
+            .collect::<String>()
+            .replace('\n', " ");
+        listing.push_str(&format!("[{}] {}: {}\n", i, c.result.filename, excerpt));
+    }
+    let prompt = format!(
+        "你是检索结果重排器。根据查询对候选片段按相关性从高到低排序。\n\n查询：{query}\n\n候选片段：\n{listing}\n只返回一个 JSON 数组，元素为候选编号、按相关性从高到低排列，例如 [2,0,1]。不要输出其他内容。"
+    );
+    let chat_request = serde_json::json!({
+        "model": chat_model,
+        "messages": [
+            {"role": "system", "content": "你是检索重排器，只输出 JSON 数组。"},
+            {"role": "user", "content": prompt}
+        ],
+        "stream": false,
+        "temperature": 0.0
+    });
+    let chat_request_str: String = serde_json::to_string(&chat_request).unwrap_or_default();
+    let proxy_result = proxy::handle_request(
+        &std::sync::Arc::new(crate::db::repository::Repository::new(pool.clone())),
+        settings,
+        "kb-rerank",
+        "RAG-rerank",
+        chat_request,
+        false,
+        Some(chat_request_str),
+        Some(format!("kb-internal_{}", kb_id)),
+        None,
+    )
+    .await;
+
+    let reply = match proxy_result {
+        Ok(result) => result
+            .body
+            .get("choices")
+            .and_then(|c| c.get(0))
+            .and_then(|c| c.get("message"))
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_str())
+            .unwrap_or("")
+            .to_string(),
+        Err(_) => String::new(),
+    };
+    match parse_rerank_order(&reply, candidates.len()) {
+        Some(order) => {
+            let mut reordered = Vec::with_capacity(candidates.len());
+            for index in order {
+                reordered.push(candidates[index].clone());
+            }
+            tracing::debug!("[RAG] LLM 重排生效（{} 候选）", reordered.len());
+            reordered
+        }
+        None => {
+            tracing::warn!("[RAG] LLM 重排回复不可解析，回退原序（相关性排序）");
+            candidates
+        }
+    }
+}
+
+#[cfg(test)]
+mod rerank_tests {
+    use super::*;
+
+    #[test]
+    fn parse_rerank_order_extracts_json_and_validates() {
+        // 纯 JSON
+        assert_eq!(parse_rerank_order("[2,0,1]", 3), Some(vec![2, 0, 1]));
+        // 前后杂文容忍
+        assert_eq!(
+            parse_rerank_order("排序结果：[1, 2, 0] 以上。", 3),
+            Some(vec![1, 2, 0])
+        );
+        // 越界丢弃 + 缺失补尾（全排列保证）
+        assert_eq!(parse_rerank_order("[5,0,5]", 3), Some(vec![0, 1, 2]));
+        assert_eq!(parse_rerank_order("[1]", 3), Some(vec![1, 0, 2]));
+        // 不可解析 → None
+        assert_eq!(parse_rerank_order("no json here", 3), None);
+        assert_eq!(parse_rerank_order("[]", 3), Some(vec![0, 1, 2]));
     }
 }

--- a/src-tauri/src/services/knowledge/retriever.rs
+++ b/src-tauri/src/services/knowledge/retriever.rs
@@ -600,6 +600,7 @@ pub async fn hybrid_search(
     top_k: usize,
     vector_weight: f32,
     keyword_weight: f32,
+    fusion_mode: FusionMode,
 ) -> Result<Vec<SearchResult>, String> {
     let scored = hybrid_search_with_details(
         pool,
@@ -609,62 +610,97 @@ pub async fn hybrid_search(
         top_k,
         vector_weight,
         keyword_weight,
+        fusion_mode,
     )
     .await?;
     Ok(scored.into_iter().map(|s| s.result).collect())
 }
 
 /// Hybrid search returning detailed score breakdowns.
-pub async fn hybrid_search_with_details(
-    pool: &SqlitePool,
-    kb_id: &str,
-    query: &str,
-    query_embedding: &[f32],
+/// 混合检索融合模式（C-06/R3）：
+/// - Rrf：倒数排名融合（只用排名，天然消两路量纲差异；默认）
+/// - Weighted：线性加权（历史行为，量纲敏感，保留可配回退）
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FusionMode {
+    Rrf,
+    Weighted,
+}
+
+impl FusionMode {
+    pub fn parse(value: &str) -> Self {
+        if value.eq_ignore_ascii_case("weighted") {
+            Self::Weighted
+        } else {
+            Self::Rrf
+        }
+    }
+}
+
+/// RRF 常数 k：排名 1 的贡献 1/(k+1)——业界惯用 60，
+/// 对 top_k 量级的候选列表区分度稳定。
+const RRF_K: f32 = 60.0;
+
+/// 融合两路检索结果（纯函数）：按 mode 计算综合分并截断 top_k。
+/// RRF 分数 = Σ 1/(k + rank)（rank 从 1 起，只在出现该 id 的路里计）；
+/// Weighted 分数 = v_score·vw + k_score·kw（历史行为原样保留）。
+pub fn fuse_scored(
+    vector_results: &[SearchResult],
+    keyword_results: &[SearchResult],
     top_k: usize,
     vector_weight: f32,
     keyword_weight: f32,
-) -> Result<Vec<ScoredSearchResult>, String> {
-    let (vector_results, keyword_results) = tokio::join!(
-        search(pool, kb_id, query_embedding, top_k * 2),
-        fts5_search(pool, kb_id, query, top_k * 2),
-    );
-
-    let vector_results = vector_results.unwrap_or_default();
-    let keyword_results = keyword_results.unwrap_or_default();
-
-    // Build lookup maps: chunk_id -> (SearchResult, raw_score)
+    mode: FusionMode,
+) -> Vec<ScoredSearchResult> {
     let mut vector_map: std::collections::HashMap<String, (SearchResult, f32)> =
         std::collections::HashMap::new();
-    for r in &vector_results {
+    for r in vector_results {
         vector_map.insert(r.chunk_id.clone(), (r.clone(), r.score));
     }
 
     let mut keyword_map: std::collections::HashMap<String, (SearchResult, f32)> =
         std::collections::HashMap::new();
-    for r in &keyword_results {
+    for r in keyword_results {
         keyword_map.insert(r.chunk_id.clone(), (r.clone(), r.score));
     }
 
-    // Collect all unique chunk IDs
     let mut all_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
     all_ids.extend(vector_map.keys().cloned());
     all_ids.extend(keyword_map.keys().cloned());
 
-    // Compute weighted scores
     let mut scored: Vec<(String, f32, Option<f32>, Option<f32>)> = Vec::new();
     for id in &all_ids {
         let v_score = vector_map.get(id).map(|(_, s)| *s);
         let k_score = keyword_map.get(id).map(|(_, s)| *s);
-        let weighted =
-            v_score.unwrap_or(0.0) * vector_weight + k_score.unwrap_or(0.0) * keyword_weight;
-        scored.push((id.clone(), weighted, v_score, k_score));
+        let final_score = match mode {
+            FusionMode::Weighted => {
+                v_score.unwrap_or(0.0) * vector_weight + k_score.unwrap_or(0.0) * keyword_weight
+            }
+            FusionMode::Rrf => {
+                // 排名在各自路内按分数降序确定（输入已排序，这里防御性重算）
+                let v_rank = vector_results
+                    .iter()
+                    .position(|r| &r.chunk_id == id)
+                    .map(|p| p + 1);
+                let k_rank = keyword_results
+                    .iter()
+                    .position(|r| &r.chunk_id == id)
+                    .map(|p| p + 1);
+                let mut score = 0.0;
+                if let Some(rank) = v_rank {
+                    score += 1.0 / (RRF_K + rank as f32);
+                }
+                if let Some(rank) = k_rank {
+                    score += 1.0 / (RRF_K + rank as f32);
+                }
+                score
+            }
+        };
+        scored.push((id.clone(), final_score, v_score, k_score));
     }
 
-    // Sort by weighted score descending
     scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     scored.truncate(top_k);
 
-    // Build final results with score breakdowns
     let mut results = Vec::with_capacity(scored.len());
     for (id, final_score, v_score, k_score) in scored {
         // Prefer vector result (has embedding metadata), fallback to keyword result
@@ -681,8 +717,35 @@ pub async fn hybrid_search_with_details(
             });
         }
     }
+    results
+}
 
-    Ok(results)
+pub async fn hybrid_search_with_details(
+    pool: &SqlitePool,
+    kb_id: &str,
+    query: &str,
+    query_embedding: &[f32],
+    top_k: usize,
+    vector_weight: f32,
+    keyword_weight: f32,
+    fusion_mode: FusionMode,
+) -> Result<Vec<ScoredSearchResult>, String> {
+    let (vector_results, keyword_results) = tokio::join!(
+        search(pool, kb_id, query_embedding, top_k * 2),
+        fts5_search(pool, kb_id, query, top_k * 2),
+    );
+
+    let vector_results = vector_results.unwrap_or_default();
+    let keyword_results = keyword_results.unwrap_or_default();
+
+    Ok(fuse_scored(
+        &vector_results,
+        &keyword_results,
+        top_k,
+        vector_weight,
+        keyword_weight,
+        fusion_mode,
+    ))
 }
 
 /// Keyword-only search using FTS5 (no vector search).
@@ -811,5 +874,90 @@ mod fts_defense_tests {
                 "查询 {query:?} 应无错返回空结果，实际: {result:?}"
             );
         }
+    }
+}
+
+// ─── C-06/R3：融合模式纯函数测试 ────────────────────────────────────────────
+#[cfg(test)]
+mod rrf_tests {
+    use super::*;
+
+    fn result(chunk_id: &str, score: f32) -> SearchResult {
+        SearchResult {
+            chunk_id: chunk_id.to_string(),
+            doc_id: "d".to_string(),
+            filename: "f.md".to_string(),
+            content: String::new(),
+            score,
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    #[test]
+    fn fusion_mode_parses_with_rrf_default() {
+        assert_eq!(FusionMode::parse("rrf"), FusionMode::Rrf);
+        assert_eq!(FusionMode::parse("RRF"), FusionMode::Rrf);
+        assert_eq!(FusionMode::parse("weighted"), FusionMode::Weighted);
+        assert_eq!(
+            FusionMode::parse("unknown"),
+            FusionMode::Rrf,
+            "未知值回退默认 RRF"
+        );
+    }
+
+    /// 量纲悬殊两路：向量分数接近 1、关键词分数微小（FTS5 bm25 常态）。
+    /// 线性加权下向量路一家独大；RRF 只看排名，两路一致认可的候选（两路都排前）
+    /// 应排到第一。
+    #[test]
+    fn rrf_beats_weighted_when_scales_are_skewed() {
+        // 两路一致认可 c_both；向量路单独强推 c_vec_only（分数最高）
+        let vector = vec![result("c_vec_only", 0.99), result("c_both", 0.97)];
+        let keyword = vec![result("c_both", 0.0007), result("c_kw_only", 0.0005)];
+
+        let weighted = fuse_scored(&vector, &keyword, 3, 0.7, 0.3, FusionMode::Weighted);
+        assert_eq!(
+            weighted[0].result.chunk_id, "c_vec_only",
+            "加权前置条件：向量量纲碾压"
+        );
+
+        let rrf = fuse_scored(&vector, &keyword, 3, 0.7, 0.3, FusionMode::Rrf);
+        assert_eq!(
+            rrf[0].result.chunk_id, "c_both",
+            "RRF 下两路都靠前的候选应排第一（排名共识优先于单路高分）"
+        );
+    }
+
+    #[test]
+    fn rrf_scores_are_rank_based_and_deterministic() {
+        let vector = vec![result("a", 0.9), result("b", 0.5)];
+        let keyword = vec![result("a", 0.1), result("b", 0.05)];
+        let fused = fuse_scored(&vector, &keyword, 2, 0.7, 0.3, FusionMode::Rrf);
+        // a: 两路 rank1 → 2/(k+1)；b: 两路 rank2 → 2/(k+2)；a > b
+        assert_eq!(fused[0].result.chunk_id, "a");
+        let expected_a = 1.0 / (60.0 + 1.0) + 1.0 / (60.0 + 1.0);
+        assert!((fused[0].result.score - expected_a).abs() < 1e-6);
+        // 分数明细保留两路原始值（可视化/调试用）
+        assert_eq!(fused[0].vector_score, Some(0.9));
+        assert_eq!(fused[0].keyword_score, Some(0.1));
+    }
+
+    #[test]
+    fn weighted_mode_preserves_historical_behavior() {
+        let vector = vec![result("a", 1.0)];
+        let keyword = vec![result("b", 1.0)];
+        let fused = fuse_scored(&vector, &keyword, 2, 0.7, 0.3, FusionMode::Weighted);
+        assert_eq!(fused[0].result.chunk_id, "a");
+        assert!((fused[0].result.score - 0.7).abs() < 1e-6);
+        assert!((fused[1].result.score - 0.3).abs() < 1e-6);
+    }
+
+    #[test]
+    fn rrf_truncates_to_top_k_and_handles_empty_lists() {
+        let vector: Vec<SearchResult> = vec![result("a", 0.9), result("b", 0.8), result("c", 0.7)];
+        assert_eq!(
+            fuse_scored(&vector, &[], 2, 0.7, 0.3, FusionMode::Rrf).len(),
+            2
+        );
+        assert!(fuse_scored(&[], &[], 5, 0.7, 0.3, FusionMode::Rrf).is_empty());
     }
 }

--- a/src-tauri/src/services/knowledge/retriever.rs
+++ b/src-tauri/src/services/knowledge/retriever.rs
@@ -905,6 +905,31 @@ mod rrf_tests {
         );
     }
 
+    /// rag_query 的实际取值表达式（settings → FusionMode）：weighted 可切回、
+    /// 未配置走默认。锁定设置存储到融合模式的接线契约。
+    #[test]
+    fn fusion_mode_settings_expression_matches_rag_query() {
+        let dir =
+            std::env::temp_dir().join(format!("waliapi-fusion-mode-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = crate::settings_store::SettingsStore::file(dir.join("settings.json"));
+
+        // 未配置 → 默认 rrf
+        let mode = FusionMode::parse(&store.get_str("kb.fusion_mode", "rrf"));
+        assert_eq!(mode, FusionMode::Rrf);
+
+        // 配置 weighted → 可切回
+        store
+            .set_many(&[("kb.fusion_mode".to_string(), serde_json::json!("weighted"))])
+            .unwrap();
+        let mode = FusionMode::parse(&store.get_str("kb.fusion_mode", "rrf"));
+        assert_eq!(
+            mode,
+            FusionMode::Weighted,
+            "设置项 weighted 必须切回线性加权"
+        );
+    }
+
     /// 量纲悬殊两路：向量分数接近 1、关键词分数微小（FTS5 bm25 常态）。
     /// 线性加权下向量路一家独大；RRF 只看排名，两路一致认可的候选（两路都排前）
     /// 应排到第一。

--- a/src-tauri/src/services/mcp/handlers.rs
+++ b/src-tauri/src/services/mcp/handlers.rs
@@ -822,6 +822,8 @@ async fn handle_tool_call(
                     top_k,
                     vector_weight,
                     keyword_weight,
+                    // MCP 工具路径用默认融合模式（RRF）；面板路径按 kb.fusion_mode 设置
+                    retriever::FusionMode::Rrf,
                 )
                 .await?;
 


### PR DESCRIPTION
Closes #88

## 开始原因

混合检索对向量/FTS5 两路线性加权——量纲不同（余弦 ~[0,1] vs BM25 任意小正数），向量路系统性碾压。RRF 只用排名，天然消量纲，零依赖。

## 方案

- 融合抽为纯函数 `fuse_scored` + `FusionMode`：RRF（k=60）设为**默认**；weighted 保留可配（`kb.fusion_mode`，历史行为逐字节保留、测试锁定）。
- 四调用点接线：标准问答按设置项；MCP 工具路径用默认。
- 可选 LLM listwise 重排（`kb.rerank_enabled` 默认关）：经网关自身渠道打分重排（kb-internal 路由组，token 自动落账）；解析容错（越界/重复/缺失补尾恒全排列）；失败静默回退。

## 测试

量纲悬殊构造用例（RRF 排序优于加权）；RRF 确定性与明细；weighted 行为锁定；设置表达式；重排解析容错；knowledge 面 43/43。