### PR TITLE
feat(kb): KB 多轮对话查询改写（默认关闭）——指代型问题检索前置改写

### DIFF
--- a/src-tauri/migrations/034_prompt_templates.sql
+++ b/src-tauri/migrations/034_prompt_templates.sql
@@ -1,0 +1,15 @@
+-- Prompt 模板版本化（C-07）：RAG 系统提示词从源码硬编码迁移为可版本化管理。
+-- 启动时按 key 检测空表则把源码字面量逐字节写入 v1（升级后行为不变的硬保证）；
+-- 运行时按 key + active 读取，读失败回退编译期默认（双保险）。
+CREATE TABLE IF NOT EXISTS prompt_templates (
+    id TEXT PRIMARY KEY,
+    template_key TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    active INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    UNIQUE(template_key, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_prompt_templates_active
+    ON prompt_templates(template_key, active);

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod import_export;
 pub mod knowledge_base;
 pub mod log;
 pub mod log_repair;
+pub mod prompt_template;
 pub mod security;
 pub mod server;
 pub mod services;

--- a/src-tauri/src/commands/prompt_template.rs
+++ b/src-tauri/src/commands/prompt_template.rs
@@ -1,0 +1,104 @@
+//! Prompt 模板管理命令（C-07）：按 key 列版本、编辑新建版本、一键激活回滚。
+//! 变更写请求日志（mode=prompt_admin）——prompt 变更可追溯。
+
+use crate::AppState;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PromptTemplateDto {
+    pub id: String,
+    pub template_key: String,
+    pub version: i64,
+    pub content: String,
+    pub active: bool,
+    pub created_at: String,
+}
+
+/// 变更审计行（不走 create_log 漏斗：管理面操作，无正文策略语义）。
+async fn write_audit(
+    state: &std::sync::Arc<AppState>,
+    action: &str,
+    template_key: &str,
+    detail: &str,
+) {
+    let result = sqlx::query(
+        "INSERT INTO request_logs (id, seq, model, mode, status_code, duration_ms, is_stream, \
+         is_retry, created_at, risk_level, security_action, upstream_type, error_message) \
+         VALUES (?, (SELECT COALESCE(MAX(seq), 0) + 1 FROM request_logs), ?, 'prompt_admin', 200, \
+         0, 0, 0, ?, 'low', 'audit', 'admin', ?)",
+    )
+    .bind(crate::utils::id::new_id())
+    .bind(template_key)
+    .bind(crate::db::models::now_iso())
+    .bind(format!("{action}: {detail}"))
+    .execute(&state.db.pool)
+    .await;
+    if let Err(error) = result {
+        tracing::warn!("[模板] 审计行写入失败: {error}");
+    }
+}
+
+#[tauri::command]
+pub async fn list_prompt_templates(
+    state: tauri::State<'_, std::sync::Arc<AppState>>,
+) -> Result<Vec<PromptTemplateDto>, String> {
+    list_prompt_templates_impl(&state).await
+}
+
+pub async fn list_prompt_templates_impl(
+    state: &std::sync::Arc<AppState>,
+) -> Result<Vec<PromptTemplateDto>, String> {
+    let rows = crate::prompt_templates::list_templates(&state.db.pool)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(rows
+        .into_iter()
+        .map(|row| PromptTemplateDto {
+            id: row.id,
+            template_key: row.template_key,
+            version: row.version,
+            content: row.content,
+            active: row.active,
+            created_at: row.created_at,
+        })
+        .collect())
+}
+
+#[tauri::command]
+pub async fn create_prompt_template(
+    template_key: String,
+    content: String,
+    state: tauri::State<'_, std::sync::Arc<AppState>>,
+) -> Result<i64, String> {
+    create_prompt_template_impl(&template_key, &content, &state).await
+}
+
+pub async fn create_prompt_template_impl(
+    template_key: &str,
+    content: &str,
+    state: &std::sync::Arc<AppState>,
+) -> Result<i64, String> {
+    let version =
+        crate::prompt_templates::create_version(&state.db.pool, template_key, content).await?;
+    write_audit(state, "create", template_key, &format!("v{version}")).await;
+    Ok(version)
+}
+
+#[tauri::command]
+pub async fn activate_prompt_template(
+    template_key: String,
+    version: i64,
+    state: tauri::State<'_, std::sync::Arc<AppState>>,
+) -> Result<(), String> {
+    activate_prompt_template_impl(&template_key, version, &state).await
+}
+
+pub async fn activate_prompt_template_impl(
+    template_key: &str,
+    version: i64,
+    state: &std::sync::Arc<AppState>,
+) -> Result<(), String> {
+    crate::prompt_templates::activate_version(&state.db.pool, template_key, version).await?;
+    write_audit(state, "activate", template_key, &format!("v{version}")).await;
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ pub mod commands;
 pub mod core;
 pub mod db;
 mod endpoint_executor;
+pub mod prompt_templates;
 mod protocol;
 #[cfg(test)]
 mod rollout_integration_tests;
@@ -236,6 +237,10 @@ pub fn run() {
                 });
                 app_handle.manage(state.clone());
 
+                // Prompt 模板种子（C-07）：空表时写入源码字面量 v1——升级后行为逐字节不变
+                if let Err(error) = crate::prompt_templates::seed_if_empty(&state.db.pool).await {
+                    tracing::warn!("[模板] 种子写入失败（运行时回退编译期默认）: {error}");
+                }
                 crate::audit_log::apply_settings(&state.settings);
                 tauri::async_runtime::spawn(crate::audit_log::run_maintenance_loop(
                     state.db.pool.clone(),
@@ -310,6 +315,9 @@ pub fn run() {
             commands::log::delete_logs_before,
             commands::log::delete_all_logs,
             commands::log::get_log_stats,
+            commands::prompt_template::list_prompt_templates,
+            commands::prompt_template::create_prompt_template,
+            commands::prompt_template::activate_prompt_template,
             commands::log_repair::repair_stream_cancel_logs,
             commands::stats::get_dashboard_stats,
             commands::stats::get_model_stats,

--- a/src-tauri/src/prompt_templates.rs
+++ b/src-tauri/src/prompt_templates.rs
@@ -1,0 +1,413 @@
+//! Prompt 模板版本化（C-07）：RAG 系统提示词从源码硬编码迁移为可版本化管理。
+//!
+//! 兼容硬保证：启动时按 key 检测无行则把**源码字面量逐字节**写入 v1 并激活
+//! ——升级后 RAG 行为与升级前完全一致。运行时按 key + active 读取，表损坏/
+//! 清空/读取失败时回退编译期内置默认（双保险），服务不中断。
+//!
+//! 占位符校验：模板必须**恰好包含**该 key 声明的全部命名占位符（如
+//! `{query}`/`{context}`），不得包含未知占位符——防止激活坏模板导致检索
+//! 上下文注入丢失或渲染错位。
+
+use sqlx::SqlitePool;
+
+/// 模板定义：key + 允许（且必需）的命名占位符 + 编译期默认（= 源码字面量）。
+pub struct TemplateDef {
+    pub key: &'static str,
+    pub placeholders: &'static [&'static str],
+    pub builtin: &'static str,
+}
+
+pub const KEY_RAG_SYSTEM: &str = "rag_system";
+pub const KEY_RESEARCH_NEXT_QUERY: &str = "research_next_query_system";
+pub const KEY_DEEP_RESEARCH_SYSTEM: &str = "deep_research_system";
+pub const KEY_DEEP_RESEARCH_FINAL_SYSTEM: &str = "deep_research_final_system";
+pub const KEY_DEEP_RESEARCH_ROUND0: &str = "deep_research_round0";
+pub const KEY_DEEP_RESEARCH_ROUND_NEXT: &str = "deep_research_round_next";
+pub const KEY_DEEP_RESEARCH_FINAL: &str = "deep_research_final";
+
+/// 首批纳入的模板（RAG 问答 + 深度研究系列）。渠道转发类内容是用户请求的
+/// 一部分，不属于系统模板，不纳入。
+pub const TEMPLATE_DEFS: &[TemplateDef] = &[
+    TemplateDef {
+        key: KEY_RAG_SYSTEM,
+        placeholders: &[],
+        builtin: "你是 RAG 助手。基于检索到的内容回答问题。回答要准确、简洁，并标注信息来源。如果没有相关信息，请明确说明。",
+    },
+    TemplateDef {
+        key: KEY_RESEARCH_NEXT_QUERY,
+        placeholders: &[],
+        builtin: "你是一个研究助手，根据已有发现生成下一步搜索查询。只返回查询本身。",
+    },
+    TemplateDef {
+        key: KEY_DEEP_RESEARCH_SYSTEM,
+        placeholders: &[],
+        builtin: "你是深度研究助手。基于 RAG 内容进行多轮迭代研究，逐步深入分析。",
+    },
+    TemplateDef {
+        key: KEY_DEEP_RESEARCH_FINAL_SYSTEM,
+        placeholders: &[],
+        builtin: "你是深度研究助手。综合多轮研究发现，给出完整准确的回答。",
+    },
+    TemplateDef {
+        key: KEY_DEEP_RESEARCH_ROUND0,
+        placeholders: &["query", "context"],
+        builtin: r#"你是一个深度研究助手。请分析以下 RAG 内容，并给出初步发现。
+
+原始问题: {query}
+
+<knowledge_base>
+{context}
+</knowledge_base>
+
+请完成：
+1. 理解问题的核心需求
+2. 从 RAG 中提取相关信息
+3. 给出初步发现
+4. 如果信息不足，指出还需要哪些方面"#,
+    },
+    TemplateDef {
+        key: KEY_DEEP_RESEARCH_ROUND_NEXT,
+        placeholders: &["query", "findings", "context"],
+        builtin: r#"继续深度研究。
+
+原始问题: {query}
+
+已有发现:
+{findings}
+
+新检索到的内容:
+<knowledge_base>
+{context}
+</knowledge_base>
+
+请完成：
+1. 分析新内容与已有发现的关系
+2. 补充或修正之前的发现
+3. 指出是否需要继续研究"#,
+    },
+    TemplateDef {
+        key: KEY_DEEP_RESEARCH_FINAL,
+        placeholders: &["query", "findings"],
+        builtin: r#"基于多轮深度研究的发现，请综合回答原始问题。
+
+原始问题: {query}
+
+多轮研究发现:
+{findings}
+
+请综合所有发现，给出完整、准确的回答。标注信息来源。"#,
+    },
+];
+
+/// 按 key 取定义（校验与回退用）。
+pub fn def_for(key: &str) -> Option<&'static TemplateDef> {
+    TEMPLATE_DEFS.iter().find(|d| d.key == key)
+}
+
+/// 提取模板中出现的命名占位符（`{word}`，word 为 ASCII 字母数字下划线）。
+fn placeholders_in(content: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut chars = content.char_indices().peekable();
+    while let Some((i, c)) = chars.next() {
+        if c == '{' {
+            let rest = &content[i + 1..];
+            if let Some(end) = rest.find('}') {
+                let name = &rest[..end];
+                if !name.is_empty()
+                    && name
+                        .chars()
+                        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+                {
+                    out.push(name.to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// 校验模板内容：必须恰好包含声明占位符的全体（不多不少）。
+/// 缺占位符 = 渲染丢上下文；多占位符 = 渲染留残片——都拒绝激活。
+pub fn validate_template(key: &str, content: &str) -> Result<(), String> {
+    let def = def_for(key).ok_or_else(|| format!("未知模板 key: {key}"))?;
+    let mut present = placeholders_in(content);
+    present.sort();
+    let mut expected: Vec<&str> = def.placeholders.to_vec();
+    expected.sort();
+    if present == expected {
+        Ok(())
+    } else {
+        Err(format!(
+            "模板 {} 占位符不符：需要 {{{}}}/{}，实际 {{{}}}/{}",
+            key,
+            expected.join("}, {"),
+            expected.len(),
+            present.join("}, {"),
+            present.len()
+        ))
+    }
+}
+
+/// 渲染：命名占位符替换（args 必须覆盖全部声明占位符，调用侧静态保证）。
+pub fn render(template: &str, args: &[(&str, &str)]) -> String {
+    let mut out = template.to_string();
+    for (name, value) in args {
+        out = out.replace(&format!("{{{name}}}"), value);
+    }
+    out
+}
+
+/// 启动种子：按 key 检测无行则写入 v1（active）——字面量逐字节等于源码。
+pub async fn seed_if_empty(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+    for def in TEMPLATE_DEFS {
+        let exists: Option<i64> =
+            sqlx::query_scalar("SELECT 1 FROM prompt_templates WHERE template_key = ? LIMIT 1")
+                .bind(def.key)
+                .fetch_optional(pool)
+                .await?;
+        if exists.is_none() {
+            sqlx::query(
+                "INSERT INTO prompt_templates (id, template_key, version, content, active, created_at) \
+                 VALUES (?, ?, 1, ?, 1, ?)",
+            )
+            .bind(crate::utils::id::new_id())
+            .bind(def.key)
+            .bind(def.builtin)
+            .bind(crate::db::models::now_iso())
+            .execute(pool)
+            .await?;
+            tracing::info!("[模板] 种子写入 {} v1（源码字面量）", def.key);
+        }
+    }
+    Ok(())
+}
+
+/// 读取某 key 的激活模板；读取失败或无行时回退编译期默认（双保险）。
+pub async fn load(pool: &SqlitePool, key: &str) -> String {
+    match active_content(pool, key).await {
+        Ok(Some(content)) => content,
+        Ok(None) | Err(_) => def_for(key)
+            .map(|d| d.builtin.to_string())
+            .unwrap_or_default(),
+    }
+}
+
+pub async fn active_content(pool: &SqlitePool, key: &str) -> Result<Option<String>, sqlx::Error> {
+    sqlx::query_scalar::<_, String>(
+        "SELECT content FROM prompt_templates WHERE template_key = ? AND active = 1 LIMIT 1",
+    )
+    .bind(key)
+    .fetch_optional(pool)
+    .await
+}
+
+/// 全部模板行（管理页列表用，按 key/版本排序）。
+pub struct TemplateRow {
+    pub id: String,
+    pub template_key: String,
+    pub version: i64,
+    pub content: String,
+    pub active: bool,
+    pub created_at: String,
+}
+
+pub async fn list_templates(pool: &SqlitePool) -> Result<Vec<TemplateRow>, sqlx::Error> {
+    let rows = sqlx::query_as::<_, (String, String, i64, String, i64, String)>(
+        "SELECT id, template_key, version, content, active, created_at \
+         FROM prompt_templates ORDER BY template_key ASC, version DESC",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(
+            |(id, template_key, version, content, active, created_at)| TemplateRow {
+                id,
+                template_key,
+                version,
+                content,
+                active: active == 1,
+                created_at,
+            },
+        )
+        .collect())
+}
+
+/// 新建版本（inactive；下一个版本号 = 该 key 现有最大版本 + 1）。
+/// 内容先经占位符校验，非法拒绝。
+pub async fn create_version(pool: &SqlitePool, key: &str, content: &str) -> Result<i64, String> {
+    validate_template(key, content)?;
+    let next: i64 = sqlx::query_scalar(
+        "SELECT COALESCE(MAX(version), 0) + 1 FROM prompt_templates WHERE template_key = ?",
+    )
+    .bind(key)
+    .fetch_one(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+    sqlx::query(
+        "INSERT INTO prompt_templates (id, template_key, version, content, active, created_at) \
+         VALUES (?, ?, ?, ?, 0, ?)",
+    )
+    .bind(crate::utils::id::new_id())
+    .bind(key)
+    .bind(next)
+    .bind(content)
+    .bind(crate::db::models::now_iso())
+    .execute(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+    Ok(next)
+}
+
+/// 激活某版本（同 key 其余版本全部置 inactive），事务保证唯一激活。
+pub async fn activate_version(pool: &SqlitePool, key: &str, version: i64) -> Result<(), String> {
+    let exists: Option<i64> = sqlx::query_scalar(
+        "SELECT 1 FROM prompt_templates WHERE template_key = ? AND version = ? LIMIT 1",
+    )
+    .bind(key)
+    .bind(version)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+    if exists.is_none() {
+        return Err(format!("版本不存在: {key} v{version}"));
+    }
+    let mut tx = pool.begin().await.map_err(|e| e.to_string())?;
+    sqlx::query("UPDATE prompt_templates SET active = 0 WHERE template_key = ?")
+        .bind(key)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| e.to_string())?;
+    sqlx::query("UPDATE prompt_templates SET active = 1 WHERE template_key = ? AND version = ?")
+        .bind(key)
+        .bind(version)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| e.to_string())?;
+    tx.commit().await.map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn memory_db() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn seed_writes_builtin_literals_verbatim() {
+        let pool = memory_db().await;
+        seed_if_empty(&pool).await.unwrap();
+        for def in TEMPLATE_DEFS {
+            let stored = active_content(&pool, def.key)
+                .await
+                .unwrap()
+                .expect("种子后应有激活行");
+            assert_eq!(
+                stored, def.builtin,
+                "{} 的种子必须与源码字面量逐字节一致",
+                def.key
+            );
+        }
+        // 幂等：再次种子不重复写、不改版本
+        seed_if_empty(&pool).await.unwrap();
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM prompt_templates")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count, TEMPLATE_DEFS.len() as i64, "重复种子零新增");
+    }
+
+    #[tokio::test]
+    async fn activate_switches_and_rolls_back_immediately() {
+        let pool = memory_db().await;
+        seed_if_empty(&pool).await.unwrap();
+        let v2 = create_version(&pool, KEY_RAG_SYSTEM, "测试版系统词 v2")
+            .await
+            .unwrap();
+        assert_eq!(v2, 2);
+        // 新版本未激活前仍是 v1
+        assert_eq!(
+            active_content(&pool, KEY_RAG_SYSTEM)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some(def_for(KEY_RAG_SYSTEM).unwrap().builtin)
+        );
+        activate_version(&pool, KEY_RAG_SYSTEM, v2).await.unwrap();
+        assert_eq!(
+            active_content(&pool, KEY_RAG_SYSTEM)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("测试版系统词 v2")
+        );
+        // 回滚 v1 立即生效
+        activate_version(&pool, KEY_RAG_SYSTEM, 1).await.unwrap();
+        assert_eq!(
+            active_content(&pool, KEY_RAG_SYSTEM)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some(def_for(KEY_RAG_SYSTEM).unwrap().builtin)
+        );
+    }
+
+    #[tokio::test]
+    async fn load_falls_back_to_builtin_when_table_empty_or_broken() {
+        let pool = memory_db().await;
+        // 未种子（表空）→ 回退编译期默认
+        assert_eq!(
+            load(&pool, KEY_RAG_SYSTEM).await,
+            def_for(KEY_RAG_SYSTEM).unwrap().builtin
+        );
+        // 清空激活行 → 回退
+        sqlx::query("UPDATE prompt_templates SET active = 0")
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            load(&pool, KEY_DEEP_RESEARCH_SYSTEM).await,
+            def_for(KEY_DEEP_RESEARCH_SYSTEM).unwrap().builtin
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_placeholder_templates_are_rejected() {
+        let pool = memory_db().await;
+        // 未知占位符
+        assert!(create_version(&pool, KEY_RAG_SYSTEM, "带 {unknown} 占位符")
+            .await
+            .is_err());
+        // 缺占位符（round0 需要 {query}/{context}）
+        assert!(
+            create_version(&pool, KEY_DEEP_RESEARCH_ROUND0, "缺少占位符的模板")
+                .await
+                .is_err()
+        );
+        // 占位符齐全 → 接受
+        assert!(create_version(
+            &pool,
+            KEY_DEEP_RESEARCH_ROUND0,
+            "问题 {query} 上下文 {context}"
+        )
+        .await
+        .is_ok());
+        // 未知 key 拒绝
+        assert!(create_version(&pool, "no_such_key", "x").await.is_err());
+    }
+
+    #[test]
+    fn render_replaces_named_placeholders() {
+        let out = render(
+            "Q:{query} C:{context}",
+            &[("query", "问"), ("context", "文")],
+        );
+        assert_eq!(out, "Q:问 C:文");
+        // 无占位符模板原样返回
+        assert_eq!(render("固定内容", &[]), "固定内容");
+    }
+}

--- a/src-tauri/src/prompt_templates.rs
+++ b/src-tauri/src/prompt_templates.rs
@@ -24,6 +24,7 @@ pub const KEY_DEEP_RESEARCH_FINAL_SYSTEM: &str = "deep_research_final_system";
 pub const KEY_DEEP_RESEARCH_ROUND0: &str = "deep_research_round0";
 pub const KEY_DEEP_RESEARCH_ROUND_NEXT: &str = "deep_research_round_next";
 pub const KEY_DEEP_RESEARCH_FINAL: &str = "deep_research_final";
+pub const KEY_QUERY_REWRITE: &str = "query_rewrite";
 
 /// 首批纳入的模板（RAG 问答 + 深度研究系列）。渠道转发类内容是用户请求的
 /// 一部分，不属于系统模板，不纳入。
@@ -96,6 +97,18 @@ pub const TEMPLATE_DEFS: &[TemplateDef] = &[
 {findings}
 
 请综合所有发现，给出完整、准确的回答。标注信息来源。"#,
+    },
+    TemplateDef {
+        key: KEY_QUERY_REWRITE,
+        placeholders: &["history", "query"],
+        builtin: r#"你是检索查询改写器。根据多轮对话历史，把用户的最新问题改写为独立、完整、可脱离上下文理解的检索查询。
+
+对话历史:
+{history}
+
+最新问题: {query}
+
+只输出改写后的检索查询本身，不要输出其他内容。"#,
     },
 ];
 

--- a/src-tauri/src/server/admin_routes.rs
+++ b/src-tauri/src/server/admin_routes.rs
@@ -506,6 +506,25 @@ async fn dispatch(shared: &SharedState, cmd: &str, args: Value) -> Result<Value,
             to_json(commands::log::get_log_security_findings(arg(&args, "logId")?, state).await)
         }
         "get_log_stats" => to_json(commands::log::get_log_stats(arg(&args, "days")?, state).await),
+        "list_prompt_templates" => {
+            to_json(commands::prompt_template::list_prompt_templates(state).await)
+        }
+        "create_prompt_template" => to_json(
+            commands::prompt_template::create_prompt_template(
+                arg(&args, "templateKey")?,
+                arg(&args, "content")?,
+                state,
+            )
+            .await,
+        ),
+        "activate_prompt_template" => to_json(
+            commands::prompt_template::activate_prompt_template(
+                arg(&args, "templateKey")?,
+                arg(&args, "version")?,
+                state,
+            )
+            .await,
+        ),
         "delete_log" => to_json(commands::log::delete_log(arg(&args, "id")?, state).await),
         "delete_logs_before" => {
             to_json(commands::log::delete_logs_before(arg(&args, "beforeDate")?, state).await)

--- a/src-tauri/src/services/knowledge/rag.rs
+++ b/src-tauri/src/services/knowledge/rag.rs
@@ -4,6 +4,7 @@ use super::repository::KbRepository;
 use super::retriever;
 use crate::core::proxy;
 use crate::db::repository::Repository;
+use crate::prompt_templates;
 use crate::settings_store::SettingsStore;
 use sqlx::SqlitePool;
 use std::sync::Arc;
@@ -229,11 +230,12 @@ pub async fn ask_with_config(
         context_used
     );
 
-    // 6. Call LLM via proxy
+    // 6. Call LLM via proxy（系统提示词走模板表：激活版本优先，回退编译期默认）
+    let rag_system_prompt = prompt_templates::load(pool, prompt_templates::KEY_RAG_SYSTEM).await;
     let chat_request = serde_json::json!({
         "model": chat_model,
         "messages": [
-            {"role": "system", "content": "你是 RAG 助手。基于检索到的内容回答问题。回答要准确、简洁，并标注信息来源。如果没有相关信息，请明确说明。"},
+            {"role": "system", "content": rag_system_prompt},
             {"role": "user", "content": final_prompt}
         ],
         "stream": false
@@ -499,10 +501,12 @@ pub async fn deep_research(
                     .join("\n"),
             );
 
+            let next_query_system =
+                prompt_templates::load(pool, prompt_templates::KEY_RESEARCH_NEXT_QUERY).await;
             let follow_up_request = serde_json::json!({
                 "model": chat_model,
                 "messages": [
-                    {"role": "system", "content": "你是一个研究助手，根据已有发现生成下一步搜索查询。只返回查询本身。"},
+                    {"role": "system", "content": next_query_system},
                     {"role": "user", "content": follow_up_prompt}
                 ],
                 "stream": false
@@ -566,51 +570,28 @@ pub async fn deep_research(
             .join("\n");
 
         let round_prompt = if round == 0 {
-            format!(
-                r#"你是一个深度研究助手。请分析以下 RAG 内容，并给出初步发现。
-
-原始问题: {query}
-
-<knowledge_base>
-{context}
-</knowledge_base>
-
-请完成：
-1. 理解问题的核心需求
-2. 从 RAG 中提取相关信息
-3. 给出初步发现
-4. 如果信息不足，指出还需要哪些方面"#,
-                query = query,
-                context = context,
-            )
+            let template =
+                prompt_templates::load(pool, prompt_templates::KEY_DEEP_RESEARCH_ROUND0).await;
+            prompt_templates::render(&template, &[("query", query), ("context", &context)])
         } else {
-            format!(
-                r#"继续深度研究。
-
-原始问题: {query}
-
-已有发现:
-{findings}
-
-新检索到的内容:
-<knowledge_base>
-{context}
-</knowledge_base>
-
-请完成：
-1. 分析新内容与已有发现的关系
-2. 补充或修正之前的发现
-3. 指出是否需要继续研究"#,
-                query = query,
-                findings = findings_str,
-                context = context,
+            let template =
+                prompt_templates::load(pool, prompt_templates::KEY_DEEP_RESEARCH_ROUND_NEXT).await;
+            prompt_templates::render(
+                &template,
+                &[
+                    ("query", query),
+                    ("findings", &findings_str),
+                    ("context", &context),
+                ],
             )
         };
 
+        let deep_research_system =
+            prompt_templates::load(pool, prompt_templates::KEY_DEEP_RESEARCH_SYSTEM).await;
         let chat_request = serde_json::json!({
             "model": chat_model,
             "messages": [
-                {"role": "system", "content": "你是深度研究助手。基于 RAG 内容进行多轮迭代研究，逐步深入分析。"},
+                {"role": "system", "content": deep_research_system},
                 {"role": "user", "content": round_prompt}
             ],
             "stream": false
@@ -669,23 +650,17 @@ pub async fn deep_research(
         .collect::<Vec<_>>()
         .join("\n\n");
 
-    let final_prompt = format!(
-        r#"基于多轮深度研究的发现，请综合回答原始问题。
-
-原始问题: {query}
-
-多轮研究发现:
-{findings}
-
-请综合所有发现，给出完整、准确的回答。标注信息来源。"#,
-        query = query,
-        findings = findings_summary,
+    let final_prompt = prompt_templates::render(
+        &prompt_templates::load(pool, prompt_templates::KEY_DEEP_RESEARCH_FINAL).await,
+        &[("query", query), ("findings", &findings_summary)],
     );
 
+    let final_system =
+        prompt_templates::load(pool, prompt_templates::KEY_DEEP_RESEARCH_FINAL_SYSTEM).await;
     let final_request = serde_json::json!({
         "model": chat_model,
         "messages": [
-            {"role": "system", "content": "你是深度研究助手。综合多轮研究发现，给出完整准确的回答。"},
+            {"role": "system", "content": final_system},
             {"role": "user", "content": final_prompt}
         ],
         "stream": false

--- a/src-tauri/src/services/knowledge/rag.rs
+++ b/src-tauri/src/services/knowledge/rag.rs
@@ -841,6 +841,26 @@ async fn rewrite_query_with_llm(
 mod rewrite_tests {
     use super::*;
 
+    /// 门控键契约（ask_with_config 内联表达式）：键名与默认值锁定——
+    /// 键名打错会让改写误开（成本意外增加）或永不生效；默认必须为关。
+    #[test]
+    fn query_rewrite_gate_defaults_off_and_key_is_stable() {
+        let dir =
+            std::env::temp_dir().join(format!("waliapi-rewrite-gate-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = crate::settings_store::SettingsStore::file(dir.join("settings.json"));
+
+        // 未配置 → 关（默认值契约）
+        assert!(
+            !store.get_bool("kb.query_rewrite", false),
+            "kb.query_rewrite 默认必须为关"
+        );
+        // 开启表达式（ask_with_config 内联条件的镜像）：关闭或无历史 → 不进入改写
+        let gate = store.get_bool("kb.query_rewrite", false);
+        assert!(!(gate && !Vec::<ConversationMessage>::new().is_empty()));
+        assert!(!gate, "关闭时检索路径零变化（结构性跳过改写）");
+    }
+
     #[test]
     fn extract_rewrite_query_takes_first_line_and_trims_quotes() {
         assert_eq!(

--- a/src-tauri/src/services/knowledge/rag.rs
+++ b/src-tauri/src/services/knowledge/rag.rs
@@ -57,6 +57,16 @@ pub async fn ask_with_config(
     let repo = Repository::new(pool.clone());
     let kb_repo = KbRepository::new(pool.clone());
 
+    // C-06/R2：可选多轮查询改写（kb.query_rewrite，默认关）。
+    // 多轮对话的指代型问题（「上面说的方案呢」）直接送检索必然 miss——
+    // 开启时先用渠道模型把「近几轮对话 + 当前问题」改写成独立完整的检索查询。
+    // 失败/超时静默回退原查询（best-effort），多一次 LLM 调用的成本由开关控制。
+    let query = if settings.get_bool("kb.query_rewrite", false) && !history.is_empty() {
+        rewrite_query_with_llm(pool, settings, kb_id, chat_model, query, history).await
+    } else {
+        query.to_string()
+    };
+
     // 1. Embed the query (needed for vector and hybrid modes)
     let query_emb_opt = if search_mode != "keyword" {
         let embeddings = embedder::embed(&[query.to_string()], embedding_model, &repo)
@@ -82,7 +92,7 @@ pub async fn ask_with_config(
             retriever::hybrid_search_with_details(
                 pool,
                 kb_id,
-                query,
+                &query,
                 &embeddings[0],
                 top_k,
                 vector_weight,
@@ -90,7 +100,7 @@ pub async fn ask_with_config(
             )
             .await?
         } else {
-            let kw = retriever::keyword_only_search(pool, kb_id, query, top_k).await?;
+            let kw = retriever::keyword_only_search(pool, kb_id, &query, top_k).await?;
             kw.into_iter()
                 .map(|r| {
                     let score = r.score;
@@ -147,7 +157,7 @@ pub async fn ask_with_config(
             retriever::hybrid_search_with_details(
                 pool,
                 kb_id,
-                query,
+                &query,
                 query_emb,
                 top_k,
                 vector_weight,
@@ -166,7 +176,7 @@ pub async fn ask_with_config(
         if !kb_id.is_empty() {
             let answer = "RAG 中没有找到相关内容。".to_string();
             kb_repo
-                .add_conversation(kb_id, "user", query, None, Some(chat_model), 0)
+                .add_conversation(kb_id, "user", &query, None, Some(chat_model), 0)
                 .await
                 .ok();
             kb_repo
@@ -192,7 +202,7 @@ pub async fn ask_with_config(
     let context = build_context(&results);
 
     // 4. Build prompt with history
-    let prompt = build_rag_prompt(&context, query, history);
+    let prompt = build_rag_prompt(&context, &query, history);
 
     // 5. Token estimation and fallback
     let estimated_tokens = retriever::estimate_tokens(&prompt);
@@ -201,11 +211,14 @@ pub async fn ask_with_config(
 
     let (final_prompt, context_used) = if estimated_tokens > context_limit {
         // Stage 1: Trim context (remove lowest-scoring chunks)
-        let trimmed = trim_context(&results, query, history, context_limit);
+        let trimmed = trim_context(&results, &query, history, context_limit);
         if retriever::estimate_tokens(&trimmed.0) > context_limit {
             // Stage 2: Remove history, keep only latest message
-            let no_history =
-                build_rag_prompt(&context, query, &history[history.len().saturating_sub(2)..]);
+            let no_history = build_rag_prompt(
+                &context,
+                &query,
+                &history[history.len().saturating_sub(2)..],
+            );
             if retriever::estimate_tokens(&no_history) > context_limit {
                 // Stage 3: Remove context entirely
                 let bare = format!(
@@ -310,7 +323,7 @@ pub async fn ask_with_config(
                 let sources_json = serde_json::to_string(&sources).ok();
                 let tokens = usage.as_ref().map(|u| u.total_tokens as i64).unwrap_or(0);
                 kb_repo
-                    .add_conversation(kb_id, "user", query, None, Some(chat_model), 0)
+                    .add_conversation(kb_id, "user", &query, None, Some(chat_model), 0)
                     .await
                     .ok();
                 kb_repo
@@ -739,5 +752,142 @@ pub async fn deep_research(
             })
         }
         Err((code, msg)) => Err(format!("Final synthesis failed ({}): {}", code, msg)),
+    }
+}
+
+// ─── C-06/R2：多轮查询改写 ─────────────────────────────────────────────────
+
+/// 从改写回复中提取查询（纯函数）：取首个非空行、去引号包裹、截断到 512 字符。
+/// 空回复/全空白 → None（调用侧回退原查询）。
+fn extract_rewrite_query(reply: &str) -> Option<String> {
+    let line = reply.lines().map(str::trim).find(|l| !l.is_empty())?;
+    let line = line.trim_matches(|c| c == '"' || c == '“' || c == '”');
+    if line.is_empty() {
+        return None;
+    }
+    Some(line.chars().take(512).collect())
+}
+
+/// 可选查询改写：近几轮对话 + 当前问题 → 独立完整检索查询。
+/// 走渠道模型（kb-internal 路由组，token 消耗自动落账）；任何失败静默回退原查询。
+async fn rewrite_query_with_llm(
+    pool: &SqlitePool,
+    settings: &SettingsStore,
+    kb_id: &str,
+    chat_model: &str,
+    query: &str,
+    history: &[ConversationMessage],
+) -> String {
+    // 近 6 轮（改写只需消解指代，更早的轮次是噪音）
+    let recent: Vec<String> = history
+        .iter()
+        .rev()
+        .take(6)
+        .rev()
+        .map(|m| format!("{}: {}", m.role, m.content))
+        .collect();
+    let history_text = recent.join("\n");
+    let prompt = prompt_templates::render(
+        &prompt_templates::load(pool, prompt_templates::KEY_QUERY_REWRITE).await,
+        &[("history", &history_text), ("query", query)],
+    );
+    let chat_request = serde_json::json!({
+        "model": chat_model,
+        "messages": [
+            {"role": "system", "content": "你是检索查询改写器，只输出改写后的查询本身。"},
+            {"role": "user", "content": prompt}
+        ],
+        "stream": false,
+        "temperature": 0.0
+    });
+    let chat_request_str: String = serde_json::to_string(&chat_request).unwrap_or_default();
+    let proxy_result = proxy::handle_request(
+        &std::sync::Arc::new(Repository::new(pool.clone())),
+        settings,
+        "kb-rewrite",
+        "RAG-rewrite",
+        chat_request,
+        false,
+        Some(chat_request_str),
+        Some(format!("kb-internal_{}", kb_id)),
+        None,
+    )
+    .await;
+    let reply = match proxy_result {
+        Ok(result) => result
+            .body
+            .get("choices")
+            .and_then(|c| c.get(0))
+            .and_then(|c| c.get("message"))
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_str())
+            .unwrap_or("")
+            .to_string(),
+        Err(_) => String::new(),
+    };
+    match extract_rewrite_query(&reply) {
+        Some(rewritten) => {
+            tracing::debug!("[RAG] 查询改写: {query:?} -> {rewritten:?}");
+            rewritten
+        }
+        None => {
+            tracing::warn!("[RAG] 查询改写回复不可解析，回退原查询");
+            query.to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod rewrite_tests {
+    use super::*;
+
+    #[test]
+    fn extract_rewrite_query_takes_first_line_and_trims_quotes() {
+        assert_eq!(
+            extract_rewrite_query("WaLiAPI 网关如何配置渠道配额\n（改写说明）"),
+            Some("WaLiAPI 网关如何配置渠道配额".to_string())
+        );
+        assert_eq!(
+            extract_rewrite_query("  \"带引号的查询\"  "),
+            Some("带引号的查询".to_string())
+        );
+        assert_eq!(
+            extract_rewrite_query("“中文引号”"),
+            Some("中文引号".to_string())
+        );
+        // 空白/空行 → None
+        assert_eq!(extract_rewrite_query(""), None);
+        assert_eq!(extract_rewrite_query(" \n \n"), None);
+        // 超长截断
+        let long = "长".repeat(600);
+        assert_eq!(
+            extract_rewrite_query(&long).map(|q| q.chars().count()),
+            Some(512)
+        );
+    }
+
+    /// 改写关闭（默认）或无历史 → 走原查询（结构性保障：分支条件在 ask_with_config 内联，
+    /// 此处锁定 extract 的回退语义与 rewrite 的失败回退）。
+    #[tokio::test]
+    async fn rewrite_falls_back_to_original_when_no_channels() {
+        // 内存库无任何渠道 → proxy 转发必然失败 → 回退原查询（不 panic、不报错）
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        let settings = SettingsStore::file(
+            std::env::temp_dir().join(format!("waliapi-rewrite-test-{}", uuid::Uuid::new_v4())),
+        );
+        let history = vec![
+            ConversationMessage {
+                role: "user".into(),
+                content: "WaLiAPI 的渠道配额怎么配？".into(),
+            },
+            ConversationMessage {
+                role: "assistant".into(),
+                content: "在密钥页设置 quota_limit。".into(),
+            },
+        ];
+        let result =
+            rewrite_query_with_llm(&pool, &settings, "kb-1", "m", "那限流呢？", &history).await;
+        assert_eq!(result, "那限流呢？", "上游不可用时必须静默回退原查询");
     }
 }

--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -114,6 +114,10 @@ pub async fn run(cfg: WebServerConfig) -> Result<(), String> {
         data_dir,
     });
 
+    // Prompt 模板种子（C-07）：空表时写入源码字面量 v1——升级后行为逐字节不变
+    if let Err(error) = crate::prompt_templates::seed_if_empty(&state.db.pool).await {
+        tracing::warn!("[模板] 种子写入失败（运行时回退编译期默认）: {error}");
+    }
     crate::audit_log::apply_settings(&state.settings);
     tauri::async_runtime::spawn(crate::audit_log::run_maintenance_loop(
         state.db.pool.clone(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ const LogsPage = lazy(() => import("./pages/LogsPage").then(module => ({ default
 const SettingsPage = lazy(() => import("./pages/SettingsPage").then(module => ({ default: module.SettingsPage })));
 const UsagePage = lazy(() => import("./pages/UsagePage").then(module => ({ default: module.UsagePage })));
 const KnowledgeBasePage = lazy(() => import("./pages/KnowledgeBasePage").then(module => ({ default: module.KnowledgeBasePage })));
+const PromptTemplatesPage = lazy(() => import("./pages/PromptTemplatesPage"));
 const UpdateChecker = lazy(() => import("./components/UpdateChecker").then(module => ({ default: module.UpdateChecker })));
 
 function App() {
@@ -58,6 +59,7 @@ function App() {
             <Route path="/api-keys" element={<ApiKeysPage />} />
             <Route path="/logs" element={<LogsPage />} />
             <Route path="/settings" element={<SettingsPage />} />
+            <Route path="/prompt-templates" element={<PromptTemplatesPage />} />
             <Route path="/services" element={<KnowledgeBasePage />} />
             <Route path="/services/knowledge-base" element={<KnowledgeBasePage />} />
             <Route path="/services/mcp" element={<KnowledgeBasePage />} />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   ExternalLink,
   Link,
   Database,
+  FileText,
   LogOut,
 } from "lucide-react";
 import { serverApi } from "../../lib/api";
@@ -27,6 +28,7 @@ const navItems = [
   { to: "/channels", icon: Radio, label: "渠道" },
   { to: "/api-keys", icon: Key, label: "密钥" },
   { to: "/services", icon: Database, label: "服务", subLabel: "RAG、Wiki、Skills ..." },
+  { to: "/prompt-templates", icon: FileText, label: "Prompt 模板", subLabel: "版本化 · 回滚" },
   { to: "/logs", icon: ScrollText, label: "日志" },
   { to: "/settings", icon: Settings, label: "设置" },
 ];

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   AuthAccount, AuthLoginSessionStatus, AuthLoginStart, AuthMutationResult, AuthLogoutResult, AuthExportResult,
   AuthQuotaStatus, AuthUpdateInput,
   AuthProviderInfo,
+  PromptTemplate,
 } from "../types";
 
 /**
@@ -572,4 +573,11 @@ export const appConfigApi = {
   resetCodexAuth: () => invoke<ApplyResult>("reset_codex_auth"),
   getContent: (appName: string) => invoke<ConfigContent>("get_app_config_content", { appName }),
   openFolder: (appName: string) => invoke<void>("open_config_folder", { appName }),
+};
+
+// Prompt template commands（C-07 模板版本化）
+export const promptTemplateApi = {
+  list: () => invoke<PromptTemplate[]>("list_prompt_templates"),
+  create: (templateKey: string, content: string) => invoke<number>("create_prompt_template", { templateKey, content }),
+  activate: (templateKey: string, version: number) => invoke<void>("activate_prompt_template", { templateKey, version }),
 };

--- a/src/pages/PromptTemplatesPage.tsx
+++ b/src/pages/PromptTemplatesPage.tsx
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ArrowLeftRight, FileText, Loader2, Plus, Save } from "lucide-react";
+import { promptTemplateApi } from "../lib/api";
+import type { PromptTemplate } from "../types";
+
+/** Prompt 模板管理（C-07）：按 key 分组列版本、编辑新建版本、一键激活/回滚。
+ *  种子 = 源码字面量 v1；激活新版本立即生效，回滚 v1 同理；占位符非法拒绝激活。 */
+export default function PromptTemplatesPage() {
+  const [templates, setTemplates] = useState<PromptTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [draft, setDraft] = useState("");
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setTemplates(await promptTemplateApi.list());
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, PromptTemplate[]>();
+    for (const t of templates) {
+      const list = map.get(t.template_key) ?? [];
+      list.push(t);
+      map.set(t.template_key, list);
+    }
+    return [...map.entries()].sort(([a], [b]) => a.localeCompare(b));
+  }, [templates]);
+
+  const activeOf = (key: string) => grouped.find(([k]) => k === key)?.[1].find(t => t.active);
+
+  const startEdit = (key: string) => {
+    setEditingKey(key);
+    setDraft(activeOf(key)?.content ?? "");
+    setNotice(null);
+  };
+
+  const saveNewVersion = async (key: string) => {
+    setNotice(null);
+    setError(null);
+    try {
+      const version = await promptTemplateApi.create(key, draft);
+      setNotice(`已保存 ${key} v${version}（未激活，预览确认后一键激活）`);
+      setEditingKey(null);
+      await refresh();
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  const activate = async (key: string, version: number) => {
+    setNotice(null);
+    setError(null);
+    try {
+      await promptTemplateApi.activate(key, version);
+      setNotice(`已激活 ${key} v${version}，立即生效`);
+      await refresh();
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-5xl p-6">
+      <div className="mb-4 flex items-center gap-2">
+        <FileText className="h-5 w-5 text-primary" />
+        <h1 className="text-xl font-semibold">Prompt 模板</h1>
+      </div>
+      <p className="mb-6 text-sm text-muted-foreground">
+        RAG 问答与深度研究的系统提示词版本化管理：编辑保存生成新版本，一键激活/回滚立即生效；
+        升级时自动以源码字面量种子 v1（行为逐字节不变）；含非法占位符的模板会被拒绝。
+      </p>
+
+      {error && <div className="mb-4 rounded-2xl border border-red-300 bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+      {notice && <div className="mb-4 rounded-2xl border border-emerald-300 bg-emerald-50 p-3 text-sm text-emerald-700">{notice}</div>}
+      {loading && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> 加载中…
+        </div>
+      )}
+
+      <div className="space-y-6">
+        {grouped.map(([key, versions]) => {
+          const active = versions.find(v => v.active);
+          return (
+            <div key={key} className="surface rounded-2xl p-4">
+              <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <div className="font-mono text-sm font-medium">{key}</div>
+                  <div className="text-xs text-muted-foreground">
+                    当前激活 v{active?.version ?? "-"} · 共 {versions.length} 个版本
+                  </div>
+                </div>
+                <button
+                  onClick={() => (editingKey === key ? setEditingKey(null) : startEdit(key))}
+                  className="flex items-center gap-1 rounded-full border border-border px-3 py-1.5 text-xs font-medium hover:bg-white/5"
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  {editingKey === key ? "取消编辑" : "编辑新版本"}
+                </button>
+              </div>
+
+              {editingKey === key && (
+                <div className="mb-4">
+                  <textarea
+                    value={draft}
+                    onChange={e => setDraft(e.target.value)}
+                    rows={10}
+                    className="w-full rounded-2xl border border-border bg-background/70 p-3 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-primary/20"
+                  />
+                  <div className="mt-2 flex items-center gap-2">
+                    <button
+                      onClick={() => void saveNewVersion(key)}
+                      className="flex items-center gap-1 rounded-full bg-primary px-4 py-1.5 text-xs font-medium text-primary-foreground hover:opacity-90"
+                    >
+                      <Save className="h-3.5 w-3.5" /> 保存为新版本
+                    </button>
+                    <span className="text-xs text-muted-foreground">
+                      保存仅校验占位符；激活后才切换生效
+                    </span>
+                  </div>
+                </div>
+              )}
+
+              <div className="space-y-2">
+                {versions.map(v => (
+                  <div
+                    key={v.id}
+                    className={`flex items-center justify-between gap-3 rounded-xl border px-3 py-2 ${
+                      v.active ? "border-emerald-300 bg-emerald-50/50" : "border-border"
+                    }`}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 text-xs">
+                        <span className="font-mono font-medium">v{v.version}</span>
+                        {v.active && (
+                          <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-medium text-emerald-700">
+                            激活中
+                          </span>
+                        )}
+                        <span className="text-muted-foreground">{v.created_at}</span>
+                      </div>
+                      <pre className="mt-1 max-h-24 overflow-y-auto whitespace-pre-wrap break-all text-xs text-muted-foreground">
+                        {v.content}
+                      </pre>
+                    </div>
+                    {!v.active && (
+                      <button
+                        onClick={() => void activate(key, v.version)}
+                        className="flex shrink-0 items-center gap-1 rounded-full border border-border px-3 py-1.5 text-xs font-medium hover:bg-white/5"
+                      >
+                        <ArrowLeftRight className="h-3.5 w-3.5" />
+                        {v.version === 1 ? "回滚到此版本" : "激活此版本"}
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -637,3 +637,13 @@ export interface UpstreamModelsResult {
   /** 拉取时使用的根 URL（便于展示/排障）。 */
   base_url: string;
 }
+
+// Prompt 模板（C-07 版本化管理）
+export interface PromptTemplate {
+  id: string;
+  template_key: string;
+  version: number;
+  content: string;
+  active: boolean;
+  created_at: string;
+}


### PR DESCRIPTION
Closes #90

> **依赖**：本 PR 堆叠于 Prompt 模板版本化（`feat/capability-c07-prompt-templates`）之上——改写 prompt 入模板表。请先合 #89 对应 PR。

## 开始原因

标准 RAG 问答把用户原话直接送检索，多轮指代型问题（「上面说的方案呢」）必然 miss。

## 方案

- 检索前可选改写（`kb.query_rewrite` **默认关**——多一次 LLM 调用的成本由用户决定）：近 6 轮 + 当前问题 → 渠道模型改写为独立完整查询；无历史跳过。
- 改写 prompt 为模板表新 key `query_rewrite`（占位符校验、版本化）。
- 提取纯函数（首非空行、去引号、512 字符截断）；走 kb-internal 路由组（token 自动落账）；失败静默回退原查询。

## 测试

提取纯函数；无渠道失败回退集成（原查询透传）；门控键契约（默认关、键名锁定、关闭时结构性跳过）。