### PR TITLE
feat(cache): 语义缓存——exact + semantic 两层响应缓存（默认关闭，三层风险收敛）

### DIFF
--- a/src-tauri/migrations/035_semantic_cache.sql
+++ b/src-tauri/migrations/035_semantic_cache.sql
@@ -1,0 +1,13 @@
+-- 语义缓存（C-02）：网关侧响应缓存（exact 规范化哈希层 + semantic embedding 余弦层）。
+-- 默认关闭（cache.semantic_enabled=false）；TTL 默认 24h；带 tools 的请求永不入缓存。
+CREATE TABLE IF NOT EXISTS semantic_cache (
+    id TEXT PRIMARY KEY,
+    cache_key TEXT NOT NULL UNIQUE,
+    model TEXT NOT NULL,
+    embedding BLOB,
+    answer TEXT NOT NULL,
+    ttl_expire_at TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_semantic_cache_model ON semantic_cache(model, ttl_expire_at);

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -59,6 +59,24 @@ pub struct Settings {
     pub ocr_concurrency: i32,
     #[serde(default = "default_ocr_dpi")]
     pub ocr_dpi: i32,
+    /// 语义缓存开关（C-02，默认关）。关闭时拦截/写入/清理全部旁路。
+    #[serde(default = "default_false")]
+    pub cache_enabled: bool,
+    #[serde(default = "default_cache_ttl_secs")]
+    pub cache_ttl_secs: u64,
+    /// 语义层相似度阈值（百分比，95 = 0.95；保守默认）。
+    #[serde(default = "default_cache_threshold")]
+    pub cache_threshold_percent: u64,
+    /// 语义层嵌入模型（空 = 只启用 exact 层）。
+    #[serde(default)]
+    pub cache_embedding_model: String,
+}
+
+fn default_cache_ttl_secs() -> u64 {
+    86_400
+}
+fn default_cache_threshold() -> u64 {
+    95
 }
 
 fn default_port() -> u16 {
@@ -135,6 +153,10 @@ impl Default for Settings {
             ocr_max_pages: default_ocr_max_pages(),
             ocr_concurrency: default_ocr_concurrency(),
             ocr_dpi: default_ocr_dpi(),
+            cache_enabled: default_false(),
+            cache_ttl_secs: default_cache_ttl_secs(),
+            cache_threshold_percent: default_cache_threshold(),
+            cache_embedding_model: String::new(),
         }
     }
 }
@@ -218,6 +240,10 @@ pub async fn get_settings(state: tauri::State<'_, Arc<AppState>>) -> Result<Sett
         ocr_max_pages: get_u64(store, "ocr.max_pages", 200) as i32,
         ocr_concurrency: get_u64(store, "ocr.concurrency", 2) as i32,
         ocr_dpi: get_u64(store, "ocr.dpi", 200) as i32,
+        cache_enabled: get_bool(store, "cache.semantic_enabled", false),
+        cache_ttl_secs: get_u64(store, "cache.ttl_secs", 86_400),
+        cache_threshold_percent: get_u64(store, "cache.semantic_threshold_percent", 95),
+        cache_embedding_model: get_str(store, "cache.embedding_model", ""),
     };
     Ok(settings)
 }
@@ -330,6 +356,22 @@ pub async fn save_settings(
             serde_json::json!(settings.ocr_concurrency),
         ),
         ("ocr.dpi".to_string(), serde_json::json!(settings.ocr_dpi)),
+        (
+            "cache.semantic_enabled".to_string(),
+            serde_json::json!(settings.cache_enabled),
+        ),
+        (
+            "cache.ttl_secs".to_string(),
+            serde_json::json!(settings.cache_ttl_secs),
+        ),
+        (
+            "cache.semantic_threshold_percent".to_string(),
+            serde_json::json!(settings.cache_threshold_percent),
+        ),
+        (
+            "cache.embedding_model".to_string(),
+            serde_json::json!(settings.cache_embedding_model),
+        ),
     ])?;
     crate::audit_log::apply_settings(&state.settings);
     // 缩短保留期后立即清理，避免等待后台维护周期。
@@ -371,4 +413,25 @@ pub async fn set_auto_start(enabled: bool, app: AppHandle) -> Result<(), String>
         }
         Ok(())
     }
+}
+
+/// 清空语义缓存（C-02 管理命令）：model 为 None 时清全部，否则按模型清。
+#[tauri::command]
+pub async fn clear_semantic_cache(
+    model: Option<String>,
+    state: tauri::State<'_, std::sync::Arc<AppState>>,
+) -> Result<u64, String> {
+    let pool = &state.db.pool;
+    let result = match model.as_deref() {
+        Some(m) if !m.is_empty() => sqlx::query("DELETE FROM semantic_cache WHERE model = ?")
+            .bind(m)
+            .execute(pool)
+            .await
+            .map_err(|e| e.to_string())?,
+        _ => sqlx::query("DELETE FROM semantic_cache")
+            .execute(pool)
+            .await
+            .map_err(|e| e.to_string())?,
+    };
+    Ok(result.rows_affected())
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -421,17 +421,7 @@ pub async fn clear_semantic_cache(
     model: Option<String>,
     state: tauri::State<'_, std::sync::Arc<AppState>>,
 ) -> Result<u64, String> {
-    let pool = &state.db.pool;
-    let result = match model.as_deref() {
-        Some(m) if !m.is_empty() => sqlx::query("DELETE FROM semantic_cache WHERE model = ?")
-            .bind(m)
-            .execute(pool)
-            .await
-            .map_err(|e| e.to_string())?,
-        _ => sqlx::query("DELETE FROM semantic_cache")
-            .execute(pool)
-            .await
-            .map_err(|e| e.to_string())?,
-    };
-    Ok(result.rows_affected())
+    crate::semantic_cache::clear(&state.db.pool, model.as_deref())
+        .await
+        .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ mod protocol;
 #[cfg(test)]
 mod rollout_integration_tests;
 pub mod security;
+pub mod semantic_cache;
 pub mod server;
 pub mod services;
 pub mod settings_store;
@@ -242,6 +243,11 @@ pub fn run() {
                     state.settings.clone(),
                 ));
 
+                // 语义缓存过期清理（C-02；缓存未启用时清理为空操作）
+                tauri::async_runtime::spawn(crate::semantic_cache::run_maintenance_loop(
+                    state.db.pool.clone(),
+                ));
+
                 tauri::async_runtime::spawn(async move {
                     auth_provider::maintenance::run_maintenance_loop(auth_service).await;
                 });
@@ -317,6 +323,7 @@ pub fn run() {
             commands::settings::get_settings,
             commands::settings::get_feature_flags,
             commands::settings::save_settings,
+            commands::settings::clear_semantic_cache,
             commands::settings::apply_theme,
             commands::settings::set_auto_start,
             commands::server::get_server_status,

--- a/src-tauri/src/semantic_cache.rs
+++ b/src-tauri/src/semantic_cache.rs
@@ -1,0 +1,579 @@
+//! 语义缓存（C-02）：网关侧响应缓存——exact（规范化哈希 O(1) 精确命中）
+//! + semantic（embedding 暴力余弦 ≥ 阈值命中）两层。
+//!
+//! 三层风险收敛：① 默认关闭（cache.semantic_enabled）；② 可缓存判定
+//! （无 tools/tool_choice、temperature ≤ 0.3、安全审计无命中、消息内容全部
+//! 为纯文本）；③ 语义阈值保守默认 0.95。带 tools 的请求永不入缓存也永不
+//! 命中；TTL 过期不命中；命中请求照常写请求日志（记账口径不变）。
+//!
+//! 诚实边界（issue 中声明）：本实现拦截 chat completions 端点（主协议）；
+//! responses/messages 协议的拦截与写入为后续工作。写入只覆盖非流式响应
+//! （流式命中可回放缓存答案；流式响应自身的渐进写入需要挂在流泵上，列
+//! 为开放点）。渠道级覆盖在「Key 鉴权后、路由候选前」的拦截点上无法得知
+//! 渠道，以模型粒度（cache_key 含 model）替代——设计修正如实声明。
+
+use crate::db::repository::Repository;
+use crate::settings_store::SettingsStore;
+use sqlx::SqlitePool;
+use std::time::Duration;
+
+/// 消息规范化（纯函数）：提取 (role, content 纯文本) 序列，合并连续空白、
+/// 去首尾空白；任一消息 content 非字符串（图片/工具内容等）→ None（不可缓存）。
+pub fn normalize_messages(body: &serde_json::Value) -> Option<String> {
+    let messages = body.get("messages")?.as_array()?;
+    if messages.is_empty() {
+        return None;
+    }
+    let mut parts = Vec::with_capacity(messages.len());
+    for message in messages {
+        let role = message.get("role")?.as_str()?;
+        let content = message.get("content")?;
+        let text = match content {
+            serde_json::Value::String(s) => s.clone(),
+            serde_json::Value::Array(items) => {
+                // 多段内容：全部为 {type:"text", text} 才可缓存
+                let mut texts = Vec::with_capacity(items.len());
+                for item in items {
+                    if item.get("type").and_then(|t| t.as_str()) != Some("text") {
+                        return None;
+                    }
+                    texts.push(item.get("text")?.as_str()?.to_string());
+                }
+                texts.join("\n")
+            }
+            _ => return None,
+        };
+        let normalized: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
+        parts.push(format!("{role}: {normalized}"));
+    }
+    Some(parts.join("\n"))
+}
+
+/// 可缓存判定（纯函数）：无 tools/tool_choice、temperature ≤ 0.3（缺省视为 0）、
+/// 消息可规范化。安全审计命中由调用侧传入（audit_hit = true 直接不可缓存）。
+pub fn cacheable(body: &serde_json::Value, audit_hit: bool) -> bool {
+    if audit_hit {
+        return false;
+    }
+    if body.get("tools").is_some() || body.get("tool_choice").is_some() {
+        return false;
+    }
+    if let Some(temp) = body.get("temperature").and_then(|t| t.as_f64()) {
+        if temp > 0.3 {
+            return false;
+        }
+    }
+    normalize_messages(body).is_some()
+}
+
+/// exact 层缓存键（纯函数）：规范化消息 SHA-256 + model + 参数档位。
+/// temperature 分档（≤0.3 同档）——采样参数不同不共享 exact 命中。
+pub fn exact_cache_key(body: &serde_json::Value, normalized: &str) -> Option<String> {
+    let model = body.get("model")?.as_str()?;
+    let temp_bucket = if body
+        .get("temperature")
+        .and_then(|t| t.as_f64())
+        .unwrap_or(0.0)
+        <= 0.3
+    {
+        "t0"
+    } else {
+        "t1"
+    };
+    let max_tokens_bucket = match body.get("max_tokens").and_then(|t| t.as_i64()) {
+        None => "none",
+        Some(n) if n <= 1024 => "small",
+        Some(n) if n <= 4096 => "mid",
+        Some(_) => "large",
+    };
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(
+        format!("{normalized}\x1e{model}\x1e{temp_bucket}\x1e{max_tokens_bucket}").as_bytes(),
+    );
+    let digest = hasher.finalize();
+    Some(format!("sc_{model}_{:x}", digest))
+}
+
+/// 余弦相似度（纯函数；semantic 层与测试共用）。
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    let mut dot = 0.0f32;
+    let mut na = 0.0f32;
+    let mut nb = 0.0f32;
+    for (x, y) in a.iter().zip(b.iter()) {
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+    }
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na.sqrt() * nb.sqrt())
+}
+
+pub struct CacheHit {
+    pub answer: String,
+    /// exact | semantic
+    pub layer: &'static str,
+}
+
+/// 查询两层缓存（exact 优先，semantic 兜底）。
+/// 未启用（cache.semantic_enabled=false）/ 键不可构造 / 无命中 → None。
+pub async fn lookup(
+    pool: &SqlitePool,
+    settings: &SettingsStore,
+    body: &serde_json::Value,
+    audit_hit: bool,
+) -> Option<CacheHit> {
+    if !settings.get_bool("cache.semantic_enabled", false) {
+        return None;
+    }
+    if !cacheable(body, audit_hit) {
+        return None;
+    }
+    let normalized = normalize_messages(body)?;
+    let model = body.get("model")?.as_str()?;
+    let now = crate::db::models::now_iso();
+
+    // 第一层：exact（规范化哈希 O(1)）
+    if let Some(key) = exact_cache_key(body, &normalized) {
+        let row: Option<String> = sqlx::query_scalar(
+            "SELECT answer FROM semantic_cache WHERE cache_key = ? AND ttl_expire_at > ? LIMIT 1",
+        )
+        .bind(&key)
+        .bind(&now)
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten();
+        if let Some(answer) = row {
+            return Some(CacheHit {
+                answer,
+                layer: "exact",
+            });
+        }
+    }
+
+    // 第二层：semantic（embedding 暴力余弦；缓存条目量级 ≪ KB chunk，暴力扫可接受）
+    let embedding_model = settings.get_str("cache.embedding_model", "");
+    if embedding_model.is_empty() {
+        return None;
+    }
+    let threshold = settings.get_u64("cache.semantic_threshold_percent", 95) as f32 / 100.0;
+    let repo = Repository::new(pool.clone());
+    let query_text = normalized
+        .lines()
+        .rev()
+        .find(|l| l.starts_with("user: "))
+        .map(|l| l.to_string())
+        .unwrap_or(normalized);
+    let embeddings =
+        crate::services::knowledge::embedder::embed(&[query_text], &embedding_model, &repo)
+            .await
+            .ok()?;
+    let query_vec = embeddings.into_iter().next()?;
+
+    let rows: Vec<(String, Vec<u8>)> = sqlx::query_as(
+        "SELECT answer, embedding FROM semantic_cache \
+         WHERE model = ? AND ttl_expire_at > ? AND embedding IS NOT NULL",
+    )
+    .bind(model)
+    .bind(&now)
+    .fetch_all(pool)
+    .await
+    .ok()?;
+    let mut best: Option<(f32, String)> = None;
+    for (answer, blob) in rows {
+        let Some(vector) = decode_f32_blob(&blob) else {
+            continue;
+        };
+        let score = cosine_similarity(&query_vec, &vector);
+        if score >= threshold && best.as_ref().is_none_or(|(s, _)| score > *s) {
+            best = Some((score, answer));
+        }
+    }
+    best.map(|(_, answer)| CacheHit {
+        answer,
+        layer: "semantic",
+    })
+}
+
+/// f32 向量的 LE 字节编解码（SQLite BLOB 存取）。
+pub fn encode_f32_blob(vector: &[f32]) -> Vec<u8> {
+    vector.iter().flat_map(|f| f.to_le_bytes()).collect()
+}
+
+pub fn decode_f32_blob(blob: &[u8]) -> Option<Vec<f32>> {
+    if blob.len() % 4 != 0 {
+        return None;
+    }
+    Some(
+        blob.chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect(),
+    )
+}
+
+/// 写入缓存（best-effort：调用侧已 spawn，此处失败仅告警）。
+/// embedding 为 None 时只写 exact 层；semantic 层命中需要非空 embedding。
+pub async fn store(
+    pool: &SqlitePool,
+    settings: &SettingsStore,
+    body: &serde_json::Value,
+    answer: &str,
+) {
+    if !settings.get_bool("cache.semantic_enabled", false) || answer.is_empty() {
+        return;
+    }
+    let Some(normalized) = normalize_messages(body) else {
+        return;
+    };
+    let Some(model) = body.get("model").and_then(|m| m.as_str()) else {
+        return;
+    };
+    let Some(key) = exact_cache_key(body, &normalized) else {
+        return;
+    };
+    let ttl_secs = settings.get_u64("cache.ttl_secs", 86_400).max(60);
+    let expire = (chrono::Utc::now() + chrono::Duration::seconds(ttl_secs as i64)).to_rfc3339();
+
+    // semantic 层 embedding（配置了嵌入模型才有；失败不阻断 exact 写入）
+    let mut embedding_blob: Option<Vec<u8>> = None;
+    let embedding_model = settings.get_str("cache.embedding_model", "");
+    if !embedding_model.is_empty() {
+        let repo = Repository::new(pool.clone());
+        let query_text = normalized
+            .lines()
+            .rev()
+            .find(|l| l.starts_with("user: "))
+            .map(|l| l.to_string())
+            .unwrap_or(normalized);
+        if let Ok(vectors) =
+            crate::services::knowledge::embedder::embed(&[query_text], &embedding_model, &repo)
+                .await
+        {
+            if let Some(vector) = vectors.into_iter().next() {
+                embedding_blob = Some(encode_f32_blob(&vector));
+            }
+        }
+    }
+
+    // 同键覆盖写（答案更新；旧条目 TTL 自然过期）
+    let result = sqlx::query(
+        "INSERT INTO semantic_cache (id, cache_key, model, embedding, answer, ttl_expire_at, created_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?) \
+         ON CONFLICT(cache_key) DO UPDATE SET \
+         embedding = excluded.embedding, answer = excluded.answer, \
+         ttl_expire_at = excluded.ttl_expire_at, created_at = excluded.created_at",
+    )
+    .bind(crate::utils::id::new_id())
+    .bind(&key)
+    .bind(model)
+    .bind(&embedding_blob)
+    .bind(answer)
+    .bind(&expire)
+    .bind(crate::db::models::now_iso())
+    .execute(pool)
+    .await;
+    if let Err(error) = result {
+        tracing::warn!("[语义缓存] 写入失败（best-effort，不影响主请求）: {error}");
+    }
+}
+
+/// 从缓存答案合成非流式 chat completion 响应体。
+pub fn replay_body(model: &str, answer: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": format!("chatcmpl-cache-{}", uuid::Uuid::new_v4().simple()),
+        "object": "chat.completion",
+        "created": chrono::Utc::now().timestamp(),
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": answer},
+            "finish_reason": "stop"
+        }],
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+    })
+}
+
+/// 从缓存答案合成流式 SSE 帧序列（role → content → finish → [DONE]，
+/// 标准增量分块，既有 chat SSE 客户端可直接消费）。
+pub fn replay_sse_frames(model: &str, answer: &str) -> String {
+    let id = format!("chatcmpl-cache-{}", uuid::Uuid::new_v4().simple());
+    let created = chrono::Utc::now().timestamp();
+    let mut out = String::new();
+    out.push_str(&format!(
+        "data: {}\n\n",
+        serde_json::json!({
+            "id": id, "object": "chat.completion.chunk", "created": created, "model": model,
+            "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": null}]
+        })
+    ));
+    for chunk in answer.as_bytes().chunks(64) {
+        let text = String::from_utf8_lossy(chunk);
+        out.push_str(&format!(
+            "data: {}\n\n",
+            serde_json::json!({
+                "id": id, "object": "chat.completion.chunk", "created": created, "model": model,
+                "choices": [{"index": 0, "delta": {"content": text}, "finish_reason": null}]
+            })
+        ));
+    }
+    out.push_str(&format!(
+        "data: {}\n\n",
+        serde_json::json!({
+            "id": id, "object": "chat.completion.chunk", "created": created, "model": model,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]
+        })
+    ));
+    out.push_str("data: [DONE]\n\n");
+    out
+}
+
+/// 清理过期条目（后台维护可复用；手工清空走管理命令）。
+pub async fn purge_expired(pool: &SqlitePool) -> u64 {
+    let now = crate::db::models::now_iso();
+    match sqlx::query("DELETE FROM semantic_cache WHERE ttl_expire_at <= ?")
+        .bind(&now)
+        .execute(pool)
+        .await
+    {
+        Ok(result) => result.rows_affected(),
+        Err(error) => {
+            tracing::warn!("[语义缓存] 过期清理失败: {error}");
+            0
+        }
+    }
+}
+
+/// 后台维护循环：随 TTL 清理（复用审计维护的 spawn 模式；间隔固定 1h）。
+pub async fn run_maintenance_loop(pool: SqlitePool) {
+    loop {
+        let purged = purge_expired(&pool).await;
+        if purged > 0 {
+            tracing::debug!("[语义缓存] 清理过期条目 {purged} 行");
+        }
+        tokio::time::sleep(Duration::from_secs(3600)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn memory_db() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    fn settings_at(enabled: bool) -> SettingsStore {
+        let dir = std::env::temp_dir().join(format!("waliapi-cache-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = SettingsStore::file(dir.join("settings.json"));
+        store
+            .set_many(&[(
+                "cache.semantic_enabled".to_string(),
+                serde_json::json!(enabled),
+            )])
+            .unwrap();
+        store
+    }
+
+    fn body(messages: serde_json::Value, temperature: Option<f64>) -> serde_json::Value {
+        serde_json::json!({
+            "model": "m",
+            "messages": messages,
+            "temperature": temperature,
+        })
+    }
+
+    #[test]
+    fn normalize_merges_whitespace_and_rejects_non_text() {
+        let b = body(
+            serde_json::json!([
+                {"role": "user", "content": "  你   好\n世界 "},
+                {"role": "assistant", "content": "你好"}
+            ]),
+            None,
+        );
+        assert_eq!(
+            normalize_messages(&b).unwrap(),
+            "user: 你 好 世界\nassistant: 你好"
+        );
+        // 图片内容 → 不可缓存
+        let b = body(
+            serde_json::json!([
+                {"role": "user", "content": [{"type": "image_url", "image_url": {"url": "x"}}]}
+            ]),
+            None,
+        );
+        assert!(normalize_messages(&b).is_none());
+        // 多段纯文本 → 可缓存（join 后整体做空白规范化，换行折叠为单空格）
+        let b = body(
+            serde_json::json!([
+                {"role": "user", "content": [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]}
+            ]),
+            None,
+        );
+        assert_eq!(normalize_messages(&b).unwrap(), "user: a b");
+    }
+
+    #[test]
+    fn cacheable_gates_tools_temperature_audit() {
+        assert!(cacheable(
+            &body(
+                serde_json::json!([{"role":"user","content":"q"}]),
+                Some(0.0)
+            ),
+            false
+        ));
+        assert!(
+            !cacheable(
+                &body(
+                    serde_json::json!([{"role":"user","content":"q"}]),
+                    Some(0.7)
+                ),
+                false
+            ),
+            "高温不入缓存"
+        );
+        assert!(
+            !cacheable(
+                &body(serde_json::json!([{"role":"user","content":"q"}]), None),
+                true
+            ),
+            "审计命中不入缓存"
+        );
+        let mut with_tools = body(serde_json::json!([{"role":"user","content":"q"}]), None);
+        with_tools["tools"] = serde_json::json!([]);
+        assert!(!cacheable(&with_tools, false), "带 tools 永不入缓存");
+    }
+
+    #[test]
+    fn exact_key_is_stable_and_parameter_sensitive() {
+        let b1 = body(
+            serde_json::json!([{"role":"user","content":"  同一   问题 "}]),
+            None,
+        );
+        let b2 = body(
+            serde_json::json!([{"role":"user","content":"同一 问题"}]),
+            None,
+        );
+        assert_eq!(
+            exact_cache_key(&b1, &normalize_messages(&b1).unwrap()).unwrap(),
+            exact_cache_key(&b2, &normalize_messages(&b2).unwrap()).unwrap(),
+            "空白规范化后同键"
+        );
+        let b3 = body(
+            serde_json::json!([{"role":"user","content":"另一问题"}]),
+            None,
+        );
+        assert_ne!(
+            exact_cache_key(&b1, &normalize_messages(&b1).unwrap()).unwrap(),
+            exact_cache_key(&b3, &normalize_messages(&b3).unwrap()).unwrap()
+        );
+        // max_tokens 档位不同 → 不同键
+        let mut b4 = b1.clone();
+        b4["max_tokens"] = serde_json::json!(8192);
+        assert_ne!(
+            exact_cache_key(&b1, &normalize_messages(&b1).unwrap()).unwrap(),
+            exact_cache_key(&b4, &normalize_messages(&b4).unwrap()).unwrap()
+        );
+    }
+
+    #[test]
+    fn cosine_similarity_full_orthogonal_and_dimension_mismatch() {
+        assert!((cosine_similarity(&[1.0, 0.0], &[1.0, 0.0]) - 1.0).abs() < 1e-6);
+        assert!(cosine_similarity(&[1.0, 0.0], &[0.0, 1.0]).abs() < 1e-6);
+        assert_eq!(
+            cosine_similarity(&[1.0], &[1.0, 0.0]),
+            0.0,
+            "维度不符按 0 处理"
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_layer_hit_miss_and_ttl_expiry() {
+        let pool = memory_db().await;
+        let settings = settings_at(true);
+        let b = body(
+            serde_json::json!([{"role":"user","content":"网关怎么配额？"}]),
+            None,
+        );
+
+        // 未写入 → miss；关闭 → 恒 miss
+        assert!(lookup(&pool, &settings, &b, false).await.is_none());
+        let off = settings_at(false);
+        assert!(lookup(&pool, &off, &b, false).await.is_none());
+
+        store(&pool, &settings, &b, "配额在密钥页设置。").await;
+        let hit = lookup(&pool, &settings, &b, false).await.unwrap();
+        assert_eq!(hit.answer, "配额在密钥页设置。");
+        assert_eq!(hit.layer, "exact");
+
+        // TTL 过期 → 不命中
+        sqlx::query("UPDATE semantic_cache SET ttl_expire_at = '2020-01-01T00:00:00+00:00'")
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert!(
+            lookup(&pool, &settings, &b, false).await.is_none(),
+            "过期不命中"
+        );
+        assert_eq!(purge_expired(&pool).await, 1, "过期清理生效");
+    }
+
+    #[tokio::test]
+    async fn semantic_layer_hits_above_threshold_via_similarity() {
+        let pool = memory_db().await;
+        let mut settings = settings_at(true);
+        settings
+            .set_many(&[(
+                "cache.embedding_model".to_string(),
+                serde_json::json!("emb-test"),
+            )])
+            .unwrap();
+        // 直接植入已知向量条目（不经 embedder——渠道依赖在集成测试外）：
+        // 缓存条目向量 = 查询向量（相似度 1.0 ≥ 阈值必命中）
+        let vector = vec![0.1f32, 0.2, 0.3];
+        sqlx::query(
+            "INSERT INTO semantic_cache (id, cache_key, model, embedding, answer, ttl_expire_at, created_at) \
+             VALUES ('c1', 'sc_seed_1', 'm', ?, '语义近邻答案', '2999-01-01T00:00:00+00:00', ?)",
+        )
+        .bind(encode_f32_blob(&vector))
+        .bind(crate::db::models::now_iso())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // exact 层不命中（键不同）→ semantic 层：查询向量与条目一致 → 命中
+        // （embedder 无渠道会失败 → lookup 回退 None——这里绕过 lookup 直测相似度路径
+        //   的组成件：余弦 + 编解码往返）
+        let round = decode_f32_blob(&encode_f32_blob(&vector)).unwrap();
+        assert_eq!(round, vector);
+        assert!(cosine_similarity(&vector, &round) >= 0.95);
+    }
+
+    #[test]
+    fn replay_body_and_sse_frames_are_well_formed() {
+        let replay = replay_body("m", "答案");
+        assert_eq!(replay["choices"][0]["message"]["content"], "答案");
+        assert_eq!(replay["choices"][0]["finish_reason"], "stop");
+
+        let sse = replay_sse_frames("m", "你好世界");
+        assert!(sse.starts_with("data: {"));
+        assert!(sse.contains("\"role\":\"assistant\""));
+        assert!(
+            sse.contains("你好世界") || sse.contains("\\u"),
+            "内容帧应包含答案文本"
+        );
+        assert!(
+            sse.trim_end().ends_with("data: [DONE]"),
+            "流式回放必须以 [DONE] 收尾"
+        );
+    }
+}

--- a/src-tauri/src/semantic_cache.rs
+++ b/src-tauri/src/semantic_cache.rs
@@ -283,6 +283,22 @@ pub async fn store(
     }
 }
 
+/// 清空缓存：model 为 Some(非空) 时按模型清，否则清全部。返回删除行数。
+/// 管理命令（clear_semantic_cache）的实体，独立成函数便于测试。
+pub async fn clear(pool: &SqlitePool, model: Option<&str>) -> Result<u64, sqlx::Error> {
+    match model {
+        Some(m) if !m.is_empty() => sqlx::query("DELETE FROM semantic_cache WHERE model = ?")
+            .bind(m)
+            .execute(pool)
+            .await
+            .map(|r| r.rows_affected()),
+        _ => sqlx::query("DELETE FROM semantic_cache")
+            .execute(pool)
+            .await
+            .map(|r| r.rows_affected()),
+    }
+}
+
 /// 从缓存答案合成非流式 chat completion 响应体。
 pub fn replay_body(model: &str, answer: &str) -> serde_json::Value {
     serde_json::json!({
@@ -575,5 +591,39 @@ mod tests {
             sse.trim_end().ends_with("data: [DONE]"),
             "流式回放必须以 [DONE] 收尾"
         );
+    }
+
+    /// 清空语义（管理命令实体）：按模型清与全清，返回删除行数。
+    #[tokio::test]
+    async fn clear_by_model_and_all() {
+        let pool = memory_db().await;
+        for (key, model) in [("sc_a_1", "m1"), ("sc_b_1", "m1"), ("sc_c_1", "m2")] {
+            sqlx::query(
+                "INSERT INTO semantic_cache (id, cache_key, model, embedding, answer, ttl_expire_at, created_at) \
+                 VALUES (?, ?, ?, NULL, ?, '2999-01-01T00:00:00+00:00', ?)",
+            )
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(key)
+            .bind(model)
+            .bind("ans")
+            .bind(crate::db::models::now_iso())
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        // 按模型清 m1 → 删 2 行，剩 m2
+        assert_eq!(clear(&pool, Some("m1")).await.unwrap(), 2);
+        let remaining: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM semantic_cache WHERE model = 'm2'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(remaining, 1);
+
+        // 空字符串等价全部清
+        assert_eq!(clear(&pool, Some("")).await.unwrap(), 1);
+        // None 全清（空表返回 0）
+        assert_eq!(clear(&pool, None).await.unwrap(), 0);
     }
 }

--- a/src-tauri/src/server/admin_routes.rs
+++ b/src-tauri/src/server/admin_routes.rs
@@ -603,6 +603,9 @@ async fn dispatch(shared: &SharedState, cmd: &str, args: Value) -> Result<Value,
             to_json(commands::stats::get_token_trend(arg(&args, "hours")?, state).await)
         }
         "get_settings" => to_json(commands::settings::get_settings(state).await),
+        "clear_semantic_cache" => {
+            to_json(commands::settings::clear_semantic_cache(arg(&args, "model")?, state).await)
+        }
         "save_settings" => {
             to_json(commands::settings::save_settings(arg(&args, "settings")?, state).await)
         }

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -560,6 +560,64 @@ pub async fn handle_chat_completions(
         return (StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS, Json(err_body)).into_response();
     }
 
+    // 语义缓存拦截（C-02）：Key 鉴权与安全门之后、路由候选之前。
+    // 默认关闭；带 tools/高温/审计命中的请求直接旁路。命中返回缓存答案
+    //（非流式 JSON / 流式 SSE 回放，响应头 X-Cache: hit），并照常写请求
+    // 日志行（记账口径不变）。
+    let audit_hit_for_cache = audit_result.risk_score > 0 || audit_result.sanitized;
+    if let Some(hit) = crate::semantic_cache::lookup(
+        repo.pool(),
+        &shared.state.settings,
+        &json,
+        audit_hit_for_cache,
+    )
+    .await
+    {
+        let model = json.get("model").and_then(|m| m.as_str()).unwrap_or("");
+        tracing::debug!("[语义缓存] 命中（{} 层）: {model}", hit.layer);
+        let cache_log = sqlx::query(
+            "INSERT INTO request_logs (id, seq, api_key_id, api_key_name, model, mode, status_code, \
+             duration_ms, is_stream, is_retry, created_at, response_choices, risk_level, \
+             security_action, upstream_type, trace_id) \
+             VALUES (?, (SELECT COALESCE(MAX(seq), 0) + 1 FROM request_logs), ?, ?, ?, 'chat', 200, \
+             0, ?, 0, ?, ?, 'low', 'audit', 'cache', ?)",
+        )
+        .bind(crate::utils::id::new_id())
+        .bind(&key_record.id)
+        .bind(&key_record.name)
+        .bind(model)
+        .bind(i64::from(is_stream))
+        .bind(crate::db::models::now_iso())
+        .bind(
+            serde_json::to_string(&crate::semantic_cache::replay_body(model, &hit.answer))
+                .unwrap_or_default(),
+        )
+        .bind(trace_id.clone())
+        .execute(repo.pool())
+        .await;
+        if let Err(error) = cache_log {
+            tracing::warn!("[语义缓存] 命中日志行写入失败（不影响响应）: {error}");
+        }
+        let mut response = if is_stream {
+            (
+                [(header::CONTENT_TYPE, "text/event-stream")],
+                [(header::CACHE_CONTROL, "no-cache")],
+                crate::semantic_cache::replay_sse_frames(model, &hit.answer),
+            )
+                .into_response()
+        } else {
+            (
+                [(header::CONTENT_TYPE, "application/json")],
+                axum::Json(crate::semantic_cache::replay_body(model, &hit.answer)),
+            )
+                .into_response()
+        };
+        response
+            .headers_mut()
+            .insert("x-cache", axum::http::HeaderValue::from_static("hit"));
+        return response;
+    }
+
     // T06: when `new_routeplan` is ON, route through the model-first RoutePlan
     // facade first (stream and non-stream both).  `Ok(None)` means the flag is
     // off and the legacy flat path runs unchanged.
@@ -608,11 +666,35 @@ pub async fn handle_chat_completions(
         )
         .await
         {
-            Ok(result) => (
-                StatusCode::from_u16(result.status).unwrap_or(StatusCode::OK),
-                Json(result.body),
-            )
-                .into_response(),
+            Ok(result) => {
+                // 语义缓存写入（C-02，best-effort 旁路）：非流式 2xx 且可缓存判定
+                // 通过时，响应完整落账后异步写缓存——失败仅告警不影响主请求。
+                let cache_status = result.status;
+                if (200..300).contains(&cache_status) {
+                    if let Some(answer) = result
+                        .body
+                        .get("choices")
+                        .and_then(|c| c.get(0))
+                        .and_then(|c| c.get("message"))
+                        .and_then(|m| m.get("content"))
+                        .and_then(|c| c.as_str())
+                        .map(|s| s.to_string())
+                    {
+                        let pool = repo.pool().clone();
+                        let settings = shared.state.settings.clone();
+                        let cache_body = json.clone();
+                        tokio::spawn(async move {
+                            crate::semantic_cache::store(&pool, &settings, &cache_body, &answer)
+                                .await;
+                        });
+                    }
+                }
+                (
+                    StatusCode::from_u16(result.status).unwrap_or(StatusCode::OK),
+                    Json(result.body),
+                )
+                    .into_response()
+            }
             Err((code, msg)) => {
                 let err_body = serde_json::json!({
                     "error": { "message": msg, "type": "upstream_error", "code": code }

--- a/src-tauri/src/server/router.rs
+++ b/src-tauri/src/server/router.rs
@@ -326,6 +326,110 @@ mod tests {
         assert_eq!(res.status(), StatusCode::OK);
     }
 
+    // ─── C-02：语义缓存端到端（命中短路 + X-Cache 头 + 记账）────────────────
+
+    async fn seed_cache_state(state: &Arc<AppState>, key: &str) {
+        sqlx::query(
+            "INSERT INTO api_keys (id, name, key, created_at, updated_at) \
+             VALUES ('ck-1', 'cache-test', ?, ?, ?)",
+        )
+        .bind(key)
+        .bind("2026-09-09T00:00:00+00:00")
+        .bind("2026-09-09T00:00:00+00:00")
+        .execute(&state.db.pool)
+        .await
+        .unwrap();
+        state
+            .settings
+            .set_many(&[(
+                "cache.semantic_enabled".to_string(),
+                serde_json::json!(true),
+            )])
+            .unwrap();
+    }
+
+    fn cache_chat_request(key: &str, content: &str) -> Request<Body> {
+        let body = serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": content}],
+            "temperature": 0.0
+        });
+        Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {key}"))
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn semantic_cache_hit_short_circuits_upstream_with_hit_header() {
+        let state = test_state().await;
+        seed_cache_state(&state, "sk-cache-1").await;
+
+        // 种入缓存条目（测试库无任何渠道——若拦截失效请求会 503 No channels）
+        let body = serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": "  相同   问题 "}],
+            "temperature": 0.0
+        });
+        crate::semantic_cache::store(&state.db.pool, &state.settings, &body, "缓存的答案").await;
+
+        let shared = test_shared(&state, Some(ADMIN_TOKEN), Some(MCP_TOKEN));
+        let app = build_router(state.clone(), shared);
+
+        // 规范化等价请求（空白差异）→ exact 命中
+        let res = app
+            .oneshot(cache_chat_request("sk-cache-1", "相同 问题"))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(
+            res.headers().get("x-cache").and_then(|v| v.to_str().ok()),
+            Some("hit"),
+            "命中必须带 X-Cache: hit"
+        );
+        let bytes = axum::body::to_bytes(res.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value["choices"][0]["message"]["content"], "缓存的答案");
+
+        // 命中照常记账
+        let logged: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM request_logs WHERE mode = 'chat' AND upstream_type = 'cache'",
+        )
+        .fetch_one(&state.db.pool)
+        .await
+        .unwrap();
+        assert_eq!(logged, 1, "命中请求应写 upstream_type=cache 的日志行");
+    }
+
+    #[tokio::test]
+    async fn semantic_cache_disabled_or_uncacheable_passes_through() {
+        let state = test_state().await;
+        seed_cache_state(&state, "sk-cache-2").await;
+        // 关闭开关
+        state
+            .settings
+            .set_many(&[(
+                "cache.semantic_enabled".to_string(),
+                serde_json::json!(false),
+            )])
+            .unwrap();
+        let shared = test_shared(&state, Some(ADMIN_TOKEN), Some(MCP_TOKEN));
+        let app = build_router(state, shared);
+
+        // 关闭时：无渠道可用 → 503（证明未走缓存拦截短路）
+        let res = app
+            .oneshot(cache_chat_request("sk-cache-2", "任意问题"))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert!(res.headers().get("x-cache").is_none());
+    }
+
     #[tokio::test]
     async fn cors_only_covers_data_plane_not_service_routes() {
         let state = test_state().await;

--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -120,6 +120,11 @@ pub async fn run(cfg: WebServerConfig) -> Result<(), String> {
         state.settings.clone(),
     ));
 
+    // 语义缓存过期清理（C-02；缓存未启用时清理为空操作）
+    tauri::async_runtime::spawn(crate::semantic_cache::run_maintenance_loop(
+        state.db.pool.clone(),
+    ));
+
     tauri::async_runtime::spawn(crate::auth_provider::maintenance::run_maintenance_loop(
         auth_service,
     ));

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -573,3 +573,8 @@ export const appConfigApi = {
   getContent: (appName: string) => invoke<ConfigContent>("get_app_config_content", { appName }),
   openFolder: (appName: string) => invoke<void>("open_config_folder", { appName }),
 };
+
+// 语义缓存管理命令（C-02）
+export const semanticCacheApi = {
+  clear: (model?: string) => invoke<number>("clear_semantic_cache", { model: model ?? null }),
+};

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { settingsApi, serverApi, securityApi, ocrApi, type OcrCacheInfo } from "../lib/api";
+import { settingsApi, serverApi, securityApi, ocrApi, semanticCacheApi, type OcrCacheInfo } from "../lib/api";
 import { isWebRuntime } from "../lib/web";
 import { PanelSettingsSection } from "../components/PanelSettingsSection";
 import type { Settings, BuiltinRule, CustomRule } from "../types";
@@ -606,6 +606,61 @@ export function SettingsPage() {
                   <option value={0}>永久保留</option>
                 </select>
                 <p className="mt-1 text-xs text-muted-foreground">过期审计日志会由服务自动清理；删除后数据库文件需单独压缩才会缩小。</p>
+              </div>
+            </div>
+          </div>
+          <div>
+            <h3 className="mb-3 text-sm font-medium text-muted-foreground">语义缓存</h3>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <label className="surface-soft flex items-center justify-between rounded-2xl px-4 py-4">
+                <div>
+                  <div className="text-sm font-medium">启用语义缓存</div>
+                  <p className="text-xs text-muted-foreground">相同/同义请求直接返回缓存答案（响应头 X-Cache: hit）。带工具调用、高温采样、安全审计命中的请求永不入缓存。默认关闭。</p>
+                </div>
+                <input
+                  type="checkbox"
+                  checked={settings.cache_enabled}
+                  onChange={e => setSettings({ ...settings, cache_enabled: e.target.checked })}
+                  className="h-5 w-5"
+                />
+              </label>
+              <div>
+                <label className="mb-2 block text-sm font-medium">嵌入模型（语义层）</label>
+                <input
+                  type="text"
+                  value={settings.cache_embedding_model}
+                  onChange={e => setSettings({ ...settings, cache_embedding_model: e.target.value })}
+                  placeholder="留空 = 仅精确匹配层"
+                  className={inputCls}
+                />
+                <p className="mt-1 text-xs text-muted-foreground">填写渠道中的 Embedding 模型名以启用语义相似命中（阈值默认 0.95，保守）。</p>
+              </div>
+              <div>
+                <label className="mb-2 block text-sm font-medium">缓存 TTL（秒）</label>
+                <input
+                  type="number"
+                  min={60}
+                  value={settings.cache_ttl_secs}
+                  onChange={e => setSettings({ ...settings, cache_ttl_secs: Number(e.target.value) })}
+                  className={inputCls}
+                />
+                <p className="mt-1 text-xs text-muted-foreground">默认 86400（24 小时），过期自动不命中并由后台清理。</p>
+              </div>
+              <div>
+                <label className="mb-2 block text-sm font-medium">手动清空缓存</label>
+                <button
+                  onClick={async () => {
+                    try {
+                      const n = await semanticCacheApi.clear();
+                      window.alert(`已清空 ${n} 条缓存`);
+                    } catch (e) {
+                      window.alert(`清空失败：${e}`);
+                    }
+                  }}
+                  className="rounded-full border border-border px-4 py-2 text-sm font-medium hover:bg-white/5"
+                >
+                  清空全部缓存条目
+                </button>
               </div>
             </div>
           </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -432,6 +432,11 @@ export interface Settings {
   ocr_dpi: number;
   log_detail_level: "basic" | "detailed" | string;
   log_retention_days: number;
+  // 语义缓存（C-02，默认关闭）
+  cache_enabled: boolean;
+  cache_ttl_secs: number;
+  cache_threshold_percent: number;
+  cache_embedding_model: string;
 }
 
 // Security rule types


### PR DESCRIPTION
Closes #91

## 开始原因

重复语义请求每次全价过模型。与上游 prompt cache 统计（026/029）互补：那是上游前缀缓存命中统计，本 PR 是网关侧响应缓存。

## 方案

- **两层**：exact（messages 规范化 SHA-256 + model + 温度/长度档位，O(1)）+ semantic（复用渠道 embedding，暴力余弦 ≥ 0.95；缓存量级下暴力扫可接受）。
- **三层风险收敛**：默认关闭；可缓存判定（无 tools/tool_choice、temperature ≤ 0.3、安全审计无命中、纯文本消息——带 tools 永不入缓存）；保守阈值。
- 拦截在 Key 鉴权与安全门后、路由候选前（chat completions）；命中非流式 JSON / 流式标准增量 SSE 回放，`X-Cache: hit`；命中照常落账（upstream_type=cache）。
- 写入异步 best-effort；TTL 默认 24h + 后台清理 + 手动清空命令（按模型/全部）；设置页缓存区。

## 设计修正（如实声明）

渠道级覆盖 → 模型粒度（拦截点在路由前渠道不可知）；只拦 chat 协议（流式回放已支持，流式响应自身写入为后续）；不做自动语义失效。

## 测试

规范化/判定/键稳定性/余弦纯函数；exact 命中-TTL-清理；清空语义；回放帧形态；router 端到端（测试库无渠道——命中 200 即证明未过上游 + X-Cache 头 + 记账行；关闭时 503 直通）。