### PR TITLE
修复 Anthropic 容量错误信封导致的故障转移问题

### DIFF
--- a/src-tauri/src/endpoint_executor/driver.rs
+++ b/src-tauri/src/endpoint_executor/driver.rs
@@ -911,6 +911,34 @@ pub(crate) async fn route_stream_plan_with_auth_service(
                                 continue;
                             }
                         };
+                        if attempt.upstream_protocol == "anthropic" {
+                            if let Some(message) =
+                                crate::endpoint_executor::anthropic_stream_error_message(
+                                    &first_frame,
+                                )
+                            {
+                                let failure = AttemptFailure {
+                                    failure_class: FailureClass::Retryable,
+                                    message: format!("Anthropic upstream stream error: {message}"),
+                                    status_code: Some(502),
+                                    retry_after: None,
+                                };
+                                if let Some(channel_id) = health_channel_id.as_deref() {
+                                    record_channel_mode_outcome(
+                                        repo,
+                                        channel_id,
+                                        endpoint.as_str(),
+                                        true,
+                                        &crate::core::attempt::AttemptResult::Failure(
+                                            failure.clone(),
+                                        ),
+                                    )
+                                    .await;
+                                }
+                                flow.record_failure(&failure);
+                                continue;
+                            }
+                        }
 
                         let mut supervisor =
                             crate::core::stream_supervisor::StreamSupervisor::new();

--- a/src-tauri/src/endpoint_executor/driver.rs
+++ b/src-tauri/src/endpoint_executor/driver.rs
@@ -73,21 +73,20 @@ fn extract_reasoning_effort(audited: &AuditedRequest) -> Option<String> {
     }
 }
 
-/// Multi-key load balancing: if the channel has extra API keys in
-/// `channel_api_keys`, randomly select one weighted by `weight`. The
-/// primary `api_key` on the channel row always participates with its
-/// channel-level `weight`. Returns the channel unchanged on error or when
-/// no extra keys exist.
-async fn select_channel_key(channel: &Channel, repo: &Arc<Repository>) -> Channel {
+/// Freeze the enabled credential slots for one request and order them by
+/// weighted sampling without replacement.  The returned `Channel` copies are
+/// intentionally request-local: credential values never enter PreparedAttempt,
+/// request logs, or tracing fields.
+async fn channel_key_slots(channel: &Channel, repo: &Arc<Repository>) -> Vec<Channel> {
     let extra_keys = match repo.get_channel_api_keys(&channel.id).await {
         Ok(keys) => keys
             .into_iter()
             .filter(|k| k.status == 1)
             .collect::<Vec<_>>(),
-        Err(_) => return channel.clone(),
+        Err(_) => return vec![channel.clone()],
     };
     if extra_keys.is_empty() {
-        return channel.clone();
+        return vec![channel.clone()];
     }
     // Build weighted pool: primary key (weight = channel.weight) + extras.
     let mut pool: Vec<(String, i64)> = Vec::new();
@@ -98,15 +97,71 @@ async fn select_channel_key(channel: &Channel, repo: &Arc<Repository>) -> Channe
         pool.push((k.api_key.clone(), k.weight.max(1)));
     }
     if pool.is_empty() {
-        return channel.clone();
+        return vec![channel.clone()];
     }
-    // FIX-10：加权选择收敛为 core::weighted_key 单一实现（等权多 Key 均匀
-    // 分布；旧内联实现 `pick <= 0` 边界错误使第二个 Key 永远轮空，#34 根因）。
-    let chosen = crate::core::weighted_key::pick_weighted_key(&pool)
-        .unwrap_or_else(|| channel.api_key.clone());
-    let mut ch = channel.clone();
-    ch.api_key = chosen;
-    ch
+    // Duplicate values are one credential slot, not two chances to send the
+    // same secret. Preserve the first configured weight for deterministic
+    // de-duplication without ever exposing the value outside this function.
+    let mut unique = Vec::new();
+    for item in pool {
+        if !unique.iter().any(|(key, _): &(String, i64)| key == &item.0) {
+            unique.push(item);
+        }
+    }
+    let mut slots = Vec::with_capacity(unique.len());
+    while !unique.is_empty() {
+        let chosen = crate::core::weighted_key::pick_weighted_key(&unique)
+            .unwrap_or_else(|| unique[0].0.clone());
+        if let Some(index) = unique.iter().position(|(key, _)| key == &chosen) {
+            unique.remove(index);
+        } else {
+            break;
+        }
+        let mut slot = channel.clone();
+        slot.api_key = chosen;
+        slots.push(slot);
+    }
+    slots
+}
+
+/// Try every frozen credential slot only while the failure is retryable.
+/// This makes capacity envelopes useful for a channel with multiple keys while
+/// retaining the route planner's terminal/auth boundaries.
+async fn dispatch_channel_with_key_failover(
+    endpoint: EndpointKind,
+    attempt: &crate::core::attempt::PreparedAttempt,
+    channel: &Channel,
+    identity: &crate::core::channel_identity::ChannelIdentity,
+    safe_headers: &[(String, String)],
+    query: Option<&str>,
+    repo: &Arc<Repository>,
+) -> crate::core::attempt::AttemptResult {
+    let slots = channel_key_slots(channel, repo).await;
+    let mut last = None;
+    // Keep credential expansion bounded by the same conservative default as
+    // RoutePlan's per-group budget. The planner still owns cross-candidate and
+    // total-attempt limits; this cap prevents a channel with dozens of keys
+    // from bypassing those limits in one closure invocation.
+    for slot in slots.into_iter().take(3) {
+        let result =
+            dispatch_executor(endpoint, attempt, &slot, identity, safe_headers, query).await;
+        match result {
+            crate::core::attempt::AttemptResult::Failure(ref failure)
+                if failure.failure_class == FailureClass::Retryable =>
+            {
+                last = Some(result)
+            }
+            _ => return result,
+        }
+    }
+    last.unwrap_or_else(|| {
+        crate::core::attempt::AttemptResult::Failure(AttemptFailure {
+            failure_class: FailureClass::Retryable,
+            message: "no enabled channel credential slot".to_string(),
+            status_code: Some(502),
+            retry_after: None,
+        })
+    })
 }
 
 fn candidate_lookup(plan: &RoutePlan) -> HashMap<String, RouteCandidate> {
@@ -293,16 +348,14 @@ pub(crate) async fn route_plan_response_with_auth_service(
             async move {
                 match candidate {
                     Some(RouteCandidate::Channel { channel, identity }) => {
-                        // Multi-key load balancing: if the channel has extra
-                        // API keys, randomly select one weighted by priority.
-                        let channel = select_channel_key(&channel, &mode_health_repo).await;
-                        let result = dispatch_executor(
+                        let result = dispatch_channel_with_key_failover(
                             endpoint,
                             &attempt,
                             &channel,
                             &identity,
                             &safe,
                             query.as_deref(),
+                            &mode_health_repo,
                         )
                         .await;
                         record_channel_mode_outcome(
@@ -795,7 +848,11 @@ pub(crate) async fn route_stream_plan_with_auth_service(
 
                 let dispatched = match candidate {
                     Some(RouteCandidate::Channel { channel, identity }) => {
-                        let channel = select_channel_key(&channel, repo).await;
+                        let channel = channel_key_slots(&channel, repo)
+                            .await
+                            .into_iter()
+                            .next()
+                            .unwrap_or(channel);
                         dispatch_stream_executor(
                             endpoint,
                             &attempt,
@@ -911,33 +968,22 @@ pub(crate) async fn route_stream_plan_with_auth_service(
                                 continue;
                             }
                         };
-                        if attempt.upstream_protocol == "anthropic" {
-                            if let Some(message) =
-                                crate::endpoint_executor::anthropic_stream_error_message(
-                                    &first_frame,
+                        if let Some(failure) = crate::endpoint_executor::semantic_stream_failure(
+                            &attempt.upstream_protocol,
+                            &first_frame,
+                        ) {
+                            if let Some(channel_id) = health_channel_id.as_deref() {
+                                record_channel_mode_outcome(
+                                    repo,
+                                    channel_id,
+                                    endpoint.as_str(),
+                                    true,
+                                    &crate::core::attempt::AttemptResult::Failure(failure.clone()),
                                 )
-                            {
-                                let failure = AttemptFailure {
-                                    failure_class: FailureClass::Retryable,
-                                    message: format!("Anthropic upstream stream error: {message}"),
-                                    status_code: Some(502),
-                                    retry_after: None,
-                                };
-                                if let Some(channel_id) = health_channel_id.as_deref() {
-                                    record_channel_mode_outcome(
-                                        repo,
-                                        channel_id,
-                                        endpoint.as_str(),
-                                        true,
-                                        &crate::core::attempt::AttemptResult::Failure(
-                                            failure.clone(),
-                                        ),
-                                    )
-                                    .await;
-                                }
-                                flow.record_failure(&failure);
-                                continue;
+                                .await;
                             }
+                            flow.record_failure(&failure);
+                            continue;
                         }
 
                         let mut supervisor =

--- a/src-tauri/src/endpoint_executor/mod.rs
+++ b/src-tauri/src/endpoint_executor/mod.rs
@@ -566,6 +566,61 @@ pub fn classify_upstream_status(status: u16, body: &str) -> Option<FailureClass>
     crate::core::attempt::classify_http_status_with_body(status, Some(body))
 }
 
+/// Detect an Anthropic error envelope even when a compatible gateway returns
+/// HTTP 2xx.  Several Claude gateways encode capacity/overload as
+/// `{"type":"error","error":{...}}` with a successful transport status.
+/// Keep this parser deliberately conservative: ordinary successful Messages
+/// responses have `type=message` and are never classified as errors.
+pub fn anthropic_error_envelope_message(body: &Value) -> Option<String> {
+    let is_error = body.get("type").and_then(Value::as_str) == Some("error")
+        || body
+            .get("error")
+            .is_some_and(|error| error.is_object() || error.is_string());
+    if !is_error {
+        return None;
+    }
+    let error = body.get("error").unwrap_or(body);
+    let kind = error
+        .get("type")
+        .and_then(Value::as_str)
+        .or_else(|| error.get("code").and_then(Value::as_str))
+        .unwrap_or("error");
+    let message = error
+        .get("message")
+        .and_then(Value::as_str)
+        .or_else(|| error.as_str())
+        .unwrap_or("Anthropic upstream returned an error")
+        .chars()
+        .take(300)
+        .collect::<String>();
+    Some(format!("{kind}: {message}"))
+}
+
+/// Parse a bounded response body and detect an Anthropic error envelope.
+pub fn anthropic_error_envelope_from_bytes(bytes: &[u8]) -> Option<String> {
+    serde_json::from_slice::<Value>(bytes)
+        .ok()
+        .and_then(|value| anthropic_error_envelope_message(&value))
+}
+
+/// Inspect one complete Anthropic SSE record for an error event/envelope.
+pub fn anthropic_stream_error_message(record: &[u8]) -> Option<String> {
+    let text = std::str::from_utf8(record).ok()?;
+    let event_error = text.lines().any(|line| line.trim() == "event: error");
+    let mut data = String::new();
+    for line in text.lines() {
+        let line = line.trim_start();
+        if let Some(value) = line.strip_prefix("data:") {
+            data.push_str(value.trim_start());
+        }
+    }
+    let envelope = anthropic_error_envelope_from_bytes(data.as_bytes());
+    if event_error {
+        return envelope.or_else(|| Some("error: Anthropic upstream stream error".to_string()));
+    }
+    envelope
+}
+
 /// Build a classified [`AttemptFailure`] from an upstream non-2xx.
 ///
 /// `retry_after_secs` — when the upstream returned a `Retry-After` header,
@@ -895,6 +950,7 @@ pub async fn dispatch_executor(
     // Snapshot headers for the success path AND the decode-failure diagnostics
     // before `bytes()` consumes the response.
     let response_headers = safe_response_headers(resp.headers());
+    let retry_after = retry_after_from_headers(resp.headers()).map(|d| d.as_secs());
     let content_encoding = resp
         .headers()
         .get(reqwest::header::CONTENT_ENCODING)
@@ -959,6 +1015,22 @@ pub async fn dispatch_executor(
             }
         }
     };
+    if attempt.upstream_protocol == "anthropic"
+        && (200..300).contains(&status)
+        && anthropic_error_envelope_message(&body).is_some()
+    {
+        let message = anthropic_error_envelope_message(&body)
+            .unwrap_or_else(|| "Anthropic upstream returned a 2xx error envelope".to_string());
+        return AttemptResult::Failure(AttemptFailure {
+            failure_class: FailureClass::Retryable,
+            message,
+            // A 2xx transport carrying an error envelope is not a successful
+            // downstream response.  Expose the gateway failure status while
+            // retaining the original body message for diagnostics.
+            status_code: Some(502),
+            retry_after,
+        });
+    }
     // Legacy Gemini override: the upstream `generateContent` response must be
     // converted back to OpenAI Chat (this is the ONLY executor that converts
     // responses; it is selected exclusively via identity override).
@@ -1247,6 +1319,31 @@ mod tests {
         assert_eq!(
             auth_headers(AuthScheme::OptionalBearer, "k"),
             vec![("authorization".to_string(), "Bearer k".to_string())]
+        );
+    }
+
+    #[test]
+    fn anthropic_error_envelopes_include_overload_and_ignore_messages_success() {
+        let error = serde_json::json!({
+            "type": "error",
+            "error": {"type": "overloaded_error", "message": "Selected model is at capacity."}
+        });
+        assert_eq!(
+            anthropic_error_envelope_message(&error).as_deref(),
+            Some("overloaded_error: Selected model is at capacity.")
+        );
+        assert!(anthropic_error_envelope_message(&serde_json::json!({
+            "type": "message", "content": [], "stop_reason": "end_turn"
+        }))
+        .is_none());
+    }
+
+    #[test]
+    fn anthropic_stream_error_envelope_is_detected_before_commit() {
+        let record = b"event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"busy\"}}\n\n";
+        assert_eq!(
+            anthropic_stream_error_message(record).as_deref(),
+            Some("overloaded_error: busy")
         );
     }
 

--- a/src-tauri/src/endpoint_executor/mod.rs
+++ b/src-tauri/src/endpoint_executor/mod.rs
@@ -201,6 +201,9 @@ pub async fn dispatch_auth_account_executor(
                 })
             }
         };
+        if let Some(failure) = semantic_failure(&attempt.upstream_protocol, &body) {
+            return AttemptResult::Failure(failure);
+        }
         return match decode_non_stream(downstream, attempt, &body) {
             Ok((body, usage)) => AttemptResult::Success(AttemptSuccess {
                 status,
@@ -249,6 +252,9 @@ pub async fn dispatch_auth_account_executor(
         Ok(body) => body,
         Err(error) => return AttemptResult::Failure(responses_protocol_failure(error.message)),
     };
+    if let Some(failure) = semantic_failure(&attempt.upstream_protocol, &body) {
+        return AttemptResult::Failure(failure);
+    }
     match decode_non_stream(downstream, attempt, &body) {
         Ok((body, usage)) => AttemptResult::Success(AttemptSuccess {
             status,
@@ -566,34 +572,82 @@ pub fn classify_upstream_status(status: u16, body: &str) -> Option<FailureClass>
     crate::core::attempt::classify_http_status_with_body(status, Some(body))
 }
 
-/// Detect an Anthropic error envelope even when a compatible gateway returns
-/// HTTP 2xx.  Several Claude gateways encode capacity/overload as
-/// `{"type":"error","error":{...}}` with a successful transport status.
-/// Keep this parser deliberately conservative: ordinary successful Messages
-/// responses have `type=message` and are never classified as errors.
-pub fn anthropic_error_envelope_message(body: &Value) -> Option<String> {
-    let is_error = body.get("type").and_then(Value::as_str) == Some("error")
-        || body
-            .get("error")
-            .is_some_and(|error| error.is_object() || error.is_string());
-    if !is_error {
+/// 将 HTTP 2xx 中的协议失败统一收敛到这里。这个函数只接受已读完的
+/// JSON/SSE data，绝不消费无界流；调用者仍负责 HTTP 状态分类。
+///
+/// 不以任意 `message` 中出现 error 为依据。必须是协议规定的 error shape，
+/// 才会在下游提交前触发故障转移。
+pub fn semantic_failure(protocol: &str, body: &Value) -> Option<AttemptFailure> {
+    let response_status = body.get("status").and_then(Value::as_str);
+    let responses_failed =
+        protocol == "openai" && matches!(response_status, Some("failed") | Some("cancelled"));
+    let anthropic_error = protocol == "anthropic"
+        && (body.get("type").and_then(Value::as_str) == Some("error")
+            || body.get("error").is_some_and(|v| !v.is_null()));
+    // OpenAI-compatible providers conventionally use a top-level non-null
+    // error object. A normal Chat/Responses success does not have this shape.
+    let openai_error = protocol != "anthropic" && body.get("error").is_some_and(|v| !v.is_null());
+    if !(responses_failed || anthropic_error || openai_error) {
         return None;
     }
-    let error = body.get("error").unwrap_or(body);
+    let error = body.get("error").filter(|v| !v.is_null()).unwrap_or(body);
     let kind = error
         .get("type")
         .and_then(Value::as_str)
         .or_else(|| error.get("code").and_then(Value::as_str))
-        .unwrap_or("error");
+        .or_else(|| body.get("type").and_then(Value::as_str))
+        .unwrap_or("upstream_error");
     let message = error
         .get("message")
         .and_then(Value::as_str)
+        .or_else(|| body.get("message").and_then(Value::as_str))
         .or_else(|| error.as_str())
-        .unwrap_or("Anthropic upstream returned an error")
+        .unwrap_or("upstream returned a semantic error")
         .chars()
         .take(300)
         .collect::<String>();
-    Some(format!("{kind}: {message}"))
+    let retry_after = error
+        .get("retry_after")
+        .and_then(|v| v.as_u64())
+        .or_else(|| body.get("retry_after").and_then(|v| v.as_u64()))
+        .map(|seconds| seconds.min(RETRY_AFTER_CAP_SECS));
+    let haystack = format!(
+        "{} {}",
+        kind.to_ascii_lowercase(),
+        message.to_ascii_lowercase()
+    );
+    let failure_class = if haystack.contains("invalid_api_key")
+        || haystack.contains("authentication")
+        || haystack.contains("unauthorized")
+        || haystack.contains("permission_denied")
+    {
+        FailureClass::ChannelAuthTerminal
+    } else if haystack.contains("invalid_request")
+        || haystack.contains("invalid model")
+        || haystack.contains("unsupported parameter")
+    {
+        FailureClass::CallerTerminal
+    } else {
+        // overload/rate-limit have the same routing result as provider-side
+        // temporary failures: retry another credential/candidate.
+        FailureClass::Retryable
+    };
+    Some(AttemptFailure {
+        failure_class,
+        message: format!("{kind}: {message}"),
+        status_code: Some(if failure_class == FailureClass::CallerTerminal {
+            400
+        } else {
+            502
+        }),
+        retry_after,
+    })
+}
+
+/// Backwards-compatible Anthropic helper retained for the existing callers and
+/// tests. New code should use [`semantic_failure`].
+pub fn anthropic_error_envelope_message(body: &Value) -> Option<String> {
+    semantic_failure("anthropic", body).map(|failure| failure.message)
 }
 
 /// Parse a bounded response body and detect an Anthropic error envelope.
@@ -601,6 +655,50 @@ pub fn anthropic_error_envelope_from_bytes(bytes: &[u8]) -> Option<String> {
     serde_json::from_slice::<Value>(bytes)
         .ok()
         .and_then(|value| anthropic_error_envelope_message(&value))
+}
+
+/// Inspect a complete upstream SSE record before any downstream byte is sent.
+/// It supports multi-line `data:` fields and both event-name and JSON shapes.
+pub fn semantic_stream_failure(protocol: &str, record: &[u8]) -> Option<AttemptFailure> {
+    let text = std::str::from_utf8(record).ok()?;
+    let event = text
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("event:").map(str::trim));
+    let data = text
+        .lines()
+        .filter_map(|line| line.trim_start().strip_prefix("data:").map(str::trim_start))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if protocol == "anthropic" && event == Some("error") {
+        return serde_json::from_str::<Value>(&data)
+            .ok()
+            .and_then(|value| semantic_failure(protocol, &value))
+            .or_else(|| {
+                Some(AttemptFailure {
+                    failure_class: FailureClass::Retryable,
+                    message: "Anthropic upstream stream error".to_string(),
+                    status_code: Some(502),
+                    retry_after: None,
+                })
+            });
+    }
+    if protocol == "openai" && matches!(event, Some("response.failed") | Some("response.cancelled"))
+    {
+        return serde_json::from_str::<Value>(&data)
+            .ok()
+            .and_then(|value| semantic_failure(protocol, value.get("response").unwrap_or(&value)))
+            .or_else(|| {
+                Some(AttemptFailure {
+                    failure_class: FailureClass::Retryable,
+                    message: "Responses upstream stream failed before output".to_string(),
+                    status_code: Some(502),
+                    retry_after: None,
+                })
+            });
+    }
+    serde_json::from_str::<Value>(&data)
+        .ok()
+        .and_then(|value| semantic_failure(protocol, &value))
 }
 
 /// Inspect one complete Anthropic SSE record for an error event/envelope.
@@ -1015,21 +1113,9 @@ pub async fn dispatch_executor(
             }
         }
     };
-    if attempt.upstream_protocol == "anthropic"
-        && (200..300).contains(&status)
-        && anthropic_error_envelope_message(&body).is_some()
-    {
-        let message = anthropic_error_envelope_message(&body)
-            .unwrap_or_else(|| "Anthropic upstream returned a 2xx error envelope".to_string());
-        return AttemptResult::Failure(AttemptFailure {
-            failure_class: FailureClass::Retryable,
-            message,
-            // A 2xx transport carrying an error envelope is not a successful
-            // downstream response.  Expose the gateway failure status while
-            // retaining the original body message for diagnostics.
-            status_code: Some(502),
-            retry_after,
-        });
+    if let Some(mut failure) = semantic_failure(&attempt.upstream_protocol, &body) {
+        failure.retry_after = retry_after;
+        return AttemptResult::Failure(failure);
     }
     // Legacy Gemini override: the upstream `generateContent` response must be
     // converted back to OpenAI Chat (this is the ONLY executor that converts
@@ -1345,6 +1431,34 @@ mod tests {
             anthropic_stream_error_message(record).as_deref(),
             Some("overloaded_error: busy")
         );
+    }
+
+    #[test]
+    fn semantic_failure_covers_responses_and_openai_compatible_shapes() {
+        let failed =
+            serde_json::json!({"status":"failed","error":{"code":"server_error","message":"busy"}});
+        assert_eq!(
+            semantic_failure("openai", &failed).unwrap().failure_class,
+            FailureClass::Retryable
+        );
+        let cancelled = serde_json::json!({"status":"cancelled"});
+        assert!(semantic_failure("openai", &cancelled).is_some());
+        let compat = serde_json::json!({"error":{"type":"rate_limit_error","message":"slow down"}});
+        assert_eq!(
+            semantic_failure("openai", &compat).unwrap().failure_class,
+            FailureClass::Retryable
+        );
+        let success = serde_json::json!({"object":"chat.completion","message":"error text"});
+        assert!(semantic_failure("openai", &success).is_none());
+    }
+
+    #[test]
+    fn responses_failed_sse_envelope_is_detected() {
+        let record = br#"event: response.failed
+data: {"type":"response.failed","response":{"status":"failed","error":{"message":"capacity"}}}
+
+"#;
+        assert!(semantic_stream_failure("openai", record).is_some());
     }
 
     #[test]

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -2216,6 +2216,61 @@ pub async fn handle_messages(
                 .await
             {
                 Ok((response, upstream_model)) if response.status().is_success() => {
+                    if !stream {
+                        let status = response.status();
+                        let headers = valuable_anthropic_response_headers(response.headers());
+                        let bytes = response.bytes().await.unwrap_or_default();
+                        if let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes) {
+                            if let Some(failure) =
+                                crate::endpoint_executor::semantic_failure("anthropic", &value)
+                            {
+                                last_error = format!("{}: {}", channel.name, failure.message);
+                                last_native_error = Some(StoredNativeError {
+                                    status: StatusCode::BAD_GATEWAY,
+                                    content_type: Some(axum::http::HeaderValue::from_static("application/json")),
+                                    headers,
+                                    body: bytes::Bytes::from(serde_json::to_vec(&serde_json::json!({"type":"error","error":{"type":"api_error","message":failure.message}})).unwrap_or_default()),
+                                });
+                                continue;
+                            }
+                            let usage = native_usage(&bytes, false);
+                            let mut merged_security = security_result.clone();
+                            security::scan_response_into(
+                                &mut merged_security,
+                                &value,
+                                &audited.security_settings,
+                                &[],
+                            );
+                            record_anthropic_success(
+                                repo.clone(),
+                                &key,
+                                &channel,
+                                &model,
+                                upstream_model.clone(),
+                                &sanitized_log_json,
+                                &merged_security,
+                                false,
+                                usage,
+                            )
+                            .await;
+                            let mut builder = Response::builder().status(status);
+                            for (name, value) in headers {
+                                builder = builder.header(name, value);
+                            }
+                            return builder.body(Body::from(bytes)).unwrap_or_else(|_| {
+                                anthropic_error(
+                                    StatusCode::BAD_GATEWAY,
+                                    "api_error",
+                                    "Unable to proxy native Anthropic response",
+                                )
+                            });
+                        }
+                        return anthropic_error(
+                            StatusCode::BAD_GATEWAY,
+                            "api_error",
+                            "Invalid JSON from native Anthropic channel",
+                        );
+                    }
                     return native_response(
                         response,
                         Some(StreamLogContext {
@@ -2229,7 +2284,7 @@ pub async fn handle_messages(
                             security_settings: audited.security_settings.clone(),
                             is_stream: stream,
                         }),
-                    )
+                    );
                 }
                 Ok((response, upstream_model)) => {
                     let status = StatusCode::from_u16(response.status().as_u16())

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -1306,6 +1306,7 @@ async fn native_anthropic_request(
     let mut request = client
         .post(url)
         .header("x-api-key", &config.api_key)
+        .header("anthropic-version", "2023-06-01")
         .header("content-type", "application/json");
     for (name, value) in forwarded_anthropic_headers(headers) {
         request = request.header(name, value);


### PR DESCRIPTION
## 变更概述

本 PR 修复上游以 HTTP 2xx 返回 Anthropic/Responses 业务失败信封时未触发故障转移的问题，并将语义失败判断接入统一执行链路。

- 新增协议感知的语义失败检测：Anthropic `type=error`、Responses `status=failed/cancelled`、OpenAI 兼容顶层 `error`。
- 非流式响应在 decoder、成功用量统计和下游写入前完成检测；容量、限流和临时 provider 错误按 `Retryable` 进入候选切换。
- RoutePlan 流式请求在首个完整 SSE 记录提交前检测 Anthropic `event: error`、Responses `response.failed/response.cancelled` 及对应错误数据。
- 普通渠道的 primary key 与启用的附加 `channel_api_keys` 在请求内按权重无重复尝试，并限制单次候选的凭证尝试数量。
- Auth Account 的 JSON/Responses SSE 非流式执行路径复用同一语义失败边界。
- legacy 原生 Anthropic 非流式路径在提交前检查 2xx 错误信封，并保持成功响应的 usage 与安全审计记账。
- Anthropic 上游请求继续统一注入默认 `anthropic-version: 2023-06-01`，并保留显式安全请求头过滤。

## 问题背景

部分上游会返回如下 HTTP 200 响应：

```json
{"type":"error","error":{"type":"overloaded_error","message":"Selected model is at capacity."}}
```

传输层成功并不代表业务成功。此前这类响应可能被当作正常结果透传或交给 decoder，导致客户端直接收到容量错误，网关没有利用其他候选渠道或凭证恢复请求。

## 验证

- `cargo check --no-default-features`
- `cargo test endpoint_executor:: --no-default-features`
- 新增 Responses/OpenAI 兼容 JSON 与 SSE 语义失败检测测试
- `git diff --check`

endpoint_executor 相关测试全部通过；编译过程中仅有仓库既有的 unused/dead-code 警告。

## 范围说明

本 PR 的提交屏障已覆盖 RoutePlan 流式路径和 legacy 原生 Anthropic 非流式路径。legacy 原生 Anthropic 流式路径仍保留原有透传结构，完整的 legacy 流首帧缓冲、回放和提交前切换需要后续独立提交，避免在本 PR 中引入未完成的半成品实现。

本地 `openspec/` 目录仅用于设计资料，未加入 PR。