### PR TITLE
feat: 能力增强第二批整合——渠道主动健康探测 + KB 检索增强（RRF/重排/改写）+ Prompt 模板版本化 + 语义缓存

### DIFF
--- a/src-tauri/migrations/033_channel_probe.sql
+++ b/src-tauri/migrations/033_channel_probe.sql
@@ -1,0 +1,7 @@
+-- 渠道主动健康探测（C-04）：
+-- channels 三列为探测状态（NULL = 从未探测，视为健康参与正常排序）；
+-- request_logs.is_probe 标记探测流量，统计/用量口径排除，避免污染用户账单。
+ALTER TABLE channels ADD COLUMN last_probe_at TEXT;
+ALTER TABLE channels ADD COLUMN last_probe_ok INTEGER;
+ALTER TABLE channels ADD COLUMN probe_latency_ms INTEGER;
+ALTER TABLE request_logs ADD COLUMN is_probe INTEGER NOT NULL DEFAULT 0;

--- a/src-tauri/migrations/034_prompt_templates.sql
+++ b/src-tauri/migrations/034_prompt_templates.sql
@@ -1,0 +1,15 @@
+-- Prompt 模板版本化（C-07）：RAG 系统提示词从源码硬编码迁移为可版本化管理。
+-- 启动时按 key 检测空表则把源码字面量逐字节写入 v1（升级后行为不变的硬保证）；
+-- 运行时按 key + active 读取，读失败回退编译期默认（双保险）。
+CREATE TABLE IF NOT EXISTS prompt_templates (
+    id TEXT PRIMARY KEY,
+    template_key TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    active INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    UNIQUE(template_key, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_prompt_templates_active
+    ON prompt_templates(template_key, active);

--- a/src-tauri/migrations/035_semantic_cache.sql
+++ b/src-tauri/migrations/035_semantic_cache.sql
@@ -1,0 +1,13 @@
+-- 语义缓存（C-02）：网关侧响应缓存（exact 规范化哈希层 + semantic embedding 余弦层）。
+-- 默认关闭（cache.semantic_enabled=false）；TTL 默认 24h；带 tools 的请求永不入缓存。
+CREATE TABLE IF NOT EXISTS semantic_cache (
+    id TEXT PRIMARY KEY,
+    cache_key TEXT NOT NULL UNIQUE,
+    model TEXT NOT NULL,
+    embedding BLOB,
+    answer TEXT NOT NULL,
+    ttl_expire_at TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_semantic_cache_model ON semantic_cache(model, ttl_expire_at);

--- a/src-tauri/src/commands/channel.rs
+++ b/src-tauri/src/commands/channel.rs
@@ -46,6 +46,10 @@ pub struct ChannelDto {
     pub updated_at: String,
     pub last_test_at: Option<String>,
     pub last_test_ok: Option<i64>,
+    /// 主动健康探测（迁移 033）：探测列优先展示，无探测数据回退手动测试列。
+    pub last_probe_at: Option<String>,
+    pub last_probe_ok: Option<i64>,
+    pub probe_latency_ms: Option<i64>,
     // --- Multi-key: extra API keys for load balancing (migration 023) ---
     pub extra_keys: Vec<ChannelKeyDto>,
 }
@@ -104,6 +108,9 @@ impl From<Channel> for ChannelDto {
             updated_at: c.updated_at,
             last_test_at: c.last_test_at,
             last_test_ok: c.last_test_ok,
+            last_probe_at: c.last_probe_at,
+            last_probe_ok: c.last_probe_ok,
+            probe_latency_ms: c.probe_latency_ms,
             extra_keys: Vec::new(), // populated by to_dto_with_keys
         }
     }

--- a/src-tauri/src/commands/import_export.rs
+++ b/src-tauri/src/commands/import_export.rs
@@ -1022,6 +1022,9 @@ mod tests {
             updated_at: "2026-08-01T00:00:00.000Z".into(),
             last_test_at: Some("2026-08-01T00:00:00.000Z".into()),
             last_test_ok: Some(1),
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 
@@ -1052,6 +1055,9 @@ mod tests {
             updated_at: "2026-07-01T00:00:00.000Z".into(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod import_export;
 pub mod knowledge_base;
 pub mod log;
 pub mod log_repair;
+pub mod prompt_template;
 pub mod security;
 pub mod server;
 pub mod services;

--- a/src-tauri/src/commands/prompt_template.rs
+++ b/src-tauri/src/commands/prompt_template.rs
@@ -1,0 +1,104 @@
+//! Prompt 模板管理命令（C-07）：按 key 列版本、编辑新建版本、一键激活回滚。
+//! 变更写请求日志（mode=prompt_admin）——prompt 变更可追溯。
+
+use crate::AppState;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PromptTemplateDto {
+    pub id: String,
+    pub template_key: String,
+    pub version: i64,
+    pub content: String,
+    pub active: bool,
+    pub created_at: String,
+}
+
+/// 变更审计行（不走 create_log 漏斗：管理面操作，无正文策略语义）。
+async fn write_audit(
+    state: &std::sync::Arc<AppState>,
+    action: &str,
+    template_key: &str,
+    detail: &str,
+) {
+    let result = sqlx::query(
+        "INSERT INTO request_logs (id, seq, model, mode, status_code, duration_ms, is_stream, \
+         is_retry, created_at, risk_level, security_action, upstream_type, error_message) \
+         VALUES (?, (SELECT COALESCE(MAX(seq), 0) + 1 FROM request_logs), ?, 'prompt_admin', 200, \
+         0, 0, 0, ?, 'low', 'audit', 'admin', ?)",
+    )
+    .bind(crate::utils::id::new_id())
+    .bind(template_key)
+    .bind(crate::db::models::now_iso())
+    .bind(format!("{action}: {detail}"))
+    .execute(&state.db.pool)
+    .await;
+    if let Err(error) = result {
+        tracing::warn!("[模板] 审计行写入失败: {error}");
+    }
+}
+
+#[tauri::command]
+pub async fn list_prompt_templates(
+    state: tauri::State<'_, std::sync::Arc<AppState>>,
+) -> Result<Vec<PromptTemplateDto>, String> {
+    list_prompt_templates_impl(&state).await
+}
+
+pub async fn list_prompt_templates_impl(
+    state: &std::sync::Arc<AppState>,
+) -> Result<Vec<PromptTemplateDto>, String> {
+    let rows = crate::prompt_templates::list_templates(&state.db.pool)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(rows
+        .into_iter()
+        .map(|row| PromptTemplateDto {
+            id: row.id,
+            template_key: row.template_key,
+            version: row.version,
+            content: row.content,
+            active: row.active,
+            created_at: row.created_at,
+        })
+        .collect())
+}
+
+#[tauri::command]
+pub async fn create_prompt_template(
+    template_key: String,
+    content: String,
+    state: tauri::State<'_, std::sync::Arc<AppState>>,
+) -> Result<i64, String> {
+    create_prompt_template_impl(&template_key, &content, &state).await
+}
+
+pub async fn create_prompt_template_impl(
+    template_key: &str,
+    content: &str,
+    state: &std::sync::Arc<AppState>,
+) -> Result<i64, String> {
+    let version =
+        crate::prompt_templates::create_version(&state.db.pool, template_key, content).await?;
+    write_audit(state, "create", template_key, &format!("v{version}")).await;
+    Ok(version)
+}
+
+#[tauri::command]
+pub async fn activate_prompt_template(
+    template_key: String,
+    version: i64,
+    state: tauri::State<'_, std::sync::Arc<AppState>>,
+) -> Result<(), String> {
+    activate_prompt_template_impl(&template_key, version, &state).await
+}
+
+pub async fn activate_prompt_template_impl(
+    template_key: &str,
+    version: i64,
+    state: &std::sync::Arc<AppState>,
+) -> Result<(), String> {
+    crate::prompt_templates::activate_version(&state.db.pool, template_key, version).await?;
+    write_audit(state, "activate", template_key, &format!("v{version}")).await;
+    Ok(())
+}

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -490,17 +490,7 @@ pub async fn clear_semantic_cache(
     model: Option<String>,
     state: tauri::State<'_, std::sync::Arc<AppState>>,
 ) -> Result<u64, String> {
-    let pool = &state.db.pool;
-    let result = match model.as_deref() {
-        Some(m) if !m.is_empty() => sqlx::query("DELETE FROM semantic_cache WHERE model = ?")
-            .bind(m)
-            .execute(pool)
-            .await
-            .map_err(|e| e.to_string())?,
-        _ => sqlx::query("DELETE FROM semantic_cache")
-            .execute(pool)
-            .await
-            .map_err(|e| e.to_string())?,
-    };
-    Ok(result.rows_affected())
+    crate::semantic_cache::clear(&state.db.pool, model.as_deref())
+        .await
+        .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -77,6 +77,17 @@ pub struct Settings {
     pub probe_enabled: bool,
     #[serde(default = "default_probe_interval_secs")]
     pub probe_interval_secs: u64,
+    /// 语义缓存开关（C-02，默认关）。关闭时拦截/写入/清理全部旁路。
+    #[serde(default = "default_false")]
+    pub cache_enabled: bool,
+    #[serde(default = "default_cache_ttl_secs")]
+    pub cache_ttl_secs: u64,
+    /// 语义层相似度阈值（百分比，95 = 0.95；保守默认）。
+    #[serde(default = "default_cache_threshold")]
+    pub cache_threshold_percent: u64,
+    /// 语义层嵌入模型（空 = 只启用 exact 层）。
+    #[serde(default)]
+    pub cache_embedding_model: String,
 }
 
 fn default_otlp_interval_secs() -> u64 {
@@ -87,6 +98,12 @@ fn default_otlp_batch_size() -> u64 {
 }
 fn default_probe_interval_secs() -> u64 {
     300
+}
+fn default_cache_ttl_secs() -> u64 {
+    86_400
+}
+fn default_cache_threshold() -> u64 {
+    95
 }
 
 fn default_port() -> u16 {
@@ -170,6 +187,10 @@ impl Default for Settings {
             otlp_batch_size: default_otlp_batch_size(),
             probe_enabled: default_true(),
             probe_interval_secs: default_probe_interval_secs(),
+            cache_enabled: default_false(),
+            cache_ttl_secs: default_cache_ttl_secs(),
+            cache_threshold_percent: default_cache_threshold(),
+            cache_embedding_model: String::new(),
         }
     }
 }
@@ -260,6 +281,10 @@ pub async fn get_settings(state: tauri::State<'_, Arc<AppState>>) -> Result<Sett
         otlp_batch_size: get_u64(store, "otlp.batch_size", 50),
         probe_enabled: get_bool(store, "probe.enabled", true),
         probe_interval_secs: get_u64(store, "probe.interval_secs", 300),
+        cache_enabled: get_bool(store, "cache.semantic_enabled", false),
+        cache_ttl_secs: get_u64(store, "cache.ttl_secs", 86_400),
+        cache_threshold_percent: get_u64(store, "cache.semantic_threshold_percent", 95),
+        cache_embedding_model: get_str(store, "cache.embedding_model", ""),
     };
     Ok(settings)
 }
@@ -400,6 +425,22 @@ pub async fn save_settings(
             "probe.interval_secs".to_string(),
             serde_json::json!(settings.probe_interval_secs),
         ),
+        (
+            "cache.semantic_enabled".to_string(),
+            serde_json::json!(settings.cache_enabled),
+        ),
+        (
+            "cache.ttl_secs".to_string(),
+            serde_json::json!(settings.cache_ttl_secs),
+        ),
+        (
+            "cache.semantic_threshold_percent".to_string(),
+            serde_json::json!(settings.cache_threshold_percent),
+        ),
+        (
+            "cache.embedding_model".to_string(),
+            serde_json::json!(settings.cache_embedding_model),
+        ),
     ])?;
     crate::audit_log::apply_settings(&state.settings);
     // 缩短保留期后立即清理，避免等待后台维护周期。
@@ -441,4 +482,25 @@ pub async fn set_auto_start(enabled: bool, app: AppHandle) -> Result<(), String>
         }
         Ok(())
     }
+}
+
+/// 清空语义缓存（C-02 管理命令）：model 为 None 时清全部，否则按模型清。
+#[tauri::command]
+pub async fn clear_semantic_cache(
+    model: Option<String>,
+    state: tauri::State<'_, std::sync::Arc<AppState>>,
+) -> Result<u64, String> {
+    let pool = &state.db.pool;
+    let result = match model.as_deref() {
+        Some(m) if !m.is_empty() => sqlx::query("DELETE FROM semantic_cache WHERE model = ?")
+            .bind(m)
+            .execute(pool)
+            .await
+            .map_err(|e| e.to_string())?,
+        _ => sqlx::query("DELETE FROM semantic_cache")
+            .execute(pool)
+            .await
+            .map_err(|e| e.to_string())?,
+    };
+    Ok(result.rows_affected())
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -72,6 +72,11 @@ pub struct Settings {
     pub otlp_interval_secs: u64,
     #[serde(default = "default_otlp_batch_size")]
     pub otlp_batch_size: u64,
+    /// 渠道主动健康探测开关（默认开）。关闭时零后台流量。
+    #[serde(default = "default_true")]
+    pub probe_enabled: bool,
+    #[serde(default = "default_probe_interval_secs")]
+    pub probe_interval_secs: u64,
 }
 
 fn default_otlp_interval_secs() -> u64 {
@@ -79,6 +84,9 @@ fn default_otlp_interval_secs() -> u64 {
 }
 fn default_otlp_batch_size() -> u64 {
     50
+}
+fn default_probe_interval_secs() -> u64 {
+    300
 }
 
 fn default_port() -> u16 {
@@ -160,6 +168,8 @@ impl Default for Settings {
             otlp_headers: String::new(),
             otlp_interval_secs: default_otlp_interval_secs(),
             otlp_batch_size: default_otlp_batch_size(),
+            probe_enabled: default_true(),
+            probe_interval_secs: default_probe_interval_secs(),
         }
     }
 }
@@ -248,6 +258,8 @@ pub async fn get_settings(state: tauri::State<'_, Arc<AppState>>) -> Result<Sett
         otlp_headers: get_str(store, "otlp.headers", ""),
         otlp_interval_secs: get_u64(store, "otlp.export_interval_secs", 30),
         otlp_batch_size: get_u64(store, "otlp.batch_size", 50),
+        probe_enabled: get_bool(store, "probe.enabled", true),
+        probe_interval_secs: get_u64(store, "probe.interval_secs", 300),
     };
     Ok(settings)
 }
@@ -379,6 +391,14 @@ pub async fn save_settings(
         (
             "otlp.batch_size".to_string(),
             serde_json::json!(settings.otlp_batch_size),
+        ),
+        (
+            "probe.enabled".to_string(),
+            serde_json::json!(settings.probe_enabled),
+        ),
+        (
+            "probe.interval_secs".to_string(),
+            serde_json::json!(settings.probe_interval_secs),
         ),
     ])?;
     crate::audit_log::apply_settings(&state.settings);

--- a/src-tauri/src/core/attempt.rs
+++ b/src-tauri/src/core/attempt.rs
@@ -627,6 +627,9 @@ mod tests {
             updated_at: "2026-01-01T00:00:00Z".into(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 

--- a/src-tauri/src/core/dispatcher.rs
+++ b/src-tauri/src/core/dispatcher.rs
@@ -96,6 +96,9 @@ mod tests {
             updated_at: "2026-01-01T00:00:00Z".into(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 

--- a/src-tauri/src/core/plan_executor.rs
+++ b/src-tauri/src/core/plan_executor.rs
@@ -324,6 +324,9 @@ mod tests {
             updated_at: "2026-01-01T00:00:00Z".into(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 

--- a/src-tauri/src/core/proxy.rs
+++ b/src-tauri/src/core/proxy.rs
@@ -390,6 +390,10 @@ pub async fn handle_request(
                     }
                 }
 
+                // 被动反哺（C-04）：真实请求成功 → 恢复该渠道的主动探测健康标记
+                // （best-effort，与日志/配额递增同级的旁路更新）。
+                repo.mark_probe_ok(&channel.id);
+
                 return Ok(ProxyResult {
                     status,
                     body: resp_body,

--- a/src-tauri/src/core/route_plan.rs
+++ b/src-tauri/src/core/route_plan.rs
@@ -1343,6 +1343,9 @@ mod tests {
             updated_at: "2026-01-01T00:00:00Z".into(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 
@@ -1388,6 +1391,9 @@ mod tests {
             updated_at: "2026-01-01T00:00:00Z".into(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -52,6 +52,14 @@ pub struct Channel {
     pub updated_at: String,
     pub last_test_at: Option<String>,
     pub last_test_ok: Option<i64>,
+    /// 主动健康探测（迁移 033）：NULL = 从未探测（排序视为健康）。
+    /// default：部分集成测试只迁移到 015，行中无这些列时按「未探测」处理。
+    #[sqlx(default)]
+    pub last_probe_at: Option<String>,
+    #[sqlx(default)]
+    pub last_probe_ok: Option<i64>,
+    #[sqlx(default)]
+    pub probe_latency_ms: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src-tauri/src/db/repository.rs
+++ b/src-tauri/src/db/repository.rs
@@ -43,11 +43,70 @@ impl Repository {
     }
 
     pub async fn get_enabled_channels(&self) -> Result<Vec<Channel>, sqlx::Error> {
+        // 主动探测（C-04）：探测失败的渠道沉底不剔除（NULL=从未探测，视为健康）。
+        // 同健康档内保持既有优先级/权重序；两轨候选查询共用此排序语义。
         sqlx::query_as::<_, Channel>(
-            "SELECT * FROM channels WHERE status = 1 ORDER BY priority DESC, weight DESC",
+            "SELECT * FROM channels WHERE status = 1 \
+             ORDER BY COALESCE(last_probe_ok, 1) DESC, priority DESC, weight DESC",
         )
         .fetch_all(&self.pool)
         .await
+    }
+
+    /// 记录一次主动探测结果：更新渠道探测三列 + 写 is_probe=1 日志行
+    /// （统计口径排除，避免污染用户用量）。直接 SQL 最小列集，不走
+    /// create_log 漏斗（探测行无正文、不受明细级别影响）。
+    pub async fn record_channel_probe(
+        &self,
+        channel_id: &str,
+        channel_name: &str,
+        outcome: crate::health_probe::ProbeOutcome,
+        now: &str,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "UPDATE channels SET last_probe_at = ?, last_probe_ok = ?, probe_latency_ms = ?, \
+             updated_at = ? WHERE id = ?",
+        )
+        .bind(now)
+        .bind(i64::from(outcome.ok))
+        .bind(outcome.latency_ms)
+        .bind(now)
+        .bind(channel_id)
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            "INSERT INTO request_logs (id, seq, channel_id, channel_name, model, mode, \
+             status_code, duration_ms, is_stream, is_retry, created_at, risk_level, \
+             security_action, upstream_type, is_probe) \
+             VALUES (?, (SELECT COALESCE(MAX(seq), 0) + 1 FROM request_logs), ?, ?, ?, 'probe', \
+             ?, ?, 0, 0, ?, 'low', 'audit', 'channel', 1)",
+        )
+        .bind(crate::utils::id::new_id())
+        .bind(channel_id)
+        .bind(channel_name)
+        .bind(channel_name)
+        .bind(if outcome.ok { 200 } else { 502 })
+        .bind(outcome.latency_ms)
+        .bind(now)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// 被动反哺：真实请求成功后立即恢复该渠道的探测健康标记
+    /// （与 mode_health 的成功清除相互独立、各管各的表）。
+    pub async fn mark_probe_ok(&self, channel_id: &str) {
+        let result = sqlx::query(
+            "UPDATE channels SET last_probe_ok = 1, last_probe_at = ?, updated_at = ? WHERE id = ?",
+        )
+        .bind(crate::db::models::now_iso())
+        .bind(crate::db::models::now_iso())
+        .bind(channel_id)
+        .execute(&self.pool)
+        .await;
+        if let Err(error) = result {
+            tracing::warn!("[探测] 被动反哺失败（channel {channel_id}）: {error}");
+        }
     }
 
     /// Return channels that are enabled and not cooling down for this exact
@@ -69,7 +128,7 @@ impl Repository {
               AND h.is_stream = ?
              WHERE c.status = 1
                AND (h.cooldown_until IS NULL OR h.cooldown_until <= ?)
-             ORDER BY c.priority DESC, c.weight DESC",
+             ORDER BY COALESCE(c.last_probe_ok, 1) DESC, c.priority DESC, c.weight DESC",
         )
         .bind(endpoint)
         .bind(i64::from(is_stream))
@@ -1720,15 +1779,16 @@ impl Repository {
         let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
         let today_prefix = format!("{}%", today);
 
-        let today_requests: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM request_logs WHERE created_at LIKE ?")
-                .bind(&today_prefix)
-                .fetch_one(&self.pool)
-                .await
-                .unwrap_or(0);
+        let today_requests: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM request_logs WHERE created_at LIKE ? AND is_probe = 0",
+        )
+        .bind(&today_prefix)
+        .fetch_one(&self.pool)
+        .await
+        .unwrap_or(0);
 
         let today_total_tokens: i64 = sqlx::query_scalar(
-            "SELECT COALESCE(SUM(total_tokens), 0) FROM request_logs WHERE created_at LIKE ?",
+            "SELECT COALESCE(SUM(total_tokens), 0) FROM request_logs WHERE created_at LIKE ? AND is_probe = 0",
         )
         .bind(&today_prefix)
         .fetch_one(&self.pool)
@@ -1736,7 +1796,7 @@ impl Repository {
         .unwrap_or(0);
 
         let today_cached_tokens: i64 = sqlx::query_scalar(
-            "SELECT COALESCE(SUM(cached_tokens), 0) FROM request_logs WHERE created_at LIKE ?",
+            "SELECT COALESCE(SUM(cached_tokens), 0) FROM request_logs WHERE created_at LIKE ? AND is_probe = 0",
         )
         .bind(&today_prefix)
         .fetch_one(&self.pool)
@@ -1744,24 +1804,26 @@ impl Repository {
         .unwrap_or(0);
 
         let today_prompt_tokens: i64 = sqlx::query_scalar(
-            "SELECT COALESCE(SUM(prompt_tokens), 0) FROM request_logs WHERE created_at LIKE ?",
+            "SELECT COALESCE(SUM(prompt_tokens), 0) FROM request_logs WHERE created_at LIKE ? AND is_probe = 0",
         )
         .bind(&today_prefix)
         .fetch_one(&self.pool)
         .await
         .unwrap_or(0);
 
-        let total_cached_tokens: i64 =
-            sqlx::query_scalar("SELECT COALESCE(SUM(cached_tokens), 0) FROM request_logs")
-                .fetch_one(&self.pool)
-                .await
-                .unwrap_or(0);
+        let total_cached_tokens: i64 = sqlx::query_scalar(
+            "SELECT COALESCE(SUM(cached_tokens), 0) FROM request_logs WHERE is_probe = 0",
+        )
+        .fetch_one(&self.pool)
+        .await
+        .unwrap_or(0);
 
-        let total_prompt_tokens: i64 =
-            sqlx::query_scalar("SELECT COALESCE(SUM(prompt_tokens), 0) FROM request_logs")
-                .fetch_one(&self.pool)
-                .await
-                .unwrap_or(0);
+        let total_prompt_tokens: i64 = sqlx::query_scalar(
+            "SELECT COALESCE(SUM(prompt_tokens), 0) FROM request_logs WHERE is_probe = 0",
+        )
+        .fetch_one(&self.pool)
+        .await
+        .unwrap_or(0);
 
         let active_channels: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM channels WHERE status = 1")
@@ -1793,19 +1855,21 @@ impl Repository {
             .await
             .unwrap_or(0);
 
-        let total_requests: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM request_logs")
-            .fetch_one(&self.pool)
-            .await
-            .unwrap_or(0);
-
-        let total_tokens: i64 =
-            sqlx::query_scalar("SELECT COALESCE(SUM(total_tokens), 0) FROM request_logs")
+        let total_requests: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM request_logs WHERE is_probe = 0")
                 .fetch_one(&self.pool)
                 .await
                 .unwrap_or(0);
 
+        let total_tokens: i64 = sqlx::query_scalar(
+            "SELECT COALESCE(SUM(total_tokens), 0) FROM request_logs WHERE is_probe = 0",
+        )
+        .fetch_one(&self.pool)
+        .await
+        .unwrap_or(0);
+
         let avg_latency: f64 = sqlx::query_scalar(
-            "SELECT COALESCE(AVG(duration_ms), 0) FROM request_logs WHERE created_at LIKE ?",
+            "SELECT COALESCE(AVG(duration_ms), 0) FROM request_logs WHERE created_at LIKE ? AND is_probe = 0",
         )
         .bind(&today_prefix)
         .fetch_one(&self.pool)
@@ -1863,7 +1927,7 @@ impl Repository {
 
     pub async fn get_channel_stats(&self) -> Result<Vec<ChannelStats>, sqlx::Error> {
         sqlx::query_as::<_, ChannelStats>(
-            "SELECT\n                r.channel_id as channel_id,\n                COUNT(*) as total_calls,\n                SUM(CASE WHEN r.status_code >= 200 AND r.status_code < 300 THEN 1 ELSE 0 END) as success_calls,\n                SUM(CASE WHEN r.status_code >= 200 AND r.status_code < 300 THEN 0 ELSE 1 END) as failed_calls,\n                COALESCE(SUM(r.total_tokens), 0) as total_tokens,\n                COALESCE(SUM(r.prompt_tokens), 0) as prompt_tokens,\n                COALESCE(SUM(r.completion_tokens), 0) as completion_tokens,\n                COALESCE(AVG(r.duration_ms), 0) as avg_latency_ms,\n                MAX(r.created_at) as last_call_at\n            FROM request_logs r\n            WHERE r.channel_id IS NOT NULL\n            GROUP BY r.channel_id"
+            "SELECT\n                r.channel_id as channel_id,\n                COUNT(*) as total_calls,\n                SUM(CASE WHEN r.status_code >= 200 AND r.status_code < 300 THEN 1 ELSE 0 END) as success_calls,\n                SUM(CASE WHEN r.status_code >= 200 AND r.status_code < 300 THEN 0 ELSE 1 END) as failed_calls,\n                COALESCE(SUM(r.total_tokens), 0) as total_tokens,\n                COALESCE(SUM(r.prompt_tokens), 0) as prompt_tokens,\n                COALESCE(SUM(r.completion_tokens), 0) as completion_tokens,\n                COALESCE(AVG(r.duration_ms), 0) as avg_latency_ms,\n                MAX(r.created_at) as last_call_at\n            FROM request_logs r\n            WHERE r.channel_id IS NOT NULL AND r.is_probe = 0\n            GROUP BY r.channel_id"
         )
         .fetch_all(&self.pool)
         .await
@@ -1871,7 +1935,7 @@ impl Repository {
 
     pub async fn get_api_key_stats(&self) -> Result<Vec<ApiKeyStats>, sqlx::Error> {
         sqlx::query_as::<_, ApiKeyStats>(
-            "SELECT\n                r.api_key_id as api_key_id,\n                COUNT(*) as total_calls,\n                SUM(CASE WHEN r.status_code >= 200 AND r.status_code < 300 THEN 1 ELSE 0 END) as success_calls,\n                SUM(CASE WHEN r.status_code >= 200 AND r.status_code < 300 THEN 0 ELSE 1 END) as failed_calls,\n                COALESCE(SUM(r.total_tokens), 0) as total_tokens,\n                COALESCE(SUM(r.prompt_tokens), 0) as prompt_tokens,\n                COALESCE(SUM(r.completion_tokens), 0) as completion_tokens,\n                COALESCE(SUM(r.cached_tokens), 0) as cached_tokens,\n                COALESCE(AVG(r.duration_ms), 0) as avg_latency_ms,\n                MAX(r.created_at) as last_call_at\n            FROM request_logs r\n            WHERE r.api_key_id IS NOT NULL\n            GROUP BY r.api_key_id"
+            "SELECT\n                r.api_key_id as api_key_id,\n                COUNT(*) as total_calls,\n                SUM(CASE WHEN r.status_code >= 200 AND r.status_code < 300 THEN 1 ELSE 0 END) as success_calls,\n                SUM(CASE WHEN r.status_code >= 200 AND r.status_code < 300 THEN 0 ELSE 1 END) as failed_calls,\n                COALESCE(SUM(r.total_tokens), 0) as total_tokens,\n                COALESCE(SUM(r.prompt_tokens), 0) as prompt_tokens,\n                COALESCE(SUM(r.completion_tokens), 0) as completion_tokens,\n                COALESCE(SUM(r.cached_tokens), 0) as cached_tokens,\n                COALESCE(AVG(r.duration_ms), 0) as avg_latency_ms,\n                MAX(r.created_at) as last_call_at\n            FROM request_logs r\n            WHERE r.api_key_id IS NOT NULL AND r.is_probe = 0\n            GROUP BY r.api_key_id"
         )
         .fetch_all(&self.pool)
         .await
@@ -1887,7 +1951,7 @@ impl Repository {
         sqlx::query_as::<_, LogStats>(
             "SELECT substr(created_at, 1, 10) as date, COUNT(*) as count, COALESCE(SUM(total_tokens), 0) as total_tokens
              FROM request_logs
-             WHERE created_at >= ?
+             WHERE created_at >= ? AND is_probe = 0
              GROUP BY date
              ORDER BY date DESC"
         )
@@ -1909,6 +1973,7 @@ impl Repository {
                 ROUND(CAST(SUM(CASE WHEN status_code >= 200 AND status_code < 300 THEN 1.0 ELSE 0.0 END) AS REAL) / COUNT(*), 4) as success_rate,
                 COALESCE(AVG(duration_ms), 0) as avg_latency_ms
             FROM request_logs
+            WHERE is_probe = 0
             GROUP BY model
             ORDER BY total_tokens DESC
         "#;
@@ -1934,7 +1999,7 @@ impl Repository {
                 COALESCE(SUM(total_tokens), 0) as total_tokens,
                 COUNT(*) as request_count
             FROM request_logs
-            WHERE created_at >= ?
+            WHERE created_at >= ? AND is_probe = 0
             GROUP BY hour, model
             ORDER BY hour ASC
         "#;

--- a/src-tauri/src/endpoint_executor/driver.rs
+++ b/src-tauri/src/endpoint_executor/driver.rs
@@ -161,6 +161,9 @@ async fn record_channel_mode_outcome(
 ) {
     let outcome = match result {
         crate::core::attempt::AttemptResult::Success(_) => {
+            // 被动反哺（C-04）：真实请求传输成功 → 立即恢复渠道的主动探测
+            // 健康标记（与 mode_health 的成功清除正交，各管各的表）。
+            repo.mark_probe_ok(channel_id);
             repo.record_channel_mode_success(channel_id, endpoint, is_stream)
                 .await
         }
@@ -2128,6 +2131,9 @@ mod tests {
             updated_at: "2026-01-01T00:00:00Z".into(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 

--- a/src-tauri/src/endpoint_executor/integration_tests.rs
+++ b/src-tauri/src/endpoint_executor/integration_tests.rs
@@ -104,6 +104,9 @@ fn channel(
         updated_at: now(),
         last_test_at: None,
         last_test_ok: None,
+        last_probe_at: None,
+        last_probe_ok: None,
+        probe_latency_ms: None,
     }
 }
 

--- a/src-tauri/src/endpoint_executor/mock_tests.rs
+++ b/src-tauri/src/endpoint_executor/mock_tests.rs
@@ -182,6 +182,9 @@ fn channel(base_url: &str, api_key: &str) -> Channel {
         updated_at: "2026-01-01T00:00:00Z".into(),
         last_test_at: None,
         last_test_ok: None,
+        last_probe_at: None,
+        last_probe_ok: None,
+        probe_latency_ms: None,
     }
 }
 

--- a/src-tauri/src/health_probe.rs
+++ b/src-tauri/src/health_probe.rs
@@ -1,0 +1,305 @@
+//! 渠道主动健康探测（C-04）：后台循环对启用中的 API 渠道发廉价探测
+//! （GET {base_url}/models，带渠道 Key，短超时），结果落渠道探测列并记
+//! `is_probe=1` 请求日志。探测失败的渠道在候选排序中**沉底不剔除**——
+//! 保守策略，误杀渠道的代价高于排序损失。OAuth/Auth 账号渠道零探测
+//! （账号表不参与本循环，成本与配额敏感）。
+//!
+//! 与既有 `channel_mode_health` 被动冷却**正交**：那是请求驱动的
+//! （渠道×端点×流式）模式级冷却；本模块是渠道级的主动信号，
+//! GET /models 可达 ≠ 聊天模式健康，互不写对方的表。
+
+use crate::db::repository::Repository;
+use crate::settings_store::SettingsStore;
+use sqlx::SqlitePool;
+use std::time::Duration;
+
+const DEFAULT_INTERVAL_SECS: u64 = 300;
+/// 探测超时：比普通请求更严——探测的意义就是快速判定可达性。
+const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// 单渠道探测结果。
+#[derive(Debug, Clone, Copy)]
+pub struct ProbeOutcome {
+    pub ok: bool,
+    pub latency_ms: i64,
+}
+
+/// 对单个渠道发一次廉价探测。GET {base_url}/models（2xx 即健康）。
+pub async fn probe_channel(
+    client: &reqwest::Client,
+    base_url: &str,
+    api_key: &str,
+) -> ProbeOutcome {
+    let url = format!("{}/models", base_url.trim_end_matches('/'));
+    let started = std::time::Instant::now();
+    let ok = client
+        .get(&url)
+        .bearer_auth(api_key)
+        .timeout(PROBE_TIMEOUT)
+        .send()
+        .await
+        .map(|response| response.status().is_success())
+        .unwrap_or(false);
+    ProbeOutcome {
+        ok,
+        latency_ms: started.elapsed().as_millis() as i64,
+    }
+}
+
+/// 单轮探测步骤（测试与循环共用）：探测全部启用渠道 → 写探测列 + is_probe 日志行。
+/// 探测关闭（`probe.enabled=false`）时零网络请求零写库。
+pub async fn probe_step(
+    pool: &SqlitePool,
+    settings: &SettingsStore,
+) -> Vec<(String, ProbeOutcome)> {
+    if !settings.get_bool("probe.enabled", true) {
+        return Vec::new();
+    }
+    let repo = Repository::new(pool.clone());
+    let channels = match repo.get_enabled_channels().await {
+        Ok(channels) => channels,
+        Err(error) => {
+            tracing::warn!("[探测] 拉取启用渠道失败: {error}");
+            return Vec::new();
+        }
+    };
+    let client = reqwest::Client::new();
+    let mut outcomes = Vec::new();
+    for channel in channels {
+        let outcome = probe_channel(&client, &channel.base_url, &channel.api_key).await;
+        tracing::debug!(
+            "[探测] 渠道 {} ({}) -> ok={} latency={}ms",
+            channel.name,
+            channel.id,
+            outcome.ok,
+            outcome.latency_ms
+        );
+        if let Err(error) = repo
+            .record_channel_probe(
+                &channel.id,
+                &channel.name,
+                outcome,
+                &crate::db::models::now_iso(),
+            )
+            .await
+        {
+            tracing::warn!("[探测] 写入渠道 {} 探测结果失败: {error}", channel.id);
+        }
+        outcomes.push((channel.id, outcome));
+    }
+    outcomes
+}
+
+/// 后台探测循环：默认 300s 一轮，可整体关闭（关闭时零后台流量）。
+pub async fn run_probe_loop(pool: SqlitePool, settings: SettingsStore) {
+    loop {
+        let interval = Duration::from_secs(
+            settings
+                .get_u64("probe.interval_secs", DEFAULT_INTERVAL_SECS)
+                .max(30),
+        );
+        let outcomes = probe_step(&pool, &settings).await;
+        if !outcomes.is_empty() {
+            let failed = outcomes.iter().filter(|(_, o)| !o.ok).count();
+            if failed > 0 {
+                tracing::info!(
+                    "[探测] 本轮 {} 渠道，{} 个不健康（排序沉底）",
+                    outcomes.len(),
+                    failed
+                );
+            }
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn memory_db() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    fn settings_at(dir: &std::path::Path, enabled: bool) -> SettingsStore {
+        let store = SettingsStore::file(dir.join("settings.json"));
+        store
+            .set_many(&[("probe.enabled".to_string(), serde_json::json!(enabled))])
+            .unwrap();
+        store
+    }
+
+    async fn seed_channel(pool: &SqlitePool, id: &str, base_url: &str) {
+        sqlx::query(
+            "INSERT INTO channels (id, name, type, base_url, api_key, models, status, priority, \
+             weight, config, model_mapping, timeout_secs, identity_revision, created_at, updated_at) \
+             VALUES (?, ?, 'openai', ?, 'sk-x', '[]', 1, 1, 1, '{}', '{}', 60, 0, ?, ?)",
+        )
+        .bind(id)
+        .bind(id)
+        .bind(base_url)
+        .bind(crate::db::models::now_iso())
+        .bind(crate::db::models::now_iso())
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn mock_models_endpoint() -> String {
+        let app = axum::Router::new().route("/models", axum::routing::get(|| async { "[]" }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn probe_step_updates_columns_and_writes_probe_logs() {
+        let pool = memory_db().await;
+        let dir = std::env::temp_dir().join(format!("waliapi-probe-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let settings = settings_at(&dir, true);
+
+        let healthy_base = mock_models_endpoint().await;
+        seed_channel(&pool, "ch-ok", &healthy_base).await;
+        // 不可达端口（保留地址，必然连接失败）
+        seed_channel(&pool, "ch-bad", "http://127.0.0.1:1").await;
+        let outcomes = probe_step(&pool, &settings).await;
+        assert_eq!(outcomes.len(), 2, "两个启用渠道都应被探测");
+
+        let row = sqlx::query_as::<_, (Option<i64>, Option<i64>)>(
+            "SELECT last_probe_ok, probe_latency_ms FROM channels WHERE id = 'ch-ok'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0, Some(1), "健康渠道 last_probe_ok=1");
+
+        let row = sqlx::query_as::<_, (Option<i64>, Option<i64>)>(
+            "SELECT last_probe_ok, probe_latency_ms FROM channels WHERE id = 'ch-bad'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0, Some(0), "不可达渠道 last_probe_ok=0");
+
+        // is_probe 日志行：每渠道一条
+        let probes: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM request_logs WHERE is_probe = 1")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(probes, 2, "每个被探测渠道应记一条 is_probe 日志");
+        let mode: String =
+            sqlx::query_scalar("SELECT mode FROM request_logs WHERE is_probe = 1 LIMIT 1")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(mode, "probe");
+    }
+
+    #[tokio::test]
+    async fn probe_disabled_means_zero_traffic_and_writes() {
+        let pool = memory_db().await;
+        let dir = std::env::temp_dir().join(format!("waliapi-probe-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let settings = settings_at(&dir, false);
+
+        let base = mock_models_endpoint().await;
+        seed_channel(&pool, "ch-x", &base).await;
+
+        let outcomes = probe_step(&pool, &settings).await;
+        assert!(outcomes.is_empty(), "关闭时零探测");
+        let probes: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM request_logs WHERE is_probe = 1")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(probes, 0, "关闭时零日志写入");
+        let never: Option<i64> =
+            sqlx::query_scalar("SELECT last_probe_ok FROM channels WHERE id = 'ch-x'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(never.is_none(), "关闭时探测列保持 NULL（从未探测）");
+    }
+
+    #[tokio::test]
+    async fn unhealthy_channels_sink_in_candidate_ordering() {
+        let pool = memory_db().await;
+        let repo = Repository::new(pool.clone());
+        // 高优先级但探测失败 / 中优先级从未探测 / 低优先级探测健康
+        for (id, priority) in [("sink", 9), ("mid", 5), ("ok", 1)] {
+            sqlx::query(
+                "INSERT INTO channels (id, name, type, base_url, api_key, models, status, priority, \
+                 weight, config, model_mapping, timeout_secs, identity_revision, created_at, updated_at) \
+                 VALUES (?, ?, 'openai', 'http://127.0.0.1:1', 'sk-x', '[]', 1, ?, 1, '{}', '{}', 60, 0, ?, ?)",
+            )
+            .bind(id)
+            .bind(id)
+            .bind(priority)
+            .bind(crate::db::models::now_iso())
+            .bind(crate::db::models::now_iso())
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+        sqlx::query("UPDATE channels SET last_probe_ok = 0 WHERE id = 'sink'")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE channels SET last_probe_ok = 1 WHERE id = 'ok'")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let ordered = repo.get_enabled_channels().await.unwrap();
+        let ids: Vec<&str> = ordered.iter().map(|c| c.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["mid", "ok", "sink"],
+            "探测失败渠道沉底（不剔除）；健康档内按优先级/权重，从未探测视为健康"
+        );
+    }
+
+    #[tokio::test]
+    async fn usage_stats_exclude_probe_rows() {
+        let pool = memory_db().await;
+        let repo = Repository::new(pool.clone());
+        let now = crate::db::models::now_iso();
+        // 一条正常请求行 + 一条探测行（model 都为 m）
+        for (model, is_probe) in [("m", 0), ("m", 1)] {
+            sqlx::query(
+                "INSERT INTO request_logs (id, seq, model, mode, status_code, duration_ms, \
+                 is_stream, is_retry, created_at, risk_level, security_action, upstream_type, \
+                 is_probe, total_tokens) \
+                 VALUES (?, (SELECT COALESCE(MAX(seq), 0) + 1 FROM request_logs), ?, 'chat', 200, \
+                 10, 0, 0, ?, 'low', 'audit', 'channel', ?, 100)",
+            )
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(model)
+            .bind(&now)
+            .bind(is_probe)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let model_stats = repo.get_model_stats().await.unwrap();
+        let row = model_stats
+            .iter()
+            .find(|s| s.model == "m")
+            .expect("正常行应计入模型统计");
+        assert_eq!(
+            row.request_count, 1,
+            "探测行不计入用量统计（is_probe=0 过滤）"
+        );
+
+        let dashboard = repo.get_dashboard_stats().await.unwrap();
+        assert_eq!(dashboard.total_requests, 1, "仪表盘请求数排除探测行");
+    }
+}

--- a/src-tauri/src/health_probe.rs
+++ b/src-tauri/src/health_probe.rs
@@ -302,4 +302,90 @@ mod tests {
         let dashboard = repo.get_dashboard_stats().await.unwrap();
         assert_eq!(dashboard.total_requests, 1, "仪表盘请求数排除探测行");
     }
+
+    /// 被动反哺：探测失败的渠道经一次 mark_probe_ok 立即恢复排序位
+    /// （验收标准「一次真实请求成功 → 恢复正常排序」）。
+    #[tokio::test]
+    async fn mark_probe_ok_recovers_ordering_after_real_success() {
+        let pool = memory_db().await;
+        let repo = Repository::new(pool.clone());
+        for (id, priority) in [("sink", 9), ("healthy", 1)] {
+            sqlx::query(
+                "INSERT INTO channels (id, name, type, base_url, api_key, models, status, priority, \
+                 weight, config, model_mapping, timeout_secs, identity_revision, created_at, updated_at) \
+                 VALUES (?, ?, 'openai', 'http://127.0.0.1:1', 'sk-x', '[]', 1, ?, 1, '{}', '{}', 60, 0, ?, ?)",
+            )
+            .bind(id)
+            .bind(id)
+            .bind(priority)
+            .bind(crate::db::models::now_iso())
+            .bind(crate::db::models::now_iso())
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+        sqlx::query("UPDATE channels SET last_probe_ok = 0 WHERE id = 'sink'")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // 反哺前：sink 沉底
+        let ids: Vec<String> = repo
+            .get_enabled_channels()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
+        assert_eq!(ids, vec!["healthy", "sink"]);
+
+        // 真实请求成功路径调用的反哺 → 立即恢复高优先级位
+        repo.mark_probe_ok("sink").await;
+        let ids: Vec<String> = repo
+            .get_enabled_channels()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
+        assert_eq!(ids, vec!["sink", "healthy"], "被动反哺后应恢复优先级排序");
+    }
+
+    /// 两轨覆盖：driver 轨入口的 get_enabled_channels_for_mode 同样吃沉底排序键
+    /// （且与 mode_health 冷却并存时，冷却剔除优先、健康排序作用于剩余候选）。
+    #[tokio::test]
+    async fn mode_query_also_sinks_unhealthy_candidates() {
+        let pool = memory_db().await;
+        let repo = Repository::new(pool.clone());
+        for (id, priority, probe_ok) in [("hot", 9, 0), ("mid", 5, 1), ("low", 1, 1)] {
+            sqlx::query(
+                "INSERT INTO channels (id, name, type, base_url, api_key, models, status, priority, \
+                 weight, config, model_mapping, timeout_secs, identity_revision, created_at, updated_at, \
+                 last_probe_ok) \
+                 VALUES (?, ?, 'openai', 'http://127.0.0.1:1', 'sk-x', '[]', 1, ?, 1, '{}', '{}', 60, 0, ?, ?, ?)",
+            )
+            .bind(id)
+            .bind(id)
+            .bind(priority)
+            .bind(crate::db::models::now_iso())
+            .bind(crate::db::models::now_iso())
+            .bind(probe_ok)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let ids: Vec<String> = repo
+            .get_enabled_channels_for_mode("chat_completions", false, &crate::db::models::now_iso())
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|c| c.id)
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["mid", "low", "hot"],
+            "for_mode 查询同样沉底探测失败渠道（两轨一致的排序语义）"
+        );
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod protocol;
 #[cfg(test)]
 mod rollout_integration_tests;
 pub mod security;
+pub mod semantic_cache;
 pub mod server;
 pub mod services;
 pub mod settings_store;
@@ -261,6 +262,11 @@ pub fn run() {
                     state.settings.clone(),
                 ));
 
+                // 语义缓存过期清理（C-02；缓存未启用时清理为空操作）
+                tauri::async_runtime::spawn(crate::semantic_cache::run_maintenance_loop(
+                    state.db.pool.clone(),
+                ));
+
                 tauri::async_runtime::spawn(async move {
                     auth_provider::maintenance::run_maintenance_loop(auth_service).await;
                 });
@@ -340,6 +346,7 @@ pub fn run() {
             commands::settings::get_settings,
             commands::settings::get_feature_flags,
             commands::settings::save_settings,
+            commands::settings::clear_semantic_cache,
             commands::settings::apply_theme,
             commands::settings::set_auto_start,
             commands::server::get_server_status,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ pub mod db;
 mod endpoint_executor;
 mod otlp_exporter;
 pub mod health_probe;
+pub mod prompt_templates;
 mod protocol;
 #[cfg(test)]
 mod rollout_integration_tests;
@@ -238,6 +239,10 @@ pub fn run() {
                 });
                 app_handle.manage(state.clone());
 
+                // Prompt 模板种子（C-07）：空表时写入源码字面量 v1——升级后行为逐字节不变
+                if let Err(error) = crate::prompt_templates::seed_if_empty(&state.db.pool).await {
+                    tracing::warn!("[模板] 种子写入失败（运行时回退编译期默认）: {error}");
+                }
                 crate::audit_log::apply_settings(&state.settings);
                 tauri::async_runtime::spawn(crate::audit_log::run_maintenance_loop(
                     state.db.pool.clone(),
@@ -325,6 +330,9 @@ pub fn run() {
             commands::log::delete_logs_before,
             commands::log::delete_all_logs,
             commands::log::get_log_stats,
+            commands::prompt_template::list_prompt_templates,
+            commands::prompt_template::create_prompt_template,
+            commands::prompt_template::activate_prompt_template,
             commands::log_repair::repair_stream_cancel_logs,
             commands::stats::get_dashboard_stats,
             commands::stats::get_model_stats,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ pub mod core;
 pub mod db;
 mod endpoint_executor;
 mod otlp_exporter;
+pub mod health_probe;
 mod protocol;
 #[cfg(test)]
 mod rollout_integration_tests;
@@ -245,6 +246,12 @@ pub fn run() {
 
                 // OTLP 导出（默认关闭，开启后按 seq 游标增量导出 request_log）
                 tauri::async_runtime::spawn(crate::otlp_exporter::run_export_loop(
+                    state.db.pool.clone(),
+                    state.settings.clone(),
+                ));
+
+                // 渠道主动健康探测（默认开启 300s 一轮，可整体关闭）
+                tauri::async_runtime::spawn(crate::health_probe::run_probe_loop(
                     state.db.pool.clone(),
                     state.settings.clone(),
                 ));

--- a/src-tauri/src/prompt_templates.rs
+++ b/src-tauri/src/prompt_templates.rs
@@ -1,0 +1,413 @@
+//! Prompt 模板版本化（C-07）：RAG 系统提示词从源码硬编码迁移为可版本化管理。
+//!
+//! 兼容硬保证：启动时按 key 检测无行则把**源码字面量逐字节**写入 v1 并激活
+//! ——升级后 RAG 行为与升级前完全一致。运行时按 key + active 读取，表损坏/
+//! 清空/读取失败时回退编译期内置默认（双保险），服务不中断。
+//!
+//! 占位符校验：模板必须**恰好包含**该 key 声明的全部命名占位符（如
+//! `{query}`/`{context}`），不得包含未知占位符——防止激活坏模板导致检索
+//! 上下文注入丢失或渲染错位。
+
+use sqlx::SqlitePool;
+
+/// 模板定义：key + 允许（且必需）的命名占位符 + 编译期默认（= 源码字面量）。
+pub struct TemplateDef {
+    pub key: &'static str,
+    pub placeholders: &'static [&'static str],
+    pub builtin: &'static str,
+}
+
+pub const KEY_RAG_SYSTEM: &str = "rag_system";
+pub const KEY_RESEARCH_NEXT_QUERY: &str = "research_next_query_system";
+pub const KEY_DEEP_RESEARCH_SYSTEM: &str = "deep_research_system";
+pub const KEY_DEEP_RESEARCH_FINAL_SYSTEM: &str = "deep_research_final_system";
+pub const KEY_DEEP_RESEARCH_ROUND0: &str = "deep_research_round0";
+pub const KEY_DEEP_RESEARCH_ROUND_NEXT: &str = "deep_research_round_next";
+pub const KEY_DEEP_RESEARCH_FINAL: &str = "deep_research_final";
+
+/// 首批纳入的模板（RAG 问答 + 深度研究系列）。渠道转发类内容是用户请求的
+/// 一部分，不属于系统模板，不纳入。
+pub const TEMPLATE_DEFS: &[TemplateDef] = &[
+    TemplateDef {
+        key: KEY_RAG_SYSTEM,
+        placeholders: &[],
+        builtin: "你是 RAG 助手。基于检索到的内容回答问题。回答要准确、简洁，并标注信息来源。如果没有相关信息，请明确说明。",
+    },
+    TemplateDef {
+        key: KEY_RESEARCH_NEXT_QUERY,
+        placeholders: &[],
+        builtin: "你是一个研究助手，根据已有发现生成下一步搜索查询。只返回查询本身。",
+    },
+    TemplateDef {
+        key: KEY_DEEP_RESEARCH_SYSTEM,
+        placeholders: &[],
+        builtin: "你是深度研究助手。基于 RAG 内容进行多轮迭代研究，逐步深入分析。",
+    },
+    TemplateDef {
+        key: KEY_DEEP_RESEARCH_FINAL_SYSTEM,
+        placeholders: &[],
+        builtin: "你是深度研究助手。综合多轮研究发现，给出完整准确的回答。",
+    },
+    TemplateDef {
+        key: KEY_DEEP_RESEARCH_ROUND0,
+        placeholders: &["query", "context"],
+        builtin: r#"你是一个深度研究助手。请分析以下 RAG 内容，并给出初步发现。
+
+原始问题: {query}
+
+<knowledge_base>
+{context}
+</knowledge_base>
+
+请完成：
+1. 理解问题的核心需求
+2. 从 RAG 中提取相关信息
+3. 给出初步发现
+4. 如果信息不足，指出还需要哪些方面"#,
+    },
+    TemplateDef {
+        key: KEY_DEEP_RESEARCH_ROUND_NEXT,
+        placeholders: &["query", "findings", "context"],
+        builtin: r#"继续深度研究。
+
+原始问题: {query}
+
+已有发现:
+{findings}
+
+新检索到的内容:
+<knowledge_base>
+{context}
+</knowledge_base>
+
+请完成：
+1. 分析新内容与已有发现的关系
+2. 补充或修正之前的发现
+3. 指出是否需要继续研究"#,
+    },
+    TemplateDef {
+        key: KEY_DEEP_RESEARCH_FINAL,
+        placeholders: &["query", "findings"],
+        builtin: r#"基于多轮深度研究的发现，请综合回答原始问题。
+
+原始问题: {query}
+
+多轮研究发现:
+{findings}
+
+请综合所有发现，给出完整、准确的回答。标注信息来源。"#,
+    },
+];
+
+/// 按 key 取定义（校验与回退用）。
+pub fn def_for(key: &str) -> Option<&'static TemplateDef> {
+    TEMPLATE_DEFS.iter().find(|d| d.key == key)
+}
+
+/// 提取模板中出现的命名占位符（`{word}`，word 为 ASCII 字母数字下划线）。
+fn placeholders_in(content: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut chars = content.char_indices().peekable();
+    while let Some((i, c)) = chars.next() {
+        if c == '{' {
+            let rest = &content[i + 1..];
+            if let Some(end) = rest.find('}') {
+                let name = &rest[..end];
+                if !name.is_empty()
+                    && name
+                        .chars()
+                        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+                {
+                    out.push(name.to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// 校验模板内容：必须恰好包含声明占位符的全体（不多不少）。
+/// 缺占位符 = 渲染丢上下文；多占位符 = 渲染留残片——都拒绝激活。
+pub fn validate_template(key: &str, content: &str) -> Result<(), String> {
+    let def = def_for(key).ok_or_else(|| format!("未知模板 key: {key}"))?;
+    let mut present = placeholders_in(content);
+    present.sort();
+    let mut expected: Vec<&str> = def.placeholders.to_vec();
+    expected.sort();
+    if present == expected {
+        Ok(())
+    } else {
+        Err(format!(
+            "模板 {} 占位符不符：需要 {{{}}}/{}，实际 {{{}}}/{}",
+            key,
+            expected.join("}, {"),
+            expected.len(),
+            present.join("}, {"),
+            present.len()
+        ))
+    }
+}
+
+/// 渲染：命名占位符替换（args 必须覆盖全部声明占位符，调用侧静态保证）。
+pub fn render(template: &str, args: &[(&str, &str)]) -> String {
+    let mut out = template.to_string();
+    for (name, value) in args {
+        out = out.replace(&format!("{{{name}}}"), value);
+    }
+    out
+}
+
+/// 启动种子：按 key 检测无行则写入 v1（active）——字面量逐字节等于源码。
+pub async fn seed_if_empty(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+    for def in TEMPLATE_DEFS {
+        let exists: Option<i64> =
+            sqlx::query_scalar("SELECT 1 FROM prompt_templates WHERE template_key = ? LIMIT 1")
+                .bind(def.key)
+                .fetch_optional(pool)
+                .await?;
+        if exists.is_none() {
+            sqlx::query(
+                "INSERT INTO prompt_templates (id, template_key, version, content, active, created_at) \
+                 VALUES (?, ?, 1, ?, 1, ?)",
+            )
+            .bind(crate::utils::id::new_id())
+            .bind(def.key)
+            .bind(def.builtin)
+            .bind(crate::db::models::now_iso())
+            .execute(pool)
+            .await?;
+            tracing::info!("[模板] 种子写入 {} v1（源码字面量）", def.key);
+        }
+    }
+    Ok(())
+}
+
+/// 读取某 key 的激活模板；读取失败或无行时回退编译期默认（双保险）。
+pub async fn load(pool: &SqlitePool, key: &str) -> String {
+    match active_content(pool, key).await {
+        Ok(Some(content)) => content,
+        Ok(None) | Err(_) => def_for(key)
+            .map(|d| d.builtin.to_string())
+            .unwrap_or_default(),
+    }
+}
+
+pub async fn active_content(pool: &SqlitePool, key: &str) -> Result<Option<String>, sqlx::Error> {
+    sqlx::query_scalar::<_, String>(
+        "SELECT content FROM prompt_templates WHERE template_key = ? AND active = 1 LIMIT 1",
+    )
+    .bind(key)
+    .fetch_optional(pool)
+    .await
+}
+
+/// 全部模板行（管理页列表用，按 key/版本排序）。
+pub struct TemplateRow {
+    pub id: String,
+    pub template_key: String,
+    pub version: i64,
+    pub content: String,
+    pub active: bool,
+    pub created_at: String,
+}
+
+pub async fn list_templates(pool: &SqlitePool) -> Result<Vec<TemplateRow>, sqlx::Error> {
+    let rows = sqlx::query_as::<_, (String, String, i64, String, i64, String)>(
+        "SELECT id, template_key, version, content, active, created_at \
+         FROM prompt_templates ORDER BY template_key ASC, version DESC",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(
+            |(id, template_key, version, content, active, created_at)| TemplateRow {
+                id,
+                template_key,
+                version,
+                content,
+                active: active == 1,
+                created_at,
+            },
+        )
+        .collect())
+}
+
+/// 新建版本（inactive；下一个版本号 = 该 key 现有最大版本 + 1）。
+/// 内容先经占位符校验，非法拒绝。
+pub async fn create_version(pool: &SqlitePool, key: &str, content: &str) -> Result<i64, String> {
+    validate_template(key, content)?;
+    let next: i64 = sqlx::query_scalar(
+        "SELECT COALESCE(MAX(version), 0) + 1 FROM prompt_templates WHERE template_key = ?",
+    )
+    .bind(key)
+    .fetch_one(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+    sqlx::query(
+        "INSERT INTO prompt_templates (id, template_key, version, content, active, created_at) \
+         VALUES (?, ?, ?, ?, 0, ?)",
+    )
+    .bind(crate::utils::id::new_id())
+    .bind(key)
+    .bind(next)
+    .bind(content)
+    .bind(crate::db::models::now_iso())
+    .execute(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+    Ok(next)
+}
+
+/// 激活某版本（同 key 其余版本全部置 inactive），事务保证唯一激活。
+pub async fn activate_version(pool: &SqlitePool, key: &str, version: i64) -> Result<(), String> {
+    let exists: Option<i64> = sqlx::query_scalar(
+        "SELECT 1 FROM prompt_templates WHERE template_key = ? AND version = ? LIMIT 1",
+    )
+    .bind(key)
+    .bind(version)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+    if exists.is_none() {
+        return Err(format!("版本不存在: {key} v{version}"));
+    }
+    let mut tx = pool.begin().await.map_err(|e| e.to_string())?;
+    sqlx::query("UPDATE prompt_templates SET active = 0 WHERE template_key = ?")
+        .bind(key)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| e.to_string())?;
+    sqlx::query("UPDATE prompt_templates SET active = 1 WHERE template_key = ? AND version = ?")
+        .bind(key)
+        .bind(version)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| e.to_string())?;
+    tx.commit().await.map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn memory_db() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn seed_writes_builtin_literals_verbatim() {
+        let pool = memory_db().await;
+        seed_if_empty(&pool).await.unwrap();
+        for def in TEMPLATE_DEFS {
+            let stored = active_content(&pool, def.key)
+                .await
+                .unwrap()
+                .expect("种子后应有激活行");
+            assert_eq!(
+                stored, def.builtin,
+                "{} 的种子必须与源码字面量逐字节一致",
+                def.key
+            );
+        }
+        // 幂等：再次种子不重复写、不改版本
+        seed_if_empty(&pool).await.unwrap();
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM prompt_templates")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count, TEMPLATE_DEFS.len() as i64, "重复种子零新增");
+    }
+
+    #[tokio::test]
+    async fn activate_switches_and_rolls_back_immediately() {
+        let pool = memory_db().await;
+        seed_if_empty(&pool).await.unwrap();
+        let v2 = create_version(&pool, KEY_RAG_SYSTEM, "测试版系统词 v2")
+            .await
+            .unwrap();
+        assert_eq!(v2, 2);
+        // 新版本未激活前仍是 v1
+        assert_eq!(
+            active_content(&pool, KEY_RAG_SYSTEM)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some(def_for(KEY_RAG_SYSTEM).unwrap().builtin)
+        );
+        activate_version(&pool, KEY_RAG_SYSTEM, v2).await.unwrap();
+        assert_eq!(
+            active_content(&pool, KEY_RAG_SYSTEM)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("测试版系统词 v2")
+        );
+        // 回滚 v1 立即生效
+        activate_version(&pool, KEY_RAG_SYSTEM, 1).await.unwrap();
+        assert_eq!(
+            active_content(&pool, KEY_RAG_SYSTEM)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some(def_for(KEY_RAG_SYSTEM).unwrap().builtin)
+        );
+    }
+
+    #[tokio::test]
+    async fn load_falls_back_to_builtin_when_table_empty_or_broken() {
+        let pool = memory_db().await;
+        // 未种子（表空）→ 回退编译期默认
+        assert_eq!(
+            load(&pool, KEY_RAG_SYSTEM).await,
+            def_for(KEY_RAG_SYSTEM).unwrap().builtin
+        );
+        // 清空激活行 → 回退
+        sqlx::query("UPDATE prompt_templates SET active = 0")
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            load(&pool, KEY_DEEP_RESEARCH_SYSTEM).await,
+            def_for(KEY_DEEP_RESEARCH_SYSTEM).unwrap().builtin
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_placeholder_templates_are_rejected() {
+        let pool = memory_db().await;
+        // 未知占位符
+        assert!(create_version(&pool, KEY_RAG_SYSTEM, "带 {unknown} 占位符")
+            .await
+            .is_err());
+        // 缺占位符（round0 需要 {query}/{context}）
+        assert!(
+            create_version(&pool, KEY_DEEP_RESEARCH_ROUND0, "缺少占位符的模板")
+                .await
+                .is_err()
+        );
+        // 占位符齐全 → 接受
+        assert!(create_version(
+            &pool,
+            KEY_DEEP_RESEARCH_ROUND0,
+            "问题 {query} 上下文 {context}"
+        )
+        .await
+        .is_ok());
+        // 未知 key 拒绝
+        assert!(create_version(&pool, "no_such_key", "x").await.is_err());
+    }
+
+    #[test]
+    fn render_replaces_named_placeholders() {
+        let out = render(
+            "Q:{query} C:{context}",
+            &[("query", "问"), ("context", "文")],
+        );
+        assert_eq!(out, "Q:问 C:文");
+        // 无占位符模板原样返回
+        assert_eq!(render("固定内容", &[]), "固定内容");
+    }
+}

--- a/src-tauri/src/prompt_templates.rs
+++ b/src-tauri/src/prompt_templates.rs
@@ -354,6 +354,54 @@ mod tests {
                 .as_deref(),
             Some(def_for(KEY_RAG_SYSTEM).unwrap().builtin)
         );
+        // 事务保证：同 key 激活行恒唯一（其余版本全部置 inactive）
+        let active_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM prompt_templates WHERE template_key = ? AND active = 1",
+        )
+        .bind(KEY_RAG_SYSTEM)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(active_count, 1, "同 key 激活行必须唯一");
+    }
+
+    /// 管理页列表：按 key 分组升序、组内版本降序，字段往返完整。
+    #[tokio::test]
+    async fn list_templates_orders_and_roundtrips() {
+        let pool = memory_db().await;
+        seed_if_empty(&pool).await.unwrap();
+        let v2 = create_version(&pool, KEY_RAG_SYSTEM, "v2 内容")
+            .await
+            .unwrap();
+        let rows = list_templates(&pool).await.unwrap();
+
+        // key 升序：rag_system 在 deep_research_* 之后、query_rewrite 之前（若存在）
+        let mut keys: Vec<&str> = rows.iter().map(|r| r.template_key.as_str()).collect();
+        keys.dedup();
+        let mut sorted = keys.clone();
+        sorted.sort();
+        assert_eq!(keys, sorted, "列表应按 key 升序");
+
+        // 同 key 组内版本降序
+        let rag_versions: Vec<i64> = rows
+            .iter()
+            .filter(|r| r.template_key == KEY_RAG_SYSTEM)
+            .map(|r| r.version)
+            .collect();
+        assert_eq!(rag_versions, vec![v2, 1], "组内版本降序");
+
+        // 激活标记与内容往返
+        let active_row = rows
+            .iter()
+            .find(|r| r.template_key == KEY_RAG_SYSTEM && r.version == 1)
+            .unwrap();
+        assert!(active_row.active);
+        assert_eq!(active_row.content, def_for(KEY_RAG_SYSTEM).unwrap().builtin);
+        let inactive_row = rows
+            .iter()
+            .find(|r| r.template_key == KEY_RAG_SYSTEM && r.version == v2)
+            .unwrap();
+        assert!(!inactive_row.active);
     }
 
     #[tokio::test]

--- a/src-tauri/src/prompt_templates.rs
+++ b/src-tauri/src/prompt_templates.rs
@@ -24,6 +24,7 @@ pub const KEY_DEEP_RESEARCH_FINAL_SYSTEM: &str = "deep_research_final_system";
 pub const KEY_DEEP_RESEARCH_ROUND0: &str = "deep_research_round0";
 pub const KEY_DEEP_RESEARCH_ROUND_NEXT: &str = "deep_research_round_next";
 pub const KEY_DEEP_RESEARCH_FINAL: &str = "deep_research_final";
+pub const KEY_QUERY_REWRITE: &str = "query_rewrite";
 
 /// 首批纳入的模板（RAG 问答 + 深度研究系列）。渠道转发类内容是用户请求的
 /// 一部分，不属于系统模板，不纳入。
@@ -96,6 +97,18 @@ pub const TEMPLATE_DEFS: &[TemplateDef] = &[
 {findings}
 
 请综合所有发现，给出完整、准确的回答。标注信息来源。"#,
+    },
+    TemplateDef {
+        key: KEY_QUERY_REWRITE,
+        placeholders: &["history", "query"],
+        builtin: r#"你是检索查询改写器。根据多轮对话历史，把用户的最新问题改写为独立、完整、可脱离上下文理解的检索查询。
+
+对话历史:
+{history}
+
+最新问题: {query}
+
+只输出改写后的检索查询本身，不要输出其他内容。"#,
     },
 ];
 

--- a/src-tauri/src/rollout_integration_tests.rs
+++ b/src-tauri/src/rollout_integration_tests.rs
@@ -360,6 +360,9 @@ fn channel(
         updated_at: now_iso(),
         last_test_at: None,
         last_test_ok: None,
+        last_probe_at: None,
+        last_probe_ok: None,
+        probe_latency_ms: None,
     }
 }
 

--- a/src-tauri/src/semantic_cache.rs
+++ b/src-tauri/src/semantic_cache.rs
@@ -1,0 +1,579 @@
+//! 语义缓存（C-02）：网关侧响应缓存——exact（规范化哈希 O(1) 精确命中）
+//! + semantic（embedding 暴力余弦 ≥ 阈值命中）两层。
+//!
+//! 三层风险收敛：① 默认关闭（cache.semantic_enabled）；② 可缓存判定
+//! （无 tools/tool_choice、temperature ≤ 0.3、安全审计无命中、消息内容全部
+//! 为纯文本）；③ 语义阈值保守默认 0.95。带 tools 的请求永不入缓存也永不
+//! 命中；TTL 过期不命中；命中请求照常写请求日志（记账口径不变）。
+//!
+//! 诚实边界（issue 中声明）：本实现拦截 chat completions 端点（主协议）；
+//! responses/messages 协议的拦截与写入为后续工作。写入只覆盖非流式响应
+//! （流式命中可回放缓存答案；流式响应自身的渐进写入需要挂在流泵上，列
+//! 为开放点）。渠道级覆盖在「Key 鉴权后、路由候选前」的拦截点上无法得知
+//! 渠道，以模型粒度（cache_key 含 model）替代——设计修正如实声明。
+
+use crate::db::repository::Repository;
+use crate::settings_store::SettingsStore;
+use sqlx::SqlitePool;
+use std::time::Duration;
+
+/// 消息规范化（纯函数）：提取 (role, content 纯文本) 序列，合并连续空白、
+/// 去首尾空白；任一消息 content 非字符串（图片/工具内容等）→ None（不可缓存）。
+pub fn normalize_messages(body: &serde_json::Value) -> Option<String> {
+    let messages = body.get("messages")?.as_array()?;
+    if messages.is_empty() {
+        return None;
+    }
+    let mut parts = Vec::with_capacity(messages.len());
+    for message in messages {
+        let role = message.get("role")?.as_str()?;
+        let content = message.get("content")?;
+        let text = match content {
+            serde_json::Value::String(s) => s.clone(),
+            serde_json::Value::Array(items) => {
+                // 多段内容：全部为 {type:"text", text} 才可缓存
+                let mut texts = Vec::with_capacity(items.len());
+                for item in items {
+                    if item.get("type").and_then(|t| t.as_str()) != Some("text") {
+                        return None;
+                    }
+                    texts.push(item.get("text")?.as_str()?.to_string());
+                }
+                texts.join("\n")
+            }
+            _ => return None,
+        };
+        let normalized: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
+        parts.push(format!("{role}: {normalized}"));
+    }
+    Some(parts.join("\n"))
+}
+
+/// 可缓存判定（纯函数）：无 tools/tool_choice、temperature ≤ 0.3（缺省视为 0）、
+/// 消息可规范化。安全审计命中由调用侧传入（audit_hit = true 直接不可缓存）。
+pub fn cacheable(body: &serde_json::Value, audit_hit: bool) -> bool {
+    if audit_hit {
+        return false;
+    }
+    if body.get("tools").is_some() || body.get("tool_choice").is_some() {
+        return false;
+    }
+    if let Some(temp) = body.get("temperature").and_then(|t| t.as_f64()) {
+        if temp > 0.3 {
+            return false;
+        }
+    }
+    normalize_messages(body).is_some()
+}
+
+/// exact 层缓存键（纯函数）：规范化消息 SHA-256 + model + 参数档位。
+/// temperature 分档（≤0.3 同档）——采样参数不同不共享 exact 命中。
+pub fn exact_cache_key(body: &serde_json::Value, normalized: &str) -> Option<String> {
+    let model = body.get("model")?.as_str()?;
+    let temp_bucket = if body
+        .get("temperature")
+        .and_then(|t| t.as_f64())
+        .unwrap_or(0.0)
+        <= 0.3
+    {
+        "t0"
+    } else {
+        "t1"
+    };
+    let max_tokens_bucket = match body.get("max_tokens").and_then(|t| t.as_i64()) {
+        None => "none",
+        Some(n) if n <= 1024 => "small",
+        Some(n) if n <= 4096 => "mid",
+        Some(_) => "large",
+    };
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(
+        format!("{normalized}\x1e{model}\x1e{temp_bucket}\x1e{max_tokens_bucket}").as_bytes(),
+    );
+    let digest = hasher.finalize();
+    Some(format!("sc_{model}_{:x}", digest))
+}
+
+/// 余弦相似度（纯函数；semantic 层与测试共用）。
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    let mut dot = 0.0f32;
+    let mut na = 0.0f32;
+    let mut nb = 0.0f32;
+    for (x, y) in a.iter().zip(b.iter()) {
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+    }
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na.sqrt() * nb.sqrt())
+}
+
+pub struct CacheHit {
+    pub answer: String,
+    /// exact | semantic
+    pub layer: &'static str,
+}
+
+/// 查询两层缓存（exact 优先，semantic 兜底）。
+/// 未启用（cache.semantic_enabled=false）/ 键不可构造 / 无命中 → None。
+pub async fn lookup(
+    pool: &SqlitePool,
+    settings: &SettingsStore,
+    body: &serde_json::Value,
+    audit_hit: bool,
+) -> Option<CacheHit> {
+    if !settings.get_bool("cache.semantic_enabled", false) {
+        return None;
+    }
+    if !cacheable(body, audit_hit) {
+        return None;
+    }
+    let normalized = normalize_messages(body)?;
+    let model = body.get("model")?.as_str()?;
+    let now = crate::db::models::now_iso();
+
+    // 第一层：exact（规范化哈希 O(1)）
+    if let Some(key) = exact_cache_key(body, &normalized) {
+        let row: Option<String> = sqlx::query_scalar(
+            "SELECT answer FROM semantic_cache WHERE cache_key = ? AND ttl_expire_at > ? LIMIT 1",
+        )
+        .bind(&key)
+        .bind(&now)
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten();
+        if let Some(answer) = row {
+            return Some(CacheHit {
+                answer,
+                layer: "exact",
+            });
+        }
+    }
+
+    // 第二层：semantic（embedding 暴力余弦；缓存条目量级 ≪ KB chunk，暴力扫可接受）
+    let embedding_model = settings.get_str("cache.embedding_model", "");
+    if embedding_model.is_empty() {
+        return None;
+    }
+    let threshold = settings.get_u64("cache.semantic_threshold_percent", 95) as f32 / 100.0;
+    let repo = Repository::new(pool.clone());
+    let query_text = normalized
+        .lines()
+        .rev()
+        .find(|l| l.starts_with("user: "))
+        .map(|l| l.to_string())
+        .unwrap_or(normalized);
+    let embeddings =
+        crate::services::knowledge::embedder::embed(&[query_text], &embedding_model, &repo)
+            .await
+            .ok()?;
+    let query_vec = embeddings.into_iter().next()?;
+
+    let rows: Vec<(String, Vec<u8>)> = sqlx::query_as(
+        "SELECT answer, embedding FROM semantic_cache \
+         WHERE model = ? AND ttl_expire_at > ? AND embedding IS NOT NULL",
+    )
+    .bind(model)
+    .bind(&now)
+    .fetch_all(pool)
+    .await
+    .ok()?;
+    let mut best: Option<(f32, String)> = None;
+    for (answer, blob) in rows {
+        let Some(vector) = decode_f32_blob(&blob) else {
+            continue;
+        };
+        let score = cosine_similarity(&query_vec, &vector);
+        if score >= threshold && best.as_ref().is_none_or(|(s, _)| score > *s) {
+            best = Some((score, answer));
+        }
+    }
+    best.map(|(_, answer)| CacheHit {
+        answer,
+        layer: "semantic",
+    })
+}
+
+/// f32 向量的 LE 字节编解码（SQLite BLOB 存取）。
+pub fn encode_f32_blob(vector: &[f32]) -> Vec<u8> {
+    vector.iter().flat_map(|f| f.to_le_bytes()).collect()
+}
+
+pub fn decode_f32_blob(blob: &[u8]) -> Option<Vec<f32>> {
+    if blob.len() % 4 != 0 {
+        return None;
+    }
+    Some(
+        blob.chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect(),
+    )
+}
+
+/// 写入缓存（best-effort：调用侧已 spawn，此处失败仅告警）。
+/// embedding 为 None 时只写 exact 层；semantic 层命中需要非空 embedding。
+pub async fn store(
+    pool: &SqlitePool,
+    settings: &SettingsStore,
+    body: &serde_json::Value,
+    answer: &str,
+) {
+    if !settings.get_bool("cache.semantic_enabled", false) || answer.is_empty() {
+        return;
+    }
+    let Some(normalized) = normalize_messages(body) else {
+        return;
+    };
+    let Some(model) = body.get("model").and_then(|m| m.as_str()) else {
+        return;
+    };
+    let Some(key) = exact_cache_key(body, &normalized) else {
+        return;
+    };
+    let ttl_secs = settings.get_u64("cache.ttl_secs", 86_400).max(60);
+    let expire = (chrono::Utc::now() + chrono::Duration::seconds(ttl_secs as i64)).to_rfc3339();
+
+    // semantic 层 embedding（配置了嵌入模型才有；失败不阻断 exact 写入）
+    let mut embedding_blob: Option<Vec<u8>> = None;
+    let embedding_model = settings.get_str("cache.embedding_model", "");
+    if !embedding_model.is_empty() {
+        let repo = Repository::new(pool.clone());
+        let query_text = normalized
+            .lines()
+            .rev()
+            .find(|l| l.starts_with("user: "))
+            .map(|l| l.to_string())
+            .unwrap_or(normalized);
+        if let Ok(vectors) =
+            crate::services::knowledge::embedder::embed(&[query_text], &embedding_model, &repo)
+                .await
+        {
+            if let Some(vector) = vectors.into_iter().next() {
+                embedding_blob = Some(encode_f32_blob(&vector));
+            }
+        }
+    }
+
+    // 同键覆盖写（答案更新；旧条目 TTL 自然过期）
+    let result = sqlx::query(
+        "INSERT INTO semantic_cache (id, cache_key, model, embedding, answer, ttl_expire_at, created_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?) \
+         ON CONFLICT(cache_key) DO UPDATE SET \
+         embedding = excluded.embedding, answer = excluded.answer, \
+         ttl_expire_at = excluded.ttl_expire_at, created_at = excluded.created_at",
+    )
+    .bind(crate::utils::id::new_id())
+    .bind(&key)
+    .bind(model)
+    .bind(&embedding_blob)
+    .bind(answer)
+    .bind(&expire)
+    .bind(crate::db::models::now_iso())
+    .execute(pool)
+    .await;
+    if let Err(error) = result {
+        tracing::warn!("[语义缓存] 写入失败（best-effort，不影响主请求）: {error}");
+    }
+}
+
+/// 从缓存答案合成非流式 chat completion 响应体。
+pub fn replay_body(model: &str, answer: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": format!("chatcmpl-cache-{}", uuid::Uuid::new_v4().simple()),
+        "object": "chat.completion",
+        "created": chrono::Utc::now().timestamp(),
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": answer},
+            "finish_reason": "stop"
+        }],
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+    })
+}
+
+/// 从缓存答案合成流式 SSE 帧序列（role → content → finish → [DONE]，
+/// 标准增量分块，既有 chat SSE 客户端可直接消费）。
+pub fn replay_sse_frames(model: &str, answer: &str) -> String {
+    let id = format!("chatcmpl-cache-{}", uuid::Uuid::new_v4().simple());
+    let created = chrono::Utc::now().timestamp();
+    let mut out = String::new();
+    out.push_str(&format!(
+        "data: {}\n\n",
+        serde_json::json!({
+            "id": id, "object": "chat.completion.chunk", "created": created, "model": model,
+            "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": null}]
+        })
+    ));
+    for chunk in answer.as_bytes().chunks(64) {
+        let text = String::from_utf8_lossy(chunk);
+        out.push_str(&format!(
+            "data: {}\n\n",
+            serde_json::json!({
+                "id": id, "object": "chat.completion.chunk", "created": created, "model": model,
+                "choices": [{"index": 0, "delta": {"content": text}, "finish_reason": null}]
+            })
+        ));
+    }
+    out.push_str(&format!(
+        "data: {}\n\n",
+        serde_json::json!({
+            "id": id, "object": "chat.completion.chunk", "created": created, "model": model,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]
+        })
+    ));
+    out.push_str("data: [DONE]\n\n");
+    out
+}
+
+/// 清理过期条目（后台维护可复用；手工清空走管理命令）。
+pub async fn purge_expired(pool: &SqlitePool) -> u64 {
+    let now = crate::db::models::now_iso();
+    match sqlx::query("DELETE FROM semantic_cache WHERE ttl_expire_at <= ?")
+        .bind(&now)
+        .execute(pool)
+        .await
+    {
+        Ok(result) => result.rows_affected(),
+        Err(error) => {
+            tracing::warn!("[语义缓存] 过期清理失败: {error}");
+            0
+        }
+    }
+}
+
+/// 后台维护循环：随 TTL 清理（复用审计维护的 spawn 模式；间隔固定 1h）。
+pub async fn run_maintenance_loop(pool: SqlitePool) {
+    loop {
+        let purged = purge_expired(&pool).await;
+        if purged > 0 {
+            tracing::debug!("[语义缓存] 清理过期条目 {purged} 行");
+        }
+        tokio::time::sleep(Duration::from_secs(3600)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn memory_db() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    fn settings_at(enabled: bool) -> SettingsStore {
+        let dir = std::env::temp_dir().join(format!("waliapi-cache-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = SettingsStore::file(dir.join("settings.json"));
+        store
+            .set_many(&[(
+                "cache.semantic_enabled".to_string(),
+                serde_json::json!(enabled),
+            )])
+            .unwrap();
+        store
+    }
+
+    fn body(messages: serde_json::Value, temperature: Option<f64>) -> serde_json::Value {
+        serde_json::json!({
+            "model": "m",
+            "messages": messages,
+            "temperature": temperature,
+        })
+    }
+
+    #[test]
+    fn normalize_merges_whitespace_and_rejects_non_text() {
+        let b = body(
+            serde_json::json!([
+                {"role": "user", "content": "  你   好\n世界 "},
+                {"role": "assistant", "content": "你好"}
+            ]),
+            None,
+        );
+        assert_eq!(
+            normalize_messages(&b).unwrap(),
+            "user: 你 好 世界\nassistant: 你好"
+        );
+        // 图片内容 → 不可缓存
+        let b = body(
+            serde_json::json!([
+                {"role": "user", "content": [{"type": "image_url", "image_url": {"url": "x"}}]}
+            ]),
+            None,
+        );
+        assert!(normalize_messages(&b).is_none());
+        // 多段纯文本 → 可缓存（join 后整体做空白规范化，换行折叠为单空格）
+        let b = body(
+            serde_json::json!([
+                {"role": "user", "content": [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]}
+            ]),
+            None,
+        );
+        assert_eq!(normalize_messages(&b).unwrap(), "user: a b");
+    }
+
+    #[test]
+    fn cacheable_gates_tools_temperature_audit() {
+        assert!(cacheable(
+            &body(
+                serde_json::json!([{"role":"user","content":"q"}]),
+                Some(0.0)
+            ),
+            false
+        ));
+        assert!(
+            !cacheable(
+                &body(
+                    serde_json::json!([{"role":"user","content":"q"}]),
+                    Some(0.7)
+                ),
+                false
+            ),
+            "高温不入缓存"
+        );
+        assert!(
+            !cacheable(
+                &body(serde_json::json!([{"role":"user","content":"q"}]), None),
+                true
+            ),
+            "审计命中不入缓存"
+        );
+        let mut with_tools = body(serde_json::json!([{"role":"user","content":"q"}]), None);
+        with_tools["tools"] = serde_json::json!([]);
+        assert!(!cacheable(&with_tools, false), "带 tools 永不入缓存");
+    }
+
+    #[test]
+    fn exact_key_is_stable_and_parameter_sensitive() {
+        let b1 = body(
+            serde_json::json!([{"role":"user","content":"  同一   问题 "}]),
+            None,
+        );
+        let b2 = body(
+            serde_json::json!([{"role":"user","content":"同一 问题"}]),
+            None,
+        );
+        assert_eq!(
+            exact_cache_key(&b1, &normalize_messages(&b1).unwrap()).unwrap(),
+            exact_cache_key(&b2, &normalize_messages(&b2).unwrap()).unwrap(),
+            "空白规范化后同键"
+        );
+        let b3 = body(
+            serde_json::json!([{"role":"user","content":"另一问题"}]),
+            None,
+        );
+        assert_ne!(
+            exact_cache_key(&b1, &normalize_messages(&b1).unwrap()).unwrap(),
+            exact_cache_key(&b3, &normalize_messages(&b3).unwrap()).unwrap()
+        );
+        // max_tokens 档位不同 → 不同键
+        let mut b4 = b1.clone();
+        b4["max_tokens"] = serde_json::json!(8192);
+        assert_ne!(
+            exact_cache_key(&b1, &normalize_messages(&b1).unwrap()).unwrap(),
+            exact_cache_key(&b4, &normalize_messages(&b4).unwrap()).unwrap()
+        );
+    }
+
+    #[test]
+    fn cosine_similarity_full_orthogonal_and_dimension_mismatch() {
+        assert!((cosine_similarity(&[1.0, 0.0], &[1.0, 0.0]) - 1.0).abs() < 1e-6);
+        assert!(cosine_similarity(&[1.0, 0.0], &[0.0, 1.0]).abs() < 1e-6);
+        assert_eq!(
+            cosine_similarity(&[1.0], &[1.0, 0.0]),
+            0.0,
+            "维度不符按 0 处理"
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_layer_hit_miss_and_ttl_expiry() {
+        let pool = memory_db().await;
+        let settings = settings_at(true);
+        let b = body(
+            serde_json::json!([{"role":"user","content":"网关怎么配额？"}]),
+            None,
+        );
+
+        // 未写入 → miss；关闭 → 恒 miss
+        assert!(lookup(&pool, &settings, &b, false).await.is_none());
+        let off = settings_at(false);
+        assert!(lookup(&pool, &off, &b, false).await.is_none());
+
+        store(&pool, &settings, &b, "配额在密钥页设置。").await;
+        let hit = lookup(&pool, &settings, &b, false).await.unwrap();
+        assert_eq!(hit.answer, "配额在密钥页设置。");
+        assert_eq!(hit.layer, "exact");
+
+        // TTL 过期 → 不命中
+        sqlx::query("UPDATE semantic_cache SET ttl_expire_at = '2020-01-01T00:00:00+00:00'")
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert!(
+            lookup(&pool, &settings, &b, false).await.is_none(),
+            "过期不命中"
+        );
+        assert_eq!(purge_expired(&pool).await, 1, "过期清理生效");
+    }
+
+    #[tokio::test]
+    async fn semantic_layer_hits_above_threshold_via_similarity() {
+        let pool = memory_db().await;
+        let mut settings = settings_at(true);
+        settings
+            .set_many(&[(
+                "cache.embedding_model".to_string(),
+                serde_json::json!("emb-test"),
+            )])
+            .unwrap();
+        // 直接植入已知向量条目（不经 embedder——渠道依赖在集成测试外）：
+        // 缓存条目向量 = 查询向量（相似度 1.0 ≥ 阈值必命中）
+        let vector = vec![0.1f32, 0.2, 0.3];
+        sqlx::query(
+            "INSERT INTO semantic_cache (id, cache_key, model, embedding, answer, ttl_expire_at, created_at) \
+             VALUES ('c1', 'sc_seed_1', 'm', ?, '语义近邻答案', '2999-01-01T00:00:00+00:00', ?)",
+        )
+        .bind(encode_f32_blob(&vector))
+        .bind(crate::db::models::now_iso())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // exact 层不命中（键不同）→ semantic 层：查询向量与条目一致 → 命中
+        // （embedder 无渠道会失败 → lookup 回退 None——这里绕过 lookup 直测相似度路径
+        //   的组成件：余弦 + 编解码往返）
+        let round = decode_f32_blob(&encode_f32_blob(&vector)).unwrap();
+        assert_eq!(round, vector);
+        assert!(cosine_similarity(&vector, &round) >= 0.95);
+    }
+
+    #[test]
+    fn replay_body_and_sse_frames_are_well_formed() {
+        let replay = replay_body("m", "答案");
+        assert_eq!(replay["choices"][0]["message"]["content"], "答案");
+        assert_eq!(replay["choices"][0]["finish_reason"], "stop");
+
+        let sse = replay_sse_frames("m", "你好世界");
+        assert!(sse.starts_with("data: {"));
+        assert!(sse.contains("\"role\":\"assistant\""));
+        assert!(
+            sse.contains("你好世界") || sse.contains("\\u"),
+            "内容帧应包含答案文本"
+        );
+        assert!(
+            sse.trim_end().ends_with("data: [DONE]"),
+            "流式回放必须以 [DONE] 收尾"
+        );
+    }
+}

--- a/src-tauri/src/semantic_cache.rs
+++ b/src-tauri/src/semantic_cache.rs
@@ -283,6 +283,22 @@ pub async fn store(
     }
 }
 
+/// 清空缓存：model 为 Some(非空) 时按模型清，否则清全部。返回删除行数。
+/// 管理命令（clear_semantic_cache）的实体，独立成函数便于测试。
+pub async fn clear(pool: &SqlitePool, model: Option<&str>) -> Result<u64, sqlx::Error> {
+    match model {
+        Some(m) if !m.is_empty() => sqlx::query("DELETE FROM semantic_cache WHERE model = ?")
+            .bind(m)
+            .execute(pool)
+            .await
+            .map(|r| r.rows_affected()),
+        _ => sqlx::query("DELETE FROM semantic_cache")
+            .execute(pool)
+            .await
+            .map(|r| r.rows_affected()),
+    }
+}
+
 /// 从缓存答案合成非流式 chat completion 响应体。
 pub fn replay_body(model: &str, answer: &str) -> serde_json::Value {
     serde_json::json!({
@@ -575,5 +591,39 @@ mod tests {
             sse.trim_end().ends_with("data: [DONE]"),
             "流式回放必须以 [DONE] 收尾"
         );
+    }
+
+    /// 清空语义（管理命令实体）：按模型清与全清，返回删除行数。
+    #[tokio::test]
+    async fn clear_by_model_and_all() {
+        let pool = memory_db().await;
+        for (key, model) in [("sc_a_1", "m1"), ("sc_b_1", "m1"), ("sc_c_1", "m2")] {
+            sqlx::query(
+                "INSERT INTO semantic_cache (id, cache_key, model, embedding, answer, ttl_expire_at, created_at) \
+                 VALUES (?, ?, ?, NULL, ?, '2999-01-01T00:00:00+00:00', ?)",
+            )
+            .bind(uuid::Uuid::new_v4().to_string())
+            .bind(key)
+            .bind(model)
+            .bind("ans")
+            .bind(crate::db::models::now_iso())
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        // 按模型清 m1 → 删 2 行，剩 m2
+        assert_eq!(clear(&pool, Some("m1")).await.unwrap(), 2);
+        let remaining: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM semantic_cache WHERE model = 'm2'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(remaining, 1);
+
+        // 空字符串等价全部清
+        assert_eq!(clear(&pool, Some("")).await.unwrap(), 1);
+        // None 全清（空表返回 0）
+        assert_eq!(clear(&pool, None).await.unwrap(), 0);
     }
 }

--- a/src-tauri/src/server/admin_routes.rs
+++ b/src-tauri/src/server/admin_routes.rs
@@ -626,6 +626,9 @@ async fn dispatch(shared: &SharedState, cmd: &str, args: Value) -> Result<Value,
             to_json(commands::stats::get_token_trend(arg(&args, "hours")?, state).await)
         }
         "get_settings" => to_json(commands::settings::get_settings(state).await),
+        "clear_semantic_cache" => {
+            to_json(commands::settings::clear_semantic_cache(arg(&args, "model")?, state).await)
+        }
         "save_settings" => {
             to_json(commands::settings::save_settings(arg(&args, "settings")?, state).await)
         }

--- a/src-tauri/src/server/admin_routes.rs
+++ b/src-tauri/src/server/admin_routes.rs
@@ -509,6 +509,25 @@ async fn dispatch(shared: &SharedState, cmd: &str, args: Value) -> Result<Value,
             to_json(commands::log::get_log_stream_segments(arg(&args, "logId")?, state).await)
         }
         "get_log_stats" => to_json(commands::log::get_log_stats(arg(&args, "days")?, state).await),
+        "list_prompt_templates" => {
+            to_json(commands::prompt_template::list_prompt_templates(state).await)
+        }
+        "create_prompt_template" => to_json(
+            commands::prompt_template::create_prompt_template(
+                arg(&args, "templateKey")?,
+                arg(&args, "content")?,
+                state,
+            )
+            .await,
+        ),
+        "activate_prompt_template" => to_json(
+            commands::prompt_template::activate_prompt_template(
+                arg(&args, "templateKey")?,
+                arg(&args, "version")?,
+                state,
+            )
+            .await,
+        ),
         "delete_log" => to_json(commands::log::delete_log(arg(&args, "id")?, state).await),
         "delete_logs_before" => {
             to_json(commands::log::delete_logs_before(arg(&args, "beforeDate")?, state).await)

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -565,6 +565,64 @@ pub async fn handle_chat_completions(
         return (StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS, Json(err_body)).into_response();
     }
 
+    // 语义缓存拦截（C-02）：Key 鉴权与安全门之后、路由候选之前。
+    // 默认关闭；带 tools/高温/审计命中的请求直接旁路。命中返回缓存答案
+    //（非流式 JSON / 流式 SSE 回放，响应头 X-Cache: hit），并照常写请求
+    // 日志行（记账口径不变）。
+    let audit_hit_for_cache = audit_result.risk_score > 0 || audit_result.sanitized;
+    if let Some(hit) = crate::semantic_cache::lookup(
+        repo.pool(),
+        &shared.state.settings,
+        &json,
+        audit_hit_for_cache,
+    )
+    .await
+    {
+        let model = json.get("model").and_then(|m| m.as_str()).unwrap_or("");
+        tracing::debug!("[语义缓存] 命中（{} 层）: {model}", hit.layer);
+        let cache_log = sqlx::query(
+            "INSERT INTO request_logs (id, seq, api_key_id, api_key_name, model, mode, status_code, \
+             duration_ms, is_stream, is_retry, created_at, response_choices, risk_level, \
+             security_action, upstream_type, trace_id) \
+             VALUES (?, (SELECT COALESCE(MAX(seq), 0) + 1 FROM request_logs), ?, ?, ?, 'chat', 200, \
+             0, ?, 0, ?, ?, 'low', 'audit', 'cache', ?)",
+        )
+        .bind(crate::utils::id::new_id())
+        .bind(&key_record.id)
+        .bind(&key_record.name)
+        .bind(model)
+        .bind(i64::from(is_stream))
+        .bind(crate::db::models::now_iso())
+        .bind(
+            serde_json::to_string(&crate::semantic_cache::replay_body(model, &hit.answer))
+                .unwrap_or_default(),
+        )
+        .bind(trace_id.clone())
+        .execute(repo.pool())
+        .await;
+        if let Err(error) = cache_log {
+            tracing::warn!("[语义缓存] 命中日志行写入失败（不影响响应）: {error}");
+        }
+        let mut response = if is_stream {
+            (
+                [(header::CONTENT_TYPE, "text/event-stream")],
+                [(header::CACHE_CONTROL, "no-cache")],
+                crate::semantic_cache::replay_sse_frames(model, &hit.answer),
+            )
+                .into_response()
+        } else {
+            (
+                [(header::CONTENT_TYPE, "application/json")],
+                axum::Json(crate::semantic_cache::replay_body(model, &hit.answer)),
+            )
+                .into_response()
+        };
+        response
+            .headers_mut()
+            .insert("x-cache", axum::http::HeaderValue::from_static("hit"));
+        return response;
+    }
+
     // T06: when `new_routeplan` is ON, route through the model-first RoutePlan
     // facade first (stream and non-stream both).  `Ok(None)` means the flag is
     // off and the legacy flat path runs unchanged.
@@ -613,11 +671,35 @@ pub async fn handle_chat_completions(
         )
         .await
         {
-            Ok(result) => (
-                StatusCode::from_u16(result.status).unwrap_or(StatusCode::OK),
-                Json(result.body),
-            )
-                .into_response(),
+            Ok(result) => {
+                // 语义缓存写入（C-02，best-effort 旁路）：非流式 2xx 且可缓存判定
+                // 通过时，响应完整落账后异步写缓存——失败仅告警不影响主请求。
+                let cache_status = result.status;
+                if (200..300).contains(&cache_status) {
+                    if let Some(answer) = result
+                        .body
+                        .get("choices")
+                        .and_then(|c| c.get(0))
+                        .and_then(|c| c.get("message"))
+                        .and_then(|m| m.get("content"))
+                        .and_then(|c| c.as_str())
+                        .map(|s| s.to_string())
+                    {
+                        let pool = repo.pool().clone();
+                        let settings = shared.state.settings.clone();
+                        let cache_body = json.clone();
+                        tokio::spawn(async move {
+                            crate::semantic_cache::store(&pool, &settings, &cache_body, &answer)
+                                .await;
+                        });
+                    }
+                }
+                (
+                    StatusCode::from_u16(result.status).unwrap_or(StatusCode::OK),
+                    Json(result.body),
+                )
+                    .into_response()
+            }
             Err((code, msg)) => {
                 let err_body = serde_json::json!({
                     "error": { "message": msg, "type": "upstream_error", "code": code }

--- a/src-tauri/src/server/handlers.rs
+++ b/src-tauri/src/server/handlers.rs
@@ -4641,6 +4641,9 @@ mod list_models_tests {
             updated_at: "2026-01-01T00:00:00.000Z".to_string(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 

--- a/src-tauri/src/server/router.rs
+++ b/src-tauri/src/server/router.rs
@@ -613,7 +613,6 @@ mod tests {
 
         let shared = test_shared(&state, Some(ADMIN_TOKEN), Some(MCP_TOKEN));
         let app = build_router(state.clone(), shared);
-
         let body = serde_json::json!({
             "model": "m",
             "messages": [{"role": "user", "content": "hello"}],
@@ -648,6 +647,111 @@ mod tests {
             "落库 trace_id 必须与响应头回显值一致（关联键闭环）"
         );
     }
+
+    // ─── C-02：语义缓存端到端（命中短路 + X-Cache 头 + 记账）────────────────
+
+    async fn seed_cache_state(state: &Arc<AppState>, key: &str) {
+        sqlx::query(
+            "INSERT INTO api_keys (id, name, key, created_at, updated_at) \
+             VALUES ('ck-1', 'cache-test', ?, ?, ?)",
+        )
+        .bind(key)
+        .bind("2026-09-09T00:00:00+00:00")
+        .bind("2026-09-09T00:00:00+00:00")
+        .execute(&state.db.pool)
+        .await
+        .unwrap();
+        state
+            .settings
+            .set_many(&[(
+                "cache.semantic_enabled".to_string(),
+                serde_json::json!(true),
+            )])
+            .unwrap();
+    }
+
+    fn cache_chat_request(key: &str, content: &str) -> Request<Body> {
+        let body = serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": content}],
+            "temperature": 0.0
+        });
+        Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {key}"))
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn semantic_cache_hit_short_circuits_upstream_with_hit_header() {
+        let state = test_state().await;
+        seed_cache_state(&state, "sk-cache-1").await;
+
+        // 种入缓存条目（测试库无任何渠道——若拦截失效请求会 503 No channels）
+        let body = serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": "  相同   问题 "}],
+            "temperature": 0.0
+        });
+        crate::semantic_cache::store(&state.db.pool, &state.settings, &body, "缓存的答案").await;
+
+        let shared = test_shared(&state, Some(ADMIN_TOKEN), Some(MCP_TOKEN));
+        let app = build_router(state.clone(), shared);
+
+        // 规范化等价请求（空白差异）→ exact 命中
+        let res = app
+            .oneshot(cache_chat_request("sk-cache-1", "相同 问题"))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        assert_eq!(
+            res.headers().get("x-cache").and_then(|v| v.to_str().ok()),
+            Some("hit"),
+            "命中必须带 X-Cache: hit"
+        );
+        let bytes = axum::body::to_bytes(res.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value["choices"][0]["message"]["content"], "缓存的答案");
+
+        // 命中照常记账
+        let logged: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM request_logs WHERE mode = 'chat' AND upstream_type = 'cache'",
+        )
+        .fetch_one(&state.db.pool)
+        .await
+        .unwrap();
+        assert_eq!(logged, 1, "命中请求应写 upstream_type=cache 的日志行");
+    }
+
+    #[tokio::test]
+    async fn semantic_cache_disabled_or_uncacheable_passes_through() {
+        let state = test_state().await;
+        seed_cache_state(&state, "sk-cache-2").await;
+        // 关闭开关
+        state
+            .settings
+            .set_many(&[(
+                "cache.semantic_enabled".to_string(),
+                serde_json::json!(false),
+            )])
+            .unwrap();
+        let shared = test_shared(&state, Some(ADMIN_TOKEN), Some(MCP_TOKEN));
+        let app = build_router(state, shared);
+
+        // 关闭时：无渠道可用 → 503（证明未走缓存拦截短路）
+        let res = app
+            .oneshot(cache_chat_request("sk-cache-2", "任意问题"))
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert!(res.headers().get("x-cache").is_none());
+    }
+
 
     #[tokio::test]
     async fn cors_only_covers_data_plane_not_service_routes() {

--- a/src-tauri/src/services/channel_test.rs
+++ b/src-tauri/src/services/channel_test.rs
@@ -514,6 +514,9 @@ fn draft_channel(input: &DraftChannelTestInput, api_key: &str, timeout_secs: i64
         updated_at: now_iso(),
         last_test_at: None,
         last_test_ok: None,
+        last_probe_at: None,
+        last_probe_ok: None,
+        probe_latency_ms: None,
     }
 }
 
@@ -1868,6 +1871,9 @@ data: {"type":"message_stop"}
             updated_at: now_iso(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         }
     }
 
@@ -1994,6 +2000,9 @@ data: {"type":"message_stop"}
             updated_at: now_iso(),
             last_test_at: None,
             last_test_ok: None,
+            last_probe_at: None,
+            last_probe_ok: None,
+            probe_latency_ms: None,
         };
         insert_channel(&pool, &channel).await;
         let repo = Repository::new(pool);

--- a/src-tauri/src/services/knowledge/rag.rs
+++ b/src-tauri/src/services/knowledge/rag.rs
@@ -4,6 +4,7 @@ use super::repository::KbRepository;
 use super::retriever;
 use crate::core::proxy;
 use crate::db::repository::Repository;
+use crate::prompt_templates;
 use crate::settings_store::SettingsStore;
 use sqlx::SqlitePool;
 use std::sync::Arc;
@@ -229,11 +230,12 @@ pub async fn ask_with_config(
         context_used
     );
 
-    // 6. Call LLM via proxy
+    // 6. Call LLM via proxy（系统提示词走模板表：激活版本优先，回退编译期默认）
+    let rag_system_prompt = prompt_templates::load(pool, prompt_templates::KEY_RAG_SYSTEM).await;
     let chat_request = serde_json::json!({
         "model": chat_model,
         "messages": [
-            {"role": "system", "content": "你是 RAG 助手。基于检索到的内容回答问题。回答要准确、简洁，并标注信息来源。如果没有相关信息，请明确说明。"},
+            {"role": "system", "content": rag_system_prompt},
             {"role": "user", "content": final_prompt}
         ],
         "stream": false
@@ -499,10 +501,12 @@ pub async fn deep_research(
                     .join("\n"),
             );
 
+            let next_query_system =
+                prompt_templates::load(pool, prompt_templates::KEY_RESEARCH_NEXT_QUERY).await;
             let follow_up_request = serde_json::json!({
                 "model": chat_model,
                 "messages": [
-                    {"role": "system", "content": "你是一个研究助手，根据已有发现生成下一步搜索查询。只返回查询本身。"},
+                    {"role": "system", "content": next_query_system},
                     {"role": "user", "content": follow_up_prompt}
                 ],
                 "stream": false
@@ -566,51 +570,28 @@ pub async fn deep_research(
             .join("\n");
 
         let round_prompt = if round == 0 {
-            format!(
-                r#"你是一个深度研究助手。请分析以下 RAG 内容，并给出初步发现。
-
-原始问题: {query}
-
-<knowledge_base>
-{context}
-</knowledge_base>
-
-请完成：
-1. 理解问题的核心需求
-2. 从 RAG 中提取相关信息
-3. 给出初步发现
-4. 如果信息不足，指出还需要哪些方面"#,
-                query = query,
-                context = context,
-            )
+            let template =
+                prompt_templates::load(pool, prompt_templates::KEY_DEEP_RESEARCH_ROUND0).await;
+            prompt_templates::render(&template, &[("query", query), ("context", &context)])
         } else {
-            format!(
-                r#"继续深度研究。
-
-原始问题: {query}
-
-已有发现:
-{findings}
-
-新检索到的内容:
-<knowledge_base>
-{context}
-</knowledge_base>
-
-请完成：
-1. 分析新内容与已有发现的关系
-2. 补充或修正之前的发现
-3. 指出是否需要继续研究"#,
-                query = query,
-                findings = findings_str,
-                context = context,
+            let template =
+                prompt_templates::load(pool, prompt_templates::KEY_DEEP_RESEARCH_ROUND_NEXT).await;
+            prompt_templates::render(
+                &template,
+                &[
+                    ("query", query),
+                    ("findings", &findings_str),
+                    ("context", &context),
+                ],
             )
         };
 
+        let deep_research_system =
+            prompt_templates::load(pool, prompt_templates::KEY_DEEP_RESEARCH_SYSTEM).await;
         let chat_request = serde_json::json!({
             "model": chat_model,
             "messages": [
-                {"role": "system", "content": "你是深度研究助手。基于 RAG 内容进行多轮迭代研究，逐步深入分析。"},
+                {"role": "system", "content": deep_research_system},
                 {"role": "user", "content": round_prompt}
             ],
             "stream": false
@@ -669,23 +650,17 @@ pub async fn deep_research(
         .collect::<Vec<_>>()
         .join("\n\n");
 
-    let final_prompt = format!(
-        r#"基于多轮深度研究的发现，请综合回答原始问题。
-
-原始问题: {query}
-
-多轮研究发现:
-{findings}
-
-请综合所有发现，给出完整、准确的回答。标注信息来源。"#,
-        query = query,
-        findings = findings_summary,
+    let final_prompt = prompt_templates::render(
+        &prompt_templates::load(pool, prompt_templates::KEY_DEEP_RESEARCH_FINAL).await,
+        &[("query", query), ("findings", &findings_summary)],
     );
 
+    let final_system =
+        prompt_templates::load(pool, prompt_templates::KEY_DEEP_RESEARCH_FINAL_SYSTEM).await;
     let final_request = serde_json::json!({
         "model": chat_model,
         "messages": [
-            {"role": "system", "content": "你是深度研究助手。综合多轮研究发现，给出完整准确的回答。"},
+            {"role": "system", "content": final_system},
             {"role": "user", "content": final_prompt}
         ],
         "stream": false

--- a/src-tauri/src/services/knowledge/rag.rs
+++ b/src-tauri/src/services/knowledge/rag.rs
@@ -841,6 +841,26 @@ async fn rewrite_query_with_llm(
 mod rewrite_tests {
     use super::*;
 
+    /// 门控键契约（ask_with_config 内联表达式）：键名与默认值锁定——
+    /// 键名打错会让改写误开（成本意外增加）或永不生效；默认必须为关。
+    #[test]
+    fn query_rewrite_gate_defaults_off_and_key_is_stable() {
+        let dir =
+            std::env::temp_dir().join(format!("waliapi-rewrite-gate-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = crate::settings_store::SettingsStore::file(dir.join("settings.json"));
+
+        // 未配置 → 关（默认值契约）
+        assert!(
+            !store.get_bool("kb.query_rewrite", false),
+            "kb.query_rewrite 默认必须为关"
+        );
+        // 开启表达式（ask_with_config 内联条件的镜像）：关闭或无历史 → 不进入改写
+        let gate = store.get_bool("kb.query_rewrite", false);
+        assert!(!(gate && !Vec::<ConversationMessage>::new().is_empty()));
+        assert!(!gate, "关闭时检索路径零变化（结构性跳过改写）");
+    }
+
     #[test]
     fn extract_rewrite_query_takes_first_line_and_trims_quotes() {
         assert_eq!(

--- a/src-tauri/src/services/knowledge/rag.rs
+++ b/src-tauri/src/services/knowledge/rag.rs
@@ -57,6 +57,16 @@ pub async fn ask_with_config(
     let repo = Repository::new(pool.clone());
     let kb_repo = KbRepository::new(pool.clone());
 
+    // C-06/R2：可选多轮查询改写（kb.query_rewrite，默认关）。
+    // 多轮对话的指代型问题（「上面说的方案呢」）直接送检索必然 miss——
+    // 开启时先用渠道模型把「近几轮对话 + 当前问题」改写成独立完整的检索查询。
+    // 失败/超时静默回退原查询（best-effort），多一次 LLM 调用的成本由开关控制。
+    let query = if settings.get_bool("kb.query_rewrite", false) && !history.is_empty() {
+        rewrite_query_with_llm(pool, settings, kb_id, chat_model, query, history).await
+    } else {
+        query.to_string()
+    };
+
     // 1. Embed the query (needed for vector and hybrid modes)
     let query_emb_opt = if search_mode != "keyword" {
         let embeddings = embedder::embed(&[query.to_string()], embedding_model, &repo)
@@ -82,7 +92,7 @@ pub async fn ask_with_config(
             retriever::hybrid_search_with_details(
                 pool,
                 kb_id,
-                query,
+                &query,
                 &embeddings[0],
                 top_k,
                 vector_weight,
@@ -90,7 +100,7 @@ pub async fn ask_with_config(
             )
             .await?
         } else {
-            let kw = retriever::keyword_only_search(pool, kb_id, query, top_k).await?;
+            let kw = retriever::keyword_only_search(pool, kb_id, &query, top_k).await?;
             kw.into_iter()
                 .map(|r| {
                     let score = r.score;
@@ -147,7 +157,7 @@ pub async fn ask_with_config(
             retriever::hybrid_search_with_details(
                 pool,
                 kb_id,
-                query,
+                &query,
                 query_emb,
                 top_k,
                 vector_weight,
@@ -166,7 +176,7 @@ pub async fn ask_with_config(
         if !kb_id.is_empty() {
             let answer = "RAG 中没有找到相关内容。".to_string();
             kb_repo
-                .add_conversation(kb_id, "user", query, None, Some(chat_model), 0)
+                .add_conversation(kb_id, "user", &query, None, Some(chat_model), 0)
                 .await
                 .ok();
             kb_repo
@@ -192,7 +202,7 @@ pub async fn ask_with_config(
     let context = build_context(&results);
 
     // 4. Build prompt with history
-    let prompt = build_rag_prompt(&context, query, history);
+    let prompt = build_rag_prompt(&context, &query, history);
 
     // 5. Token estimation and fallback
     let estimated_tokens = retriever::estimate_tokens(&prompt);
@@ -201,11 +211,14 @@ pub async fn ask_with_config(
 
     let (final_prompt, context_used) = if estimated_tokens > context_limit {
         // Stage 1: Trim context (remove lowest-scoring chunks)
-        let trimmed = trim_context(&results, query, history, context_limit);
+        let trimmed = trim_context(&results, &query, history, context_limit);
         if retriever::estimate_tokens(&trimmed.0) > context_limit {
             // Stage 2: Remove history, keep only latest message
-            let no_history =
-                build_rag_prompt(&context, query, &history[history.len().saturating_sub(2)..]);
+            let no_history = build_rag_prompt(
+                &context,
+                &query,
+                &history[history.len().saturating_sub(2)..],
+            );
             if retriever::estimate_tokens(&no_history) > context_limit {
                 // Stage 3: Remove context entirely
                 let bare = format!(
@@ -310,7 +323,7 @@ pub async fn ask_with_config(
                 let sources_json = serde_json::to_string(&sources).ok();
                 let tokens = usage.as_ref().map(|u| u.total_tokens as i64).unwrap_or(0);
                 kb_repo
-                    .add_conversation(kb_id, "user", query, None, Some(chat_model), 0)
+                    .add_conversation(kb_id, "user", &query, None, Some(chat_model), 0)
                     .await
                     .ok();
                 kb_repo
@@ -739,5 +752,142 @@ pub async fn deep_research(
             })
         }
         Err((code, msg)) => Err(format!("Final synthesis failed ({}): {}", code, msg)),
+    }
+}
+
+// ─── C-06/R2：多轮查询改写 ─────────────────────────────────────────────────
+
+/// 从改写回复中提取查询（纯函数）：取首个非空行、去引号包裹、截断到 512 字符。
+/// 空回复/全空白 → None（调用侧回退原查询）。
+fn extract_rewrite_query(reply: &str) -> Option<String> {
+    let line = reply.lines().map(str::trim).find(|l| !l.is_empty())?;
+    let line = line.trim_matches(|c| c == '"' || c == '“' || c == '”');
+    if line.is_empty() {
+        return None;
+    }
+    Some(line.chars().take(512).collect())
+}
+
+/// 可选查询改写：近几轮对话 + 当前问题 → 独立完整检索查询。
+/// 走渠道模型（kb-internal 路由组，token 消耗自动落账）；任何失败静默回退原查询。
+async fn rewrite_query_with_llm(
+    pool: &SqlitePool,
+    settings: &SettingsStore,
+    kb_id: &str,
+    chat_model: &str,
+    query: &str,
+    history: &[ConversationMessage],
+) -> String {
+    // 近 6 轮（改写只需消解指代，更早的轮次是噪音）
+    let recent: Vec<String> = history
+        .iter()
+        .rev()
+        .take(6)
+        .rev()
+        .map(|m| format!("{}: {}", m.role, m.content))
+        .collect();
+    let history_text = recent.join("\n");
+    let prompt = prompt_templates::render(
+        &prompt_templates::load(pool, prompt_templates::KEY_QUERY_REWRITE).await,
+        &[("history", &history_text), ("query", query)],
+    );
+    let chat_request = serde_json::json!({
+        "model": chat_model,
+        "messages": [
+            {"role": "system", "content": "你是检索查询改写器，只输出改写后的查询本身。"},
+            {"role": "user", "content": prompt}
+        ],
+        "stream": false,
+        "temperature": 0.0
+    });
+    let chat_request_str: String = serde_json::to_string(&chat_request).unwrap_or_default();
+    let proxy_result = proxy::handle_request(
+        &std::sync::Arc::new(Repository::new(pool.clone())),
+        settings,
+        "kb-rewrite",
+        "RAG-rewrite",
+        chat_request,
+        false,
+        Some(chat_request_str),
+        Some(format!("kb-internal_{}", kb_id)),
+        None,
+    )
+    .await;
+    let reply = match proxy_result {
+        Ok(result) => result
+            .body
+            .get("choices")
+            .and_then(|c| c.get(0))
+            .and_then(|c| c.get("message"))
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_str())
+            .unwrap_or("")
+            .to_string(),
+        Err(_) => String::new(),
+    };
+    match extract_rewrite_query(&reply) {
+        Some(rewritten) => {
+            tracing::debug!("[RAG] 查询改写: {query:?} -> {rewritten:?}");
+            rewritten
+        }
+        None => {
+            tracing::warn!("[RAG] 查询改写回复不可解析，回退原查询");
+            query.to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod rewrite_tests {
+    use super::*;
+
+    #[test]
+    fn extract_rewrite_query_takes_first_line_and_trims_quotes() {
+        assert_eq!(
+            extract_rewrite_query("WaLiAPI 网关如何配置渠道配额\n（改写说明）"),
+            Some("WaLiAPI 网关如何配置渠道配额".to_string())
+        );
+        assert_eq!(
+            extract_rewrite_query("  \"带引号的查询\"  "),
+            Some("带引号的查询".to_string())
+        );
+        assert_eq!(
+            extract_rewrite_query("“中文引号”"),
+            Some("中文引号".to_string())
+        );
+        // 空白/空行 → None
+        assert_eq!(extract_rewrite_query(""), None);
+        assert_eq!(extract_rewrite_query(" \n \n"), None);
+        // 超长截断
+        let long = "长".repeat(600);
+        assert_eq!(
+            extract_rewrite_query(&long).map(|q| q.chars().count()),
+            Some(512)
+        );
+    }
+
+    /// 改写关闭（默认）或无历史 → 走原查询（结构性保障：分支条件在 ask_with_config 内联，
+    /// 此处锁定 extract 的回退语义与 rewrite 的失败回退）。
+    #[tokio::test]
+    async fn rewrite_falls_back_to_original_when_no_channels() {
+        // 内存库无任何渠道 → proxy 转发必然失败 → 回退原查询（不 panic、不报错）
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        let settings = SettingsStore::file(
+            std::env::temp_dir().join(format!("waliapi-rewrite-test-{}", uuid::Uuid::new_v4())),
+        );
+        let history = vec![
+            ConversationMessage {
+                role: "user".into(),
+                content: "WaLiAPI 的渠道配额怎么配？".into(),
+            },
+            ConversationMessage {
+                role: "assistant".into(),
+                content: "在密钥页设置 quota_limit。".into(),
+            },
+        ];
+        let result =
+            rewrite_query_with_llm(&pool, &settings, "kb-1", "m", "那限流呢？", &history).await;
+        assert_eq!(result, "那限流呢？", "上游不可用时必须静默回退原查询");
     }
 }

--- a/src-tauri/src/services/knowledge/rag.rs
+++ b/src-tauri/src/services/knowledge/rag.rs
@@ -56,6 +56,8 @@ pub async fn ask_with_config(
 ) -> Result<RagAnswer, String> {
     let repo = Repository::new(pool.clone());
     let kb_repo = KbRepository::new(pool.clone());
+    // 融合模式（C-06/R3）：RRF 默认（消量纲），weighted 保留可配回退
+    let fusion_mode = retriever::FusionMode::parse(&settings.get_str("kb.fusion_mode", "rrf"));
 
     // C-06/R2：可选多轮查询改写（kb.query_rewrite，默认关）。
     // 多轮对话的指代型问题（「上面说的方案呢」）直接送检索必然 miss——
@@ -97,6 +99,7 @@ pub async fn ask_with_config(
                 top_k,
                 vector_weight,
                 keyword_weight,
+                fusion_mode,
             )
             .await?
         } else {
@@ -162,10 +165,21 @@ pub async fn ask_with_config(
                 top_k,
                 vector_weight,
                 keyword_weight,
+                fusion_mode,
             )
             .await?
         }
     };
+
+    // C-06/R3 第二步：可选 LLM listwise 重排（`kb.rerank_enabled`，默认关）。
+    // 走网关自身的渠道跑渠道（proxy::handle_request，kb-internal 路由组），
+    // 重排调用的 token 消耗自动计入请求日志；失败静默回退原序（best-effort）。
+    let scored_results =
+        if settings.get_bool("kb.rerank_enabled", false) && scored_results.len() > 1 {
+            rerank_with_llm(pool, settings, kb_id, chat_model, &query, scored_results).await
+        } else {
+            scored_results
+        };
 
     // Extract plain results for context building
     let results: Vec<super::models::SearchResult> =
@@ -813,6 +827,7 @@ async fn rewrite_query_with_llm(
         None,
     )
     .await;
+
     let reply = match proxy_result {
         Ok(result) => result
             .body
@@ -909,5 +924,129 @@ mod rewrite_tests {
         let result =
             rewrite_query_with_llm(&pool, &settings, "kb-1", "m", "那限流呢？", &history).await;
         assert_eq!(result, "那限流呢？", "上游不可用时必须静默回退原查询");
+    }
+}
+
+// ─── C-06/R3 第二步：LLM listwise 重排 ─────────────────────────────────────
+
+/// 解析重排回复为候选顺序（纯函数）：
+/// 容忍前后杂文（截取首个 [ 到最后一个 ]）；编号越界/重复丢弃；
+/// 未出现的候选按原序补尾——保证输出恒为原候选的全排列。
+fn parse_rerank_order(reply: &str, len: usize) -> Option<Vec<usize>> {
+    let start = reply.find('[')?;
+    let end = reply.rfind(']')?;
+    if end <= start {
+        return None;
+    }
+    let parsed: Vec<i64> = serde_json::from_str(&reply[start..=end]).ok()?;
+    let mut order: Vec<usize> = Vec::with_capacity(len);
+    for index in parsed {
+        let index = index as usize;
+        if index < len && !order.contains(&index) {
+            order.push(index);
+        }
+    }
+    for i in 0..len {
+        if !order.contains(&i) {
+            order.push(i);
+        }
+    }
+    Some(order)
+}
+
+/// 可选 LLM 重排：把 top 候选拼给渠道模型打分重排（用渠道跑渠道）。
+/// 失败/关闭不影响主流程——原序返回，仅 tracing 告警。
+async fn rerank_with_llm(
+    pool: &SqlitePool,
+    settings: &crate::settings_store::SettingsStore,
+    kb_id: &str,
+    chat_model: &str,
+    query: &str,
+    candidates: Vec<retriever::ScoredSearchResult>,
+) -> Vec<retriever::ScoredSearchResult> {
+    let mut listing = String::new();
+    for (i, c) in candidates.iter().enumerate() {
+        let excerpt: String = c
+            .result
+            .content
+            .chars()
+            .take(200)
+            .collect::<String>()
+            .replace('\n', " ");
+        listing.push_str(&format!("[{}] {}: {}\n", i, c.result.filename, excerpt));
+    }
+    let prompt = format!(
+        "你是检索结果重排器。根据查询对候选片段按相关性从高到低排序。\n\n查询：{query}\n\n候选片段：\n{listing}\n只返回一个 JSON 数组，元素为候选编号、按相关性从高到低排列，例如 [2,0,1]。不要输出其他内容。"
+    );
+    let chat_request = serde_json::json!({
+        "model": chat_model,
+        "messages": [
+            {"role": "system", "content": "你是检索重排器，只输出 JSON 数组。"},
+            {"role": "user", "content": prompt}
+        ],
+        "stream": false,
+        "temperature": 0.0
+    });
+    let chat_request_str: String = serde_json::to_string(&chat_request).unwrap_or_default();
+    let proxy_result = proxy::handle_request(
+        &std::sync::Arc::new(crate::db::repository::Repository::new(pool.clone())),
+        settings,
+        "kb-rerank",
+        "RAG-rerank",
+        chat_request,
+        false,
+        Some(chat_request_str),
+        Some(format!("kb-internal_{}", kb_id)),
+        None,
+    )
+    .await;
+
+    let reply = match proxy_result {
+        Ok(result) => result
+            .body
+            .get("choices")
+            .and_then(|c| c.get(0))
+            .and_then(|c| c.get("message"))
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_str())
+            .unwrap_or("")
+            .to_string(),
+        Err(_) => String::new(),
+    };
+    match parse_rerank_order(&reply, candidates.len()) {
+        Some(order) => {
+            let mut reordered = Vec::with_capacity(candidates.len());
+            for index in order {
+                reordered.push(candidates[index].clone());
+            }
+            tracing::debug!("[RAG] LLM 重排生效（{} 候选）", reordered.len());
+            reordered
+        }
+        None => {
+            tracing::warn!("[RAG] LLM 重排回复不可解析，回退原序（相关性排序）");
+            candidates
+        }
+    }
+}
+
+#[cfg(test)]
+mod rerank_tests {
+    use super::*;
+
+    #[test]
+    fn parse_rerank_order_extracts_json_and_validates() {
+        // 纯 JSON
+        assert_eq!(parse_rerank_order("[2,0,1]", 3), Some(vec![2, 0, 1]));
+        // 前后杂文容忍
+        assert_eq!(
+            parse_rerank_order("排序结果：[1, 2, 0] 以上。", 3),
+            Some(vec![1, 2, 0])
+        );
+        // 越界丢弃 + 缺失补尾（全排列保证）
+        assert_eq!(parse_rerank_order("[5,0,5]", 3), Some(vec![0, 1, 2]));
+        assert_eq!(parse_rerank_order("[1]", 3), Some(vec![1, 0, 2]));
+        // 不可解析 → None
+        assert_eq!(parse_rerank_order("no json here", 3), None);
+        assert_eq!(parse_rerank_order("[]", 3), Some(vec![0, 1, 2]));
     }
 }

--- a/src-tauri/src/services/knowledge/retriever.rs
+++ b/src-tauri/src/services/knowledge/retriever.rs
@@ -691,6 +691,7 @@ pub async fn hybrid_search(
     top_k: usize,
     vector_weight: f32,
     keyword_weight: f32,
+    fusion_mode: FusionMode,
 ) -> Result<Vec<SearchResult>, String> {
     let scored = hybrid_search_with_details(
         pool,
@@ -700,62 +701,97 @@ pub async fn hybrid_search(
         top_k,
         vector_weight,
         keyword_weight,
+        fusion_mode,
     )
     .await?;
     Ok(scored.into_iter().map(|s| s.result).collect())
 }
 
 /// Hybrid search returning detailed score breakdowns.
-pub async fn hybrid_search_with_details(
-    pool: &SqlitePool,
-    kb_id: &str,
-    query: &str,
-    query_embedding: &[f32],
+/// 混合检索融合模式（C-06/R3）：
+/// - Rrf：倒数排名融合（只用排名，天然消两路量纲差异；默认）
+/// - Weighted：线性加权（历史行为，量纲敏感，保留可配回退）
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FusionMode {
+    Rrf,
+    Weighted,
+}
+
+impl FusionMode {
+    pub fn parse(value: &str) -> Self {
+        if value.eq_ignore_ascii_case("weighted") {
+            Self::Weighted
+        } else {
+            Self::Rrf
+        }
+    }
+}
+
+/// RRF 常数 k：排名 1 的贡献 1/(k+1)——业界惯用 60，
+/// 对 top_k 量级的候选列表区分度稳定。
+const RRF_K: f32 = 60.0;
+
+/// 融合两路检索结果（纯函数）：按 mode 计算综合分并截断 top_k。
+/// RRF 分数 = Σ 1/(k + rank)（rank 从 1 起，只在出现该 id 的路里计）；
+/// Weighted 分数 = v_score·vw + k_score·kw（历史行为原样保留）。
+pub fn fuse_scored(
+    vector_results: &[SearchResult],
+    keyword_results: &[SearchResult],
     top_k: usize,
     vector_weight: f32,
     keyword_weight: f32,
-) -> Result<Vec<ScoredSearchResult>, String> {
-    let (vector_results, keyword_results) = tokio::join!(
-        search(pool, kb_id, query_embedding, top_k * 2),
-        fts5_search(pool, kb_id, query, top_k * 2),
-    );
-
-    let vector_results = vector_results.unwrap_or_default();
-    let keyword_results = keyword_results.unwrap_or_default();
-
-    // Build lookup maps: chunk_id -> (SearchResult, raw_score)
+    mode: FusionMode,
+) -> Vec<ScoredSearchResult> {
     let mut vector_map: std::collections::HashMap<String, (SearchResult, f32)> =
         std::collections::HashMap::new();
-    for r in &vector_results {
+    for r in vector_results {
         vector_map.insert(r.chunk_id.clone(), (r.clone(), r.score));
     }
 
     let mut keyword_map: std::collections::HashMap<String, (SearchResult, f32)> =
         std::collections::HashMap::new();
-    for r in &keyword_results {
+    for r in keyword_results {
         keyword_map.insert(r.chunk_id.clone(), (r.clone(), r.score));
     }
 
-    // Collect all unique chunk IDs
     let mut all_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
     all_ids.extend(vector_map.keys().cloned());
     all_ids.extend(keyword_map.keys().cloned());
 
-    // Compute weighted scores
     let mut scored: Vec<(String, f32, Option<f32>, Option<f32>)> = Vec::new();
     for id in &all_ids {
         let v_score = vector_map.get(id).map(|(_, s)| *s);
         let k_score = keyword_map.get(id).map(|(_, s)| *s);
-        let weighted =
-            v_score.unwrap_or(0.0) * vector_weight + k_score.unwrap_or(0.0) * keyword_weight;
-        scored.push((id.clone(), weighted, v_score, k_score));
+        let final_score = match mode {
+            FusionMode::Weighted => {
+                v_score.unwrap_or(0.0) * vector_weight + k_score.unwrap_or(0.0) * keyword_weight
+            }
+            FusionMode::Rrf => {
+                // 排名在各自路内按分数降序确定（输入已排序，这里防御性重算）
+                let v_rank = vector_results
+                    .iter()
+                    .position(|r| &r.chunk_id == id)
+                    .map(|p| p + 1);
+                let k_rank = keyword_results
+                    .iter()
+                    .position(|r| &r.chunk_id == id)
+                    .map(|p| p + 1);
+                let mut score = 0.0;
+                if let Some(rank) = v_rank {
+                    score += 1.0 / (RRF_K + rank as f32);
+                }
+                if let Some(rank) = k_rank {
+                    score += 1.0 / (RRF_K + rank as f32);
+                }
+                score
+            }
+        };
+        scored.push((id.clone(), final_score, v_score, k_score));
     }
 
-    // Sort by weighted score descending
     scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     scored.truncate(top_k);
 
-    // Build final results with score breakdowns
     let mut results = Vec::with_capacity(scored.len());
     for (id, final_score, v_score, k_score) in scored {
         // Prefer vector result (has embedding metadata), fallback to keyword result
@@ -772,8 +808,35 @@ pub async fn hybrid_search_with_details(
             });
         }
     }
+    results
+}
 
-    Ok(results)
+pub async fn hybrid_search_with_details(
+    pool: &SqlitePool,
+    kb_id: &str,
+    query: &str,
+    query_embedding: &[f32],
+    top_k: usize,
+    vector_weight: f32,
+    keyword_weight: f32,
+    fusion_mode: FusionMode,
+) -> Result<Vec<ScoredSearchResult>, String> {
+    let (vector_results, keyword_results) = tokio::join!(
+        search(pool, kb_id, query_embedding, top_k * 2),
+        fts5_search(pool, kb_id, query, top_k * 2),
+    );
+
+    let vector_results = vector_results.unwrap_or_default();
+    let keyword_results = keyword_results.unwrap_or_default();
+
+    Ok(fuse_scored(
+        &vector_results,
+        &keyword_results,
+        top_k,
+        vector_weight,
+        keyword_weight,
+        fusion_mode,
+    ))
 }
 
 /// Keyword-only search using FTS5 (no vector search).
@@ -1084,5 +1147,115 @@ mod index_delta_tests {
         assert_eq!(rebuilt.doc_node_ids("doc-a").len(), 2);
 
         std::fs::remove_file(index_path(&kb_id)).ok();
+    }
+}
+
+// ─── C-06/R3：融合模式纯函数测试 ────────────────────────────────────────────
+#[cfg(test)]
+mod rrf_tests {
+    use super::*;
+
+    fn result(chunk_id: &str, score: f32) -> SearchResult {
+        SearchResult {
+            chunk_id: chunk_id.to_string(),
+            doc_id: "d".to_string(),
+            filename: "f.md".to_string(),
+            content: String::new(),
+            score,
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    #[test]
+    fn fusion_mode_parses_with_rrf_default() {
+        assert_eq!(FusionMode::parse("rrf"), FusionMode::Rrf);
+        assert_eq!(FusionMode::parse("RRF"), FusionMode::Rrf);
+        assert_eq!(FusionMode::parse("weighted"), FusionMode::Weighted);
+        assert_eq!(
+            FusionMode::parse("unknown"),
+            FusionMode::Rrf,
+            "未知值回退默认 RRF"
+        );
+    }
+
+    /// rag_query 的实际取值表达式（settings → FusionMode）：weighted 可切回、
+    /// 未配置走默认。锁定设置存储到融合模式的接线契约。
+    #[test]
+    fn fusion_mode_settings_expression_matches_rag_query() {
+        let dir =
+            std::env::temp_dir().join(format!("waliapi-fusion-mode-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = crate::settings_store::SettingsStore::file(dir.join("settings.json"));
+
+        // 未配置 → 默认 rrf
+        let mode = FusionMode::parse(&store.get_str("kb.fusion_mode", "rrf"));
+        assert_eq!(mode, FusionMode::Rrf);
+
+        // 配置 weighted → 可切回
+        store
+            .set_many(&[("kb.fusion_mode".to_string(), serde_json::json!("weighted"))])
+            .unwrap();
+        let mode = FusionMode::parse(&store.get_str("kb.fusion_mode", "rrf"));
+        assert_eq!(
+            mode,
+            FusionMode::Weighted,
+            "设置项 weighted 必须切回线性加权"
+        );
+    }
+
+    /// 量纲悬殊两路：向量分数接近 1、关键词分数微小（FTS5 bm25 常态）。
+    /// 线性加权下向量路一家独大；RRF 只看排名，两路一致认可的候选（两路都排前）
+    /// 应排到第一。
+    #[test]
+    fn rrf_beats_weighted_when_scales_are_skewed() {
+        // 两路一致认可 c_both；向量路单独强推 c_vec_only（分数最高）
+        let vector = vec![result("c_vec_only", 0.99), result("c_both", 0.97)];
+        let keyword = vec![result("c_both", 0.0007), result("c_kw_only", 0.0005)];
+
+        let weighted = fuse_scored(&vector, &keyword, 3, 0.7, 0.3, FusionMode::Weighted);
+        assert_eq!(
+            weighted[0].result.chunk_id, "c_vec_only",
+            "加权前置条件：向量量纲碾压"
+        );
+
+        let rrf = fuse_scored(&vector, &keyword, 3, 0.7, 0.3, FusionMode::Rrf);
+        assert_eq!(
+            rrf[0].result.chunk_id, "c_both",
+            "RRF 下两路都靠前的候选应排第一（排名共识优先于单路高分）"
+        );
+    }
+
+    #[test]
+    fn rrf_scores_are_rank_based_and_deterministic() {
+        let vector = vec![result("a", 0.9), result("b", 0.5)];
+        let keyword = vec![result("a", 0.1), result("b", 0.05)];
+        let fused = fuse_scored(&vector, &keyword, 2, 0.7, 0.3, FusionMode::Rrf);
+        // a: 两路 rank1 → 2/(k+1)；b: 两路 rank2 → 2/(k+2)；a > b
+        assert_eq!(fused[0].result.chunk_id, "a");
+        let expected_a = 1.0 / (60.0 + 1.0) + 1.0 / (60.0 + 1.0);
+        assert!((fused[0].result.score - expected_a).abs() < 1e-6);
+        // 分数明细保留两路原始值（可视化/调试用）
+        assert_eq!(fused[0].vector_score, Some(0.9));
+        assert_eq!(fused[0].keyword_score, Some(0.1));
+    }
+
+    #[test]
+    fn weighted_mode_preserves_historical_behavior() {
+        let vector = vec![result("a", 1.0)];
+        let keyword = vec![result("b", 1.0)];
+        let fused = fuse_scored(&vector, &keyword, 2, 0.7, 0.3, FusionMode::Weighted);
+        assert_eq!(fused[0].result.chunk_id, "a");
+        assert!((fused[0].result.score - 0.7).abs() < 1e-6);
+        assert!((fused[1].result.score - 0.3).abs() < 1e-6);
+    }
+
+    #[test]
+    fn rrf_truncates_to_top_k_and_handles_empty_lists() {
+        let vector: Vec<SearchResult> = vec![result("a", 0.9), result("b", 0.8), result("c", 0.7)];
+        assert_eq!(
+            fuse_scored(&vector, &[], 2, 0.7, 0.3, FusionMode::Rrf).len(),
+            2
+        );
+        assert!(fuse_scored(&[], &[], 5, 0.7, 0.3, FusionMode::Rrf).is_empty());
     }
 }

--- a/src-tauri/src/services/mcp/handlers.rs
+++ b/src-tauri/src/services/mcp/handlers.rs
@@ -822,6 +822,8 @@ async fn handle_tool_call(
                     top_k,
                     vector_weight,
                     keyword_weight,
+                    // MCP 工具路径用默认融合模式（RRF）；面板路径按 kb.fusion_mode 设置
+                    retriever::FusionMode::Rrf,
                 )
                 .await?;
 

--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -114,6 +114,10 @@ pub async fn run(cfg: WebServerConfig) -> Result<(), String> {
         data_dir,
     });
 
+    // Prompt 模板种子（C-07）：空表时写入源码字面量 v1——升级后行为逐字节不变
+    if let Err(error) = crate::prompt_templates::seed_if_empty(&state.db.pool).await {
+        tracing::warn!("[模板] 种子写入失败（运行时回退编译期默认）: {error}");
+    }
     crate::audit_log::apply_settings(&state.settings);
     tauri::async_runtime::spawn(crate::audit_log::run_maintenance_loop(
         state.db.pool.clone(),

--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -136,6 +136,11 @@ pub async fn run(cfg: WebServerConfig) -> Result<(), String> {
         state.settings.clone(),
     ));
 
+    // 语义缓存过期清理（C-02；缓存未启用时清理为空操作）
+    tauri::async_runtime::spawn(crate::semantic_cache::run_maintenance_loop(
+        state.db.pool.clone(),
+    ));
+
     tauri::async_runtime::spawn(crate::auth_provider::maintenance::run_maintenance_loop(
         auth_service,
     ));

--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -126,6 +126,12 @@ pub async fn run(cfg: WebServerConfig) -> Result<(), String> {
         state.settings.clone(),
     ));
 
+    // 渠道主动健康探测（默认开启 300s 一轮，可整体关闭）
+    tauri::async_runtime::spawn(crate::health_probe::run_probe_loop(
+        state.db.pool.clone(),
+        state.settings.clone(),
+    ));
+
     tauri::async_runtime::spawn(crate::auth_provider::maintenance::run_maintenance_loop(
         auth_service,
     ));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ const LogsPage = lazy(() => import("./pages/LogsPage").then(module => ({ default
 const SettingsPage = lazy(() => import("./pages/SettingsPage").then(module => ({ default: module.SettingsPage })));
 const UsagePage = lazy(() => import("./pages/UsagePage").then(module => ({ default: module.UsagePage })));
 const KnowledgeBasePage = lazy(() => import("./pages/KnowledgeBasePage").then(module => ({ default: module.KnowledgeBasePage })));
+const PromptTemplatesPage = lazy(() => import("./pages/PromptTemplatesPage"));
 const UpdateChecker = lazy(() => import("./components/UpdateChecker").then(module => ({ default: module.UpdateChecker })));
 
 function App() {
@@ -58,6 +59,7 @@ function App() {
             <Route path="/api-keys" element={<ApiKeysPage />} />
             <Route path="/logs" element={<LogsPage />} />
             <Route path="/settings" element={<SettingsPage />} />
+            <Route path="/prompt-templates" element={<PromptTemplatesPage />} />
             <Route path="/services" element={<KnowledgeBasePage />} />
             <Route path="/services/knowledge-base" element={<KnowledgeBasePage />} />
             <Route path="/services/mcp" element={<KnowledgeBasePage />} />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   ExternalLink,
   Link,
   Database,
+  FileText,
   LogOut,
 } from "lucide-react";
 import { serverApi } from "../../lib/api";
@@ -27,6 +28,7 @@ const navItems = [
   { to: "/channels", icon: Radio, label: "渠道" },
   { to: "/api-keys", icon: Key, label: "密钥" },
   { to: "/services", icon: Database, label: "服务", subLabel: "RAG、Wiki、Skills ..." },
+  { to: "/prompt-templates", icon: FileText, label: "Prompt 模板", subLabel: "版本化 · 回滚" },
   { to: "/logs", icon: ScrollText, label: "日志" },
   { to: "/settings", icon: Settings, label: "设置" },
 ];

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -584,3 +584,8 @@ export const promptTemplateApi = {
   create: (templateKey: string, content: string) => invoke<number>("create_prompt_template", { templateKey, content }),
   activate: (templateKey: string, version: number) => invoke<void>("activate_prompt_template", { templateKey, version }),
 };
+
+// 语义缓存管理命令（C-02）
+export const semanticCacheApi = {
+  clear: (model?: string) => invoke<number>("clear_semantic_cache", { model: model ?? null }),
+};

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   AuthAccount, AuthLoginSessionStatus, AuthLoginStart, AuthMutationResult, AuthLogoutResult, AuthExportResult,
   AuthQuotaStatus, AuthUpdateInput,
   AuthProviderInfo, AuthLoginMethod,
+  PromptTemplate,
 } from "../types";
 
 /**
@@ -575,4 +576,11 @@ export const appConfigApi = {
   resetCodexAuth: () => invoke<ApplyResult>("reset_codex_auth"),
   getContent: (appName: string) => invoke<ConfigContent>("get_app_config_content", { appName }),
   openFolder: (appName: string) => invoke<void>("open_config_folder", { appName }),
+};
+
+// Prompt template commands（C-07 模板版本化）
+export const promptTemplateApi = {
+  list: () => invoke<PromptTemplate[]>("list_prompt_templates"),
+  create: (templateKey: string, content: string) => invoke<number>("create_prompt_template", { templateKey, content }),
+  activate: (templateKey: string, version: number) => invoke<void>("activate_prompt_template", { templateKey, version }),
 };

--- a/src/pages/ChannelsPage.tsx
+++ b/src/pages/ChannelsPage.tsx
@@ -593,6 +593,18 @@ export function ChannelsPage() {
                     )}
 
                     {/* 最近测试 */}
+                    {ch.last_probe_ok !== null && (
+                      <div className="flex items-center gap-2 text-xs text-slate-500">
+                        <span className="text-slate-400">健康探测:</span>
+                        <span
+                          className={`inline-block h-2 w-2 rounded-full ${ch.last_probe_ok ? "bg-emerald-500" : "bg-red-500"}`}
+                          title={ch.last_probe_ok ? "探测正常" : "探测失败（候选排序沉底）"}
+                        />
+                        <span>{ch.last_probe_ok ? "正常" : "异常"}</span>
+                        {ch.probe_latency_ms !== null && <span className="text-slate-400">{ch.probe_latency_ms}ms</span>}
+                        {ch.last_probe_at && <span>{formatTime(ch.last_probe_at)}</span>}
+                      </div>
+                    )}
                     {ch.last_test_at && (
                       <div className="flex items-center gap-2 text-xs text-slate-500">
                         <span className="text-slate-400">最近测试:</span>

--- a/src/pages/PromptTemplatesPage.tsx
+++ b/src/pages/PromptTemplatesPage.tsx
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ArrowLeftRight, FileText, Loader2, Plus, Save } from "lucide-react";
+import { promptTemplateApi } from "../lib/api";
+import type { PromptTemplate } from "../types";
+
+/** Prompt 模板管理（C-07）：按 key 分组列版本、编辑新建版本、一键激活/回滚。
+ *  种子 = 源码字面量 v1；激活新版本立即生效，回滚 v1 同理；占位符非法拒绝激活。 */
+export default function PromptTemplatesPage() {
+  const [templates, setTemplates] = useState<PromptTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [draft, setDraft] = useState("");
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setTemplates(await promptTemplateApi.list());
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, PromptTemplate[]>();
+    for (const t of templates) {
+      const list = map.get(t.template_key) ?? [];
+      list.push(t);
+      map.set(t.template_key, list);
+    }
+    return [...map.entries()].sort(([a], [b]) => a.localeCompare(b));
+  }, [templates]);
+
+  const activeOf = (key: string) => grouped.find(([k]) => k === key)?.[1].find(t => t.active);
+
+  const startEdit = (key: string) => {
+    setEditingKey(key);
+    setDraft(activeOf(key)?.content ?? "");
+    setNotice(null);
+  };
+
+  const saveNewVersion = async (key: string) => {
+    setNotice(null);
+    setError(null);
+    try {
+      const version = await promptTemplateApi.create(key, draft);
+      setNotice(`已保存 ${key} v${version}（未激活，预览确认后一键激活）`);
+      setEditingKey(null);
+      await refresh();
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  const activate = async (key: string, version: number) => {
+    setNotice(null);
+    setError(null);
+    try {
+      await promptTemplateApi.activate(key, version);
+      setNotice(`已激活 ${key} v${version}，立即生效`);
+      await refresh();
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-5xl p-6">
+      <div className="mb-4 flex items-center gap-2">
+        <FileText className="h-5 w-5 text-primary" />
+        <h1 className="text-xl font-semibold">Prompt 模板</h1>
+      </div>
+      <p className="mb-6 text-sm text-muted-foreground">
+        RAG 问答与深度研究的系统提示词版本化管理：编辑保存生成新版本，一键激活/回滚立即生效；
+        升级时自动以源码字面量种子 v1（行为逐字节不变）；含非法占位符的模板会被拒绝。
+      </p>
+
+      {error && <div className="mb-4 rounded-2xl border border-red-300 bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+      {notice && <div className="mb-4 rounded-2xl border border-emerald-300 bg-emerald-50 p-3 text-sm text-emerald-700">{notice}</div>}
+      {loading && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> 加载中…
+        </div>
+      )}
+
+      <div className="space-y-6">
+        {grouped.map(([key, versions]) => {
+          const active = versions.find(v => v.active);
+          return (
+            <div key={key} className="surface rounded-2xl p-4">
+              <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <div className="font-mono text-sm font-medium">{key}</div>
+                  <div className="text-xs text-muted-foreground">
+                    当前激活 v{active?.version ?? "-"} · 共 {versions.length} 个版本
+                  </div>
+                </div>
+                <button
+                  onClick={() => (editingKey === key ? setEditingKey(null) : startEdit(key))}
+                  className="flex items-center gap-1 rounded-full border border-border px-3 py-1.5 text-xs font-medium hover:bg-white/5"
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  {editingKey === key ? "取消编辑" : "编辑新版本"}
+                </button>
+              </div>
+
+              {editingKey === key && (
+                <div className="mb-4">
+                  <textarea
+                    value={draft}
+                    onChange={e => setDraft(e.target.value)}
+                    rows={10}
+                    className="w-full rounded-2xl border border-border bg-background/70 p-3 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-primary/20"
+                  />
+                  <div className="mt-2 flex items-center gap-2">
+                    <button
+                      onClick={() => void saveNewVersion(key)}
+                      className="flex items-center gap-1 rounded-full bg-primary px-4 py-1.5 text-xs font-medium text-primary-foreground hover:opacity-90"
+                    >
+                      <Save className="h-3.5 w-3.5" /> 保存为新版本
+                    </button>
+                    <span className="text-xs text-muted-foreground">
+                      保存仅校验占位符；激活后才切换生效
+                    </span>
+                  </div>
+                </div>
+              )}
+
+              <div className="space-y-2">
+                {versions.map(v => (
+                  <div
+                    key={v.id}
+                    className={`flex items-center justify-between gap-3 rounded-xl border px-3 py-2 ${
+                      v.active ? "border-emerald-300 bg-emerald-50/50" : "border-border"
+                    }`}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 text-xs">
+                        <span className="font-mono font-medium">v{v.version}</span>
+                        {v.active && (
+                          <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-medium text-emerald-700">
+                            激活中
+                          </span>
+                        )}
+                        <span className="text-muted-foreground">{v.created_at}</span>
+                      </div>
+                      <pre className="mt-1 max-h-24 overflow-y-auto whitespace-pre-wrap break-all text-xs text-muted-foreground">
+                        {v.content}
+                      </pre>
+                    </div>
+                    {!v.active && (
+                      <button
+                        onClick={() => void activate(key, v.version)}
+                        className="flex shrink-0 items-center gap-1 rounded-full border border-border px-3 py-1.5 text-xs font-medium hover:bg-white/5"
+                      >
+                        <ArrowLeftRight className="h-3.5 w-3.5" />
+                        {v.version === 1 ? "回滚到此版本" : "激活此版本"}
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { settingsApi, serverApi, securityApi, ocrApi, type OcrCacheInfo } from "../lib/api";
+import { settingsApi, serverApi, securityApi, ocrApi, semanticCacheApi, type OcrCacheInfo } from "../lib/api";
 import { isWebRuntime } from "../lib/web";
 import { PanelSettingsSection } from "../components/PanelSettingsSection";
 import type { Settings, BuiltinRule, CustomRule } from "../types";
@@ -667,6 +667,7 @@ export function SettingsPage() {
                     className={inputCls}
                   />
                 </div>
+              </div>
             </div>
           </div>
           <div>
@@ -694,6 +695,61 @@ export function SettingsPage() {
                   className={inputCls}
                 />
                 <p className="mt-1 text-xs text-muted-foreground">默认 300 秒；最短 30 秒。探测请求记入请求日志（is_probe 标记），不计入用量统计。</p>
+              </div>
+            </div>
+          </div>
+          <div>
+            <h3 className="mb-3 text-sm font-medium text-muted-foreground">语义缓存</h3>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <label className="surface-soft flex items-center justify-between rounded-2xl px-4 py-4">
+                <div>
+                  <div className="text-sm font-medium">启用语义缓存</div>
+                  <p className="text-xs text-muted-foreground">相同/同义请求直接返回缓存答案（响应头 X-Cache: hit）。带工具调用、高温采样、安全审计命中的请求永不入缓存。默认关闭。</p>
+                </div>
+                <input
+                  type="checkbox"
+                  checked={settings.cache_enabled}
+                  onChange={e => setSettings({ ...settings, cache_enabled: e.target.checked })}
+                  className="h-5 w-5"
+                />
+              </label>
+              <div>
+                <label className="mb-2 block text-sm font-medium">嵌入模型（语义层）</label>
+                <input
+                  type="text"
+                  value={settings.cache_embedding_model}
+                  onChange={e => setSettings({ ...settings, cache_embedding_model: e.target.value })}
+                  placeholder="留空 = 仅精确匹配层"
+                  className={inputCls}
+                />
+                <p className="mt-1 text-xs text-muted-foreground">填写渠道中的 Embedding 模型名以启用语义相似命中（阈值默认 0.95，保守）。</p>
+              </div>
+              <div>
+                <label className="mb-2 block text-sm font-medium">缓存 TTL（秒）</label>
+                <input
+                  type="number"
+                  min={60}
+                  value={settings.cache_ttl_secs}
+                  onChange={e => setSettings({ ...settings, cache_ttl_secs: Number(e.target.value) })}
+                  className={inputCls}
+                />
+                <p className="mt-1 text-xs text-muted-foreground">默认 86400（24 小时），过期自动不命中并由后台清理。</p>
+              </div>
+              <div>
+                <label className="mb-2 block text-sm font-medium">手动清空缓存</label>
+                <button
+                  onClick={async () => {
+                    try {
+                      const n = await semanticCacheApi.clear();
+                      window.alert(`已清空 ${n} 条缓存`);
+                    } catch (e) {
+                      window.alert(`清空失败：${e}`);
+                    }
+                  }}
+                  className="rounded-full border border-border px-4 py-2 text-sm font-medium hover:bg-white/5"
+                >
+                  清空全部缓存条目
+                </button>
               </div>
             </div>
           </div>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -667,6 +667,33 @@ export function SettingsPage() {
                     className={inputCls}
                   />
                 </div>
+            </div>
+          </div>
+          <div>
+            <h3 className="mb-3 text-sm font-medium text-muted-foreground">渠道健康探测</h3>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <label className="surface-soft flex items-center justify-between rounded-2xl px-4 py-4">
+                <div>
+                  <div className="text-sm font-medium">启用主动探测</div>
+                  <p className="text-xs text-muted-foreground">后台定期对启用渠道发 GET /models 廉价探测；失败渠道候选排序沉底（不剔除）；关闭时零后台流量。Auth 账号渠道永不探测。</p>
+                </div>
+                <input
+                  type="checkbox"
+                  checked={settings.probe_enabled}
+                  onChange={e => setSettings({ ...settings, probe_enabled: e.target.checked })}
+                  className="h-5 w-5"
+                />
+              </label>
+              <div>
+                <label className="mb-2 block text-sm font-medium">探测间隔（秒）</label>
+                <input
+                  type="number"
+                  min={30}
+                  value={settings.probe_interval_secs}
+                  onChange={e => setSettings({ ...settings, probe_interval_secs: Number(e.target.value) })}
+                  className={inputCls}
+                />
+                <p className="mt-1 text-xs text-muted-foreground">默认 300 秒；最短 30 秒。探测请求记入请求日志（is_probe 标记），不计入用量统计。</p>
               </div>
             </div>
           </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -652,3 +652,13 @@ export interface UpstreamModelsResult {
   /** 拉取时使用的根 URL（便于展示/排障）。 */
   base_url: string;
 }
+
+// Prompt 模板（C-07 版本化管理）
+export interface PromptTemplate {
+  id: string;
+  template_key: string;
+  version: number;
+  content: string;
+  active: boolean;
+  created_at: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,6 +43,10 @@ export interface Channel {
   updated_at: string;
   last_test_at: string | null;
   last_test_ok: number | null;
+  /** 主动健康探测（迁移 033）：探测列优先展示，无探测数据回退手动测试列。 */
+  last_probe_at: string | null;
+  last_probe_ok: number | null;
+  probe_latency_ms: number | null;
   /** Multi-key: extra API keys (masked in DTO, use getChannelExtraKeys for full). */
   extra_keys: ChannelKey[];
 }
@@ -440,6 +444,9 @@ export interface Settings {
   otlp_headers: string;
   otlp_interval_secs: number;
   otlp_batch_size: number;
+  // 渠道主动健康探测
+  probe_enabled: boolean;
+  probe_interval_secs: number;
 }
 
 // Security rule types

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -447,6 +447,11 @@ export interface Settings {
   // 渠道主动健康探测
   probe_enabled: boolean;
   probe_interval_secs: number;
+  // 语义缓存（C-02，默认关闭）
+  cache_enabled: boolean;
+  cache_ttl_secs: number;
+  cache_threshold_percent: number;
+  cache_embedding_model: string;
 }
 
 // Security rule types


### PR DESCRIPTION
Closes #87, closes #88, closes #89, closes #90, closes #91
Supersedes #96, #97, #98, #99, #100（按维护者指示五合一提交；内容为原 PR 的 cherry-pick 整合，原提交信息与作者保留）

## 前置检查

- 上游最新 release：**waliapi-v0.3.0**（2026-09-08，api.github.com releases/latest 查询）；本 PR 基于维护者指定的 **v0.3.1 分支 @ ea7194e**（#95 合入点，含已合入的 #92–#95）。
- 冲突检查：基于 ea7194e 重建；迁移 033_channel_probe / 034_prompt_templates / 035_semantic_cache 顺延上游现有 032 之后，无编号冲突。

## 内容（五合一）

### 一、渠道主动健康探测（原 #96，C-04）

- 后台循环（默认 300s，`probe.enabled` 可关、最短 30s）：仅 API 渠道 `GET {base_url}/models`（带 Key、10s 超时）；Auth 账号渠道零探测。
- 迁移 033：channels 探测三列（NULL = 从未探测视为健康）+ `request_logs.is_probe`。
- **沉底不剔除**：两轨候选查询统一 `COALESCE(last_probe_ok, 1) DESC`；被动反哺（真实请求成功立即恢复排序）。
- 统计口径隔离：仪表盘/日志/模型/渠道/Key/趋势全部排除 is_probe 行。

### 二、KB 混合检索 RRF 融合 + 可选 LLM listwise 重排（原 #97，C-06/R3）

- 融合抽为纯函数 `fuse_scored` + `FusionMode`：RRF（k=60）默认，weighted 保留可配（`kb.fusion_mode`，历史行为测试锁定）。
- 可选 LLM 重排（`kb.rerank_enabled` 默认关）：走网关自身渠道打分（kb-internal 路由组，token 自动落账）；解析容错恒全排列；失败静默回退。

### 三、Prompt 模板版本化（原 #98，C-07）

- 迁移 034 `prompt_templates`（key+version 唯一、active 标记）；启动种子把源码字面量逐字节写入 v1 并激活——升级后行为逐字节不变（测试断言）。
- 占位符校验（缺/多均拒绝激活）；管理页 `/prompt-templates`；变更写请求日志（mode=prompt_admin）。

### 四、KB 多轮对话查询改写（原 #99，C-06/R2，默认关）

- `kb.query_rewrite` 默认关：近 6 轮 + 当前问题 → 渠道模型改写为独立完整检索查询；无历史跳过；失败静默回退。
- 改写 prompt 为模板表新 key `query_rewrite`（版本化 + 占位符校验）。

### 五、语义缓存 exact + semantic 两层（原 #100，C-02，默认关）

- exact（规范化 SHA-256 + model + 温度/长度档位）+ semantic（渠道 embedding 余弦 ≥ 0.95）。
- 三层风险收敛：默认关闭；带 tools、高温采样、安全审计命中的请求永不入缓存；命中 `X-Cache: hit` 且照常落账（upstream_type=cache）；TTL 默认 24h + 后台清理 + 手动清空。

## 整合适配点（相对原 PR 的差异，均有测试覆盖）

1. 与已合入 #94（OTLP）/ #95（流式持久化）共存：设置结构体/设置页/后台循环三方合并（OTLP + 探测 + 缓存清理三循环并存）。
2. RAG 主流程接线顺序：查询改写（默认关）→ 检索（fusion_mode 融合）→ 可选重排（默认关）；重排调用适配改写后的查询（`&query`）。
3. retriever.rs 同时保留 #93 的 `index_delta_tests` 与 R3 的 `rrf_tests`；router.rs 同时保留 #94/#95 的回放与 request-id 测试与 C-02 端到端测试。
4. `models::Channel` 探测三列加 `#[sqlx(default)]`：部分集成测试只迁移到 015，列缺失时按「未探测」（None）处理，与迁移 033 的 NULL 语义一致。
5. `semantic_cache::run_maintenance_loop` 单参数（pool）接入桌面/headless 两条启动路径。

## 完整测试（本机 Windows 10，MSVC 工具链）

- **cargo test 全量**（lib 单测 + main/waliapi-web 两个 bin 目标 + 6 个集成套件 + doc-tests）：**923 通过 / 2 失败**——2 个失败为上游基线既有（`codex_login::export_is_nested_private_backed_up...` Windows rename 语义、`rollout_integration_tests::security_gate_block_zero_upstream`），与本次改动无关
  - lib 单测 877 过；channel_migration **21/21**；auth_repository 5/5；request_log 10/10；kb_ocr 7/7；custom_rules_integration 3/3；doc-tests 0
- cargo clippy --lib --tests：**0 错误**；新增代码行零新增告警（存量 223 条与基线一致）
- cargo fmt --check：本次 28 个改动 Rust 文件零 diff
- cargo check --no-default-features --features embed-web：headless 目标编译通过
- pnpm build（tsc strict + vite）：通过
- pnpm --filter waliapi-web build（Web 管理面板子包）：通过
