### PR TITLE
fix(probe): 审计日志只反映探测状态翻转，恢复就地标记不新增行

### DIFF
--- a/src-tauri/src/core/proxy.rs
+++ b/src-tauri/src/core/proxy.rs
@@ -392,7 +392,9 @@ pub async fn handle_request(
 
                 // 被动反哺（C-04）：真实请求成功 → 恢复该渠道的主动探测健康标记
                 // （best-effort，与日志/配额递增同级的旁路更新）。
-                repo.mark_probe_ok(&channel.id);
+                // 必须 .await：mark_probe_ok 是 async fn，不 await 的 future 会被直接
+                // 丢弃、函数体一次都不执行（编译器报 unused_must_use）。
+                repo.mark_probe_ok(&channel.id).await;
 
                 return Ok(ProxyResult {
                     status,

--- a/src-tauri/src/db/repository.rs
+++ b/src-tauri/src/db/repository.rs
@@ -53,9 +53,19 @@ impl Repository {
         .await
     }
 
-    /// 记录一次主动探测结果：更新渠道探测三列 + 写 is_probe=1 日志行
-    /// （统计口径排除，避免污染用户用量）。直接 SQL 最小列集，不走
-    /// create_log 漏斗（探测行无正文、不受明细级别影响）。
+    /// 记录一次主动探测结果：更新渠道探测三列（调度排序依据，每轮都写）；
+    /// 审计日志只反映**状态发生翻转的那条边**，且恢复不新增行：
+    /// - 正常 → 异常：新增一行 `mode='probe'`、`status_code=502`
+    /// - 异常 → 正常：就地标记那条失败行为已恢复（见 [`Self::mark_probe_recovered`]）
+    /// - 持续正常 / 持续故障：不写
+    ///
+    /// 为什么成功探测不写：探测行不携带请求/响应正文，统计口径又一律 `is_probe = 0` 排除，
+    /// 所以成功探测行没有任何读取方，留在审计日志里只会淹没真实流量 —— 默认 300 秒一轮
+    /// × 每个启用渠道，实测某库最近 40 行里 31 行是这类噪音（占全库 31.5%）。
+    /// 为什么恢复也不补一行：恢复是失败事件的**后续状态**，不是一次新请求；为它写一行
+    /// 200 会让列表里重新出现“看起来像成功探测”的条目，与上面的目标直接冲突。
+    /// 标记只改既有列（mode + upstream_model），状态码保持 502，不篡改审计历史。
+    /// 直接 SQL 最小列集，不走 create_log 漏斗（探测行无正文、不受明细级别影响）。
     pub async fn record_channel_probe(
         &self,
         channel_id: &str,
@@ -63,6 +73,16 @@ impl Repository {
         outcome: crate::health_probe::ProbeOutcome,
         now: &str,
     ) -> Result<(), sqlx::Error> {
+        // 先取上一轮状态再更新，才能认出状态翻转。
+        // COALESCE 把“从未探测”按健康处理：首次探测就失败也算一次新异常。
+        let previous_ok: i64 = sqlx::query_scalar::<_, i64>(
+            "SELECT COALESCE(last_probe_ok, 1) FROM channels WHERE id = ?",
+        )
+        .bind(channel_id)
+        .fetch_optional(&self.pool)
+        .await?
+        .unwrap_or(1);
+
         sqlx::query(
             "UPDATE channels SET last_probe_at = ?, last_probe_ok = ?, probe_latency_ms = ?, \
              updated_at = ? WHERE id = ?",
@@ -74,23 +94,78 @@ impl Repository {
         .bind(channel_id)
         .execute(&self.pool)
         .await?;
-        sqlx::query(
-            "INSERT INTO request_logs (id, seq, channel_id, channel_name, model, mode, \
-             status_code, duration_ms, is_stream, is_retry, created_at, risk_level, \
-             security_action, upstream_type, is_probe) \
-             VALUES (?, (SELECT COALESCE(MAX(seq), 0) + 1 FROM request_logs), ?, ?, ?, 'probe', \
-             ?, ?, 0, 0, ?, 'low', 'audit', 'channel', 1)",
+
+        // 只有状态翻转才动日志，且**恢复绝不新增行**：
+        //   正常 → 异常：新增一行 mode='probe' / 502（故障事件）
+        //   异常 → 正常：就地标记该渠道最近一条待标记的故障行，不新增行
+        //   稳态（持续正常、持续故障）：什么都不做
+        match (previous_ok == 0, outcome.ok) {
+            (false, false) => {
+                sqlx::query(
+                    "INSERT INTO request_logs (id, seq, channel_id, channel_name, model, mode, \
+                     status_code, duration_ms, is_stream, is_retry, created_at, risk_level, \
+                     security_action, upstream_type, is_probe) \
+                     VALUES (?, (SELECT COALESCE(MAX(seq), 0) + 1 FROM request_logs), ?, ?, ?, \
+                     'probe', 502, ?, 0, 0, ?, 'low', 'audit', 'channel', 1)",
+                )
+                .bind(crate::utils::id::new_id())
+                .bind(channel_id)
+                .bind(channel_name)
+                .bind(channel_name)
+                .bind(outcome.latency_ms)
+                .bind(now)
+                .execute(&self.pool)
+                .await?;
+            }
+            (true, true) => {
+                self.mark_probe_recovered(channel_id).await?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// 把某渠道最近一条“尚未标记恢复”的探测失败行**就地标记**为已恢复。
+    ///
+    /// 只改两个既有列：`mode` 由 'probe' 变 'probe_recovered'（机器可读标记），
+    /// `upstream_model` 写标记文案（前端模型列本就渲染 `model → upstream_model`，
+    /// 于是列表里直接显示 `渠道名 → 已恢复`）。**状态码保持 502** —— 那一刻确实
+    /// 失败了，不篡改审计历史；也不新增任何行。
+    /// 标记后该行不再匹配 `mode='probe'`，所以再故障→写新行、再恢复→标记新行，天然幂等。
+    async fn mark_probe_recovered(&self, channel_id: &str) -> Result<(), sqlx::Error> {
+        const MARK: &str = "已恢复";
+        let result = sqlx::query(
+            "UPDATE request_logs SET mode = 'probe_recovered', upstream_model = ? \
+             WHERE id = (SELECT id FROM request_logs WHERE channel_id = ? AND is_probe = 1 \
+                         AND mode = 'probe' AND status_code = 502 \
+                         ORDER BY seq DESC LIMIT 1)",
         )
-        .bind(crate::utils::id::new_id())
+        .bind(MARK)
         .bind(channel_id)
-        .bind(channel_name)
-        .bind(channel_name)
-        .bind(if outcome.ok { 200 } else { 502 })
-        .bind(outcome.latency_ms)
-        .bind(now)
         .execute(&self.pool)
         .await?;
+        if result.rows_affected() == 0 {
+            // 没有待标记的故障行（故障发生在老版本、或已被启动清理删掉）。
+            // 按“零新增行”的要求什么都不做，不为恢复事件补写日志。
+            tracing::debug!("[探测] 渠道 {channel_id} 已恢复，但库中没有待标记的探测失败行");
+        }
         Ok(())
+    }
+
+    /// 启动期一次性清理：删掉历史上写入的“成功形态”探测行。
+    ///
+    /// 覆盖两种来源：0.3.1 及更早每轮探测都写一行的“探测成功”；以及中间版本为“渠道已恢复”
+    /// 补写的 200 行（该设计已改为就地标记失败行，不再新增行）。新语义下任何 `is_probe = 1`
+    /// 且 2xx 的行都不该存在，所以条件就是这一条 —— 真实审计记录（`is_probe = 0`）与探测
+    /// 失败行（502，含已标记恢复的）一律不动。
+    pub async fn purge_successful_probe_logs(&self) -> Result<u64, sqlx::Error> {
+        let result = sqlx::query(
+            "DELETE FROM request_logs \
+             WHERE is_probe = 1 AND status_code >= 200 AND status_code < 300",
+        )
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected())
     }
 
     /// 被动反哺：真实请求成功后立即恢复该渠道的探测健康标记

--- a/src-tauri/src/endpoint_executor/driver.rs
+++ b/src-tauri/src/endpoint_executor/driver.rs
@@ -218,7 +218,9 @@ async fn record_channel_mode_outcome(
         crate::core::attempt::AttemptResult::Success(_) => {
             // 被动反哺（C-04）：真实请求传输成功 → 立即恢复渠道的主动探测
             // 健康标记（与 mode_health 的成功清除正交，各管各的表）。
-            repo.mark_probe_ok(channel_id);
+            // 必须 .await：mark_probe_ok 是 async fn，不 await 的 future 会被直接丢弃，
+            // 函数体一次都不执行（编译器已报 unused_must_use），等于这个反哺机制失效。
+            repo.mark_probe_ok(channel_id).await;
             repo.record_channel_mode_success(channel_id, endpoint, is_stream)
                 .await
         }

--- a/src-tauri/src/health_probe.rs
+++ b/src-tauri/src/health_probe.rs
@@ -1,6 +1,9 @@
 //! 渠道主动健康探测（C-04）：后台循环对启用中的 API 渠道发廉价探测
-//! （GET {base_url}/models，带渠道 Key，短超时），结果落渠道探测列并记
-//! `is_probe=1` 请求日志。探测失败的渠道在候选排序中**沉底不剔除**——
+//! （GET {base_url}/models，带渠道 Key，短超时），结果每轮落渠道探测列；
+//! 审计日志只反映**状态翻转**：正常→异常新增一条 `mode='probe'`/502；异常→正常不新增行，
+//! 而是把那条失败行就地标记为已恢复；稳态（持续正常、持续故障）一行都不写
+//! （探测行无正文、统计口径又一律排除，逐轮写只会淹没真实流量）。
+//! 探测失败的渠道在候选排序中**沉底不剔除**——
 //! 保守策略，误杀渠道的代价高于排序损失。OAuth/Auth 账号渠道零探测
 //! （账号表不参与本循环，成本与配额敏感）。
 //!
@@ -46,7 +49,9 @@ pub async fn probe_channel(
     }
 }
 
-/// 单轮探测步骤（测试与循环共用）：探测全部启用渠道 → 写探测列 + is_probe 日志行。
+/// 单轮探测步骤（测试与循环共用）：探测全部启用渠道 → 每轮写探测列，
+/// 但审计日志只反映状态翻转：故障新增一行 `probe`/502，恢复则就地标记那条失败行、
+/// 不新增行（详见 [`Repository::record_channel_probe`]）。
 /// 探测关闭（`probe.enabled=false`）时零网络请求零写库。
 pub async fn probe_step(
     pool: &SqlitePool,
@@ -92,6 +97,18 @@ pub async fn probe_step(
 
 /// 后台探测循环：默认 300s 一轮，可整体关闭（关闭时零后台流量）。
 pub async fn run_probe_loop(pool: SqlitePool, settings: SettingsStore) {
+    // 启动期先清一次历史噪音：0.3.1 及更早版本每轮探测都写一行“探测成功”，存量可达上千
+    // 条且无人读取，会一直霸占审计日志前几页。放在循环前、且不受 probe.enabled 影响 ——
+    // 噪音是既成的，即使把探测关掉也该清掉。只删 is_probe=1 的 2xx 行，审计记录不受影响。
+    match Repository::new(pool.clone())
+        .purge_successful_probe_logs()
+        .await
+    {
+        Ok(0) => {}
+        Ok(deleted) => tracing::info!("[探测] 启动清理：删除历史探测成功日志 {deleted} 条"),
+        Err(error) => tracing::warn!("[探测] 启动清理历史探测日志失败: {error}"),
+    }
+
     loop {
         let interval = Duration::from_secs(
             settings
@@ -158,7 +175,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn probe_step_updates_columns_and_writes_probe_logs() {
+    async fn probe_step_updates_columns_but_logs_only_new_failures() {
         let pool = memory_db().await;
         let dir = std::env::temp_dir().join(format!("waliapi-probe-test-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&dir).unwrap();
@@ -187,19 +204,210 @@ mod tests {
         .unwrap();
         assert_eq!(row.0, Some(0), "不可达渠道 last_probe_ok=0");
 
-        // is_probe 日志行：每渠道一条
-        let probes: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM request_logs WHERE is_probe = 1")
+        // 探测状态列每轮都更新（调度排序要用），但日志行只在“正常 → 异常”这条边上写：
+        // 成功渠道一条都不写，失败渠道写一条 mode=probe / 502。
+        let probes: Vec<(String, String, i64)> = sqlx::query_as::<_, (String, String, i64)>(
+            "SELECT channel_name, mode, status_code FROM request_logs WHERE is_probe = 1",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            probes,
+            vec![("ch-bad".to_string(), "probe".to_string(), 502)],
+            "成功探测不得入库；只有失败的那条留痕"
+        );
+    }
+
+    /// 渠道持续故障时只留第一条异常，不逐轮累积（300s 一轮 × 一个故障渠道
+    /// 一天能刷出 288 行，那是同一种噪音的另一副面孔）。
+    #[tokio::test]
+    async fn repeated_probe_failure_records_only_first_edge() {
+        let pool = memory_db().await;
+        let dir = std::env::temp_dir().join(format!("waliapi-probe-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let settings = settings_at(&dir, true);
+        seed_channel(&pool, "ch-bad", "http://127.0.0.1:1").await;
+
+        for _ in 0..3 {
+            probe_step(&pool, &settings).await;
+        }
+
+        let rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM request_logs WHERE is_probe = 1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(rows, 1, "连续失败只记第一条边");
+        // 但调度状态必须每轮都刷新，否则探测功能本身失效
+        let ok: Option<i64> =
+            sqlx::query_scalar("SELECT last_probe_ok FROM channels WHERE id = 'ch-bad'")
                 .fetch_one(&pool)
                 .await
                 .unwrap();
-        assert_eq!(probes, 2, "每个被探测渠道应记一条 is_probe 日志");
-        let mode: String =
-            sqlx::query_scalar("SELECT mode FROM request_logs WHERE is_probe = 1 LIMIT 1")
+        assert_eq!(ok, Some(0));
+    }
+
+    /// 已落库的探测日志行（mode, status_code, upstream_model），按 seq 升序。
+    async fn probe_log_rows(pool: &SqlitePool) -> Vec<(String, i64, Option<String>)> {
+        sqlx::query_as::<_, (String, i64, Option<String>)>(
+            "SELECT mode, status_code, upstream_model FROM request_logs WHERE is_probe = 1 \
+             ORDER BY seq ASC",
+        )
+        .fetch_all(pool)
+        .await
+        .unwrap()
+    }
+
+    /// 状态翻转的两条边：故障新增一行；恢复**不新增行**，只就地标记那条故障行。
+    /// 稳态（持续正常、持续故障）什么都不写。
+    #[tokio::test]
+    async fn probe_state_transitions_are_recorded() {
+        let pool = memory_db().await;
+        let dir = std::env::temp_dir().join(format!("waliapi-probe-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let settings = settings_at(&dir, true);
+        seed_channel(&pool, "ch-flaky", "http://127.0.0.1:1").await;
+
+        // 1) 正常 → 异常，2) 持续故障：只应有第一条
+        probe_step(&pool, &settings).await;
+        probe_step(&pool, &settings).await;
+        assert_eq!(
+            probe_log_rows(&pool).await,
+            vec![("probe".to_string(), 502, None::<String>)],
+            "持续故障不得逐轮累积"
+        );
+
+        // 3) 异常 → 正常：行数不变，只把那条失败行就地标记
+        let healthy = mock_models_endpoint().await;
+        sqlx::query("UPDATE channels SET base_url = ? WHERE id = 'ch-flaky'")
+            .bind(&healthy)
+            .execute(&pool)
+            .await
+            .unwrap();
+        probe_step(&pool, &settings).await;
+        assert_eq!(
+            probe_log_rows(&pool).await,
+            vec![(
+                "probe_recovered".to_string(),
+                502,
+                Some("已恢复".to_string())
+            )],
+            "恢复须就地标记：行数不变、状态仍是 502（不篡改历史）、标记文案写在 upstream_model"
+        );
+
+        // 4) 持续正常：不写也不改
+        probe_step(&pool, &settings).await;
+        assert_eq!(probe_log_rows(&pool).await.len(), 1, "持续正常不写日志");
+
+        // 5) 再次故障：新增一行，且只标记最近一条未标记的失败行
+        sqlx::query("UPDATE channels SET base_url = 'http://127.0.0.1:1' WHERE id = 'ch-flaky'")
+            .execute(&pool)
+            .await
+            .unwrap();
+        probe_step(&pool, &settings).await;
+        assert_eq!(
+            probe_log_rows(&pool).await,
+            vec![
+                (
+                    "probe_recovered".to_string(),
+                    502,
+                    Some("已恢复".to_string())
+                ),
+                ("probe".to_string(), 502, None),
+            ],
+            "再故障应新增一行，旧标记行不受影响"
+        );
+    }
+
+    /// 恢复时若库里没有待标记的失败行（故障发生在老版本、或已被启动清理删掉），
+    /// 必须静默跳过，绝不为恢复事件补写一行 —— 那正是本次要消灭的东西。
+    #[tokio::test]
+    async fn probe_recovery_without_failure_row_writes_nothing() {
+        let pool = memory_db().await;
+        let dir = std::env::temp_dir().join(format!("waliapi-probe-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let settings = settings_at(&dir, true);
+        let healthy = mock_models_endpoint().await;
+        seed_channel(&pool, "ch-ok", &healthy).await;
+        // 把渠道置成“上一轮异常”，但库里没有对应的失败日志行
+        sqlx::query("UPDATE channels SET last_probe_ok = 0 WHERE id = 'ch-ok'")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        probe_step(&pool, &settings).await;
+        assert_eq!(
+            probe_log_rows(&pool).await,
+            Vec::new(),
+            "无待标记行时不得新增任何探测日志"
+        );
+        // 但调度用的状态列要正常复位
+        let ok: Option<i64> =
+            sqlx::query_scalar("SELECT last_probe_ok FROM channels WHERE id = 'ch-ok'")
                 .fetch_one(&pool)
                 .await
                 .unwrap();
-        assert_eq!(mode, "probe");
+        assert_eq!(ok, Some(1));
+    }
+
+    /// 启动清理的边界：所有 2xx 的探测行都该清掉（0.3.1 的“探测成功”、以及中间版本为
+    /// 恢复补写的 200 行）；真实审计记录、探测失败行、就地标记为已恢复的 502 行都不动。
+    #[tokio::test]
+    async fn purge_removes_only_successful_probe_rows() {
+        let pool = memory_db().await;
+        let repo = Repository::new(pool.clone());
+        let now = crate::db::models::now_iso();
+        // (id, mode, status_code, is_probe)
+        for (id, mode, status, is_probe) in [
+            ("real", "chat", 200, 0),               // 真实请求：保留
+            ("ok-probe", "probe", 200, 1),          // 0.3.1 成功噪音：删
+            ("bad-probe", "probe", 502, 1),         // 探测失败：保留
+            ("interim", "probe_recovered", 200, 1), // 中间版本的恢复行：删
+            ("marked", "probe_recovered", 502, 1),  // 就地标记的失败行：保留
+        ] {
+            sqlx::query(
+                "INSERT INTO request_logs (id, seq, model, mode, status_code, duration_ms, \
+                 is_stream, is_retry, created_at, risk_level, security_action, upstream_type, \
+                 is_probe) \
+                 VALUES (?, (SELECT COALESCE(MAX(seq), 0) + 1 FROM request_logs), 'm', ?, \
+                 ?, 10, 0, 0, ?, 'low', 'audit', 'channel', ?)",
+            )
+            .bind(id)
+            .bind(mode)
+            .bind(status)
+            .bind(&now)
+            .bind(is_probe)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let deleted = repo.purge_successful_probe_logs().await.unwrap();
+        assert_eq!(
+            deleted, 2,
+            "应删掉两条 2xx 探测行（成功噪音 + 中间版本恢复行）"
+        );
+
+        let left: Vec<(String, String, i64, i64)> =
+            sqlx::query_as::<_, (String, String, i64, i64)>(
+                "SELECT id, mode, status_code, is_probe FROM request_logs ORDER BY id",
+            )
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert_eq!(left.len(), 3);
+        assert!(
+            left.iter().any(|r| r.0 == "real" && r.3 == 0),
+            "真实审计记录必须保留"
+        );
+        assert!(
+            left.iter().any(|r| r.0 == "bad-probe" && r.2 == 502),
+            "探测失败记录必须保留"
+        );
+        assert!(
+            left.iter().any(|r| r.0 == "marked" && r.2 == 502),
+            "就地标记为已恢复的失败行必须保留（它是 502，不是 2xx）"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 问题

审计日志被渠道健康探测行淹没。0.3.1 起 `record_channel_probe` 每轮探测都往 `request_logs`
写一行 `is_probe=1`，而探测是「每个启用渠道 × 默认 300 秒一轮」，量级轻易超过真实流量。

本机实测（0.3.1，运行约两天，6 个启用渠道）：

| 指标 | 数值 |
|:---|:---|
| 总日志行 | 3,690 |
| 探测行 | 1,164（**31.5%**）= 1,172 成功 + 11 失败 |
| 最近 40 行中探测行 | **31 行（77.5%）** ← 打开日志页几乎看不到真实请求 |
| 探测行的 request_body / response_choices 字节 | **0 / 0** |

**这些成功探测行是死数据**：不携带正文；全仓库对 `is_probe` 的引用**只有 `= 0` 的统计排除，
没有任何一处读 `is_probe = 1`**；探测结果本身已落在 `channels` 的三个探测列上，候选排序
用的是那三列（`ORDER BY COALESCE(last_probe_ok,1) DESC`），不是日志行。

澄清：**这不是磁盘问题**。探测行合计约 0.3 MB，占整库 2,854.7 MB 的 0.01%；空间全在真实
请求的 `request_body`（2,123 MB）。本 PR 修的是**审计信噪比**。

## 改动

### 1. 只反映状态翻转，恢复不新增行

`record_channel_probe`：探测三列照旧每轮更新（调度依赖，不能省），审计日志：

| 上一轮 → 本轮 | 动作 | mode | status |
|:---|:---|:---|:---:|
| 正常/未知 → 异常 | 新增一行 | `probe` | 502 |
| 异常 → 正常 | **就地标记那行失败行** | `probe_recovered` | 502（不变） |
| 持续正常 / 持续故障 | 什么都不写 | — | — |

- 先读上一轮 `last_probe_ok` 再更新才能认出这条边；`COALESCE(...,1)` 把「从未探测」按
  健康处理，首次探测即失败也算一次新异常。
- 持续故障只记第一条：否则一个故障渠道按 300s 一轮一天仍会刷 288 行。
- **恢复不补一行**：恢复是失败事件的后续状态，不是一次新请求；为它写一行 200 会让列表里
  重新出现「看起来像成功探测」的条目，与本 PR 目标直接冲突。

### 2. `mark_probe_recovered`：用既有列承载标记，不新增列

```sql
UPDATE request_logs SET mode = 'probe_recovered', upstream_model = '已恢复'
 WHERE id = (SELECT id FROM request_logs WHERE channel_id = ? AND is_probe = 1
             AND mode = 'probe' AND status_code = 502 ORDER BY seq DESC LIMIT 1)
```

- 前端模型列本就渲染 `model → upstream_model`（`LogsPage.tsx:675`），于是列表里直接显示
  **`渠道名 → 已恢复`**，**无需任何前端改动**；
- `status_code` 保持 502 —— 那一刻确实失败了，不篡改审计历史；
- 标记后该行不再匹配 `mode='probe'`，所以「再故障→写新行、再恢复→标记新行」天然幂等；
- 库里没有待标记失败行时（故障发生在老版本、或已被启动清理删掉）静默跳过，绝不补写；
- 不用 `error_message` 承载：它在前端渲染成红色错误块，把「恢复」显示成错误是错的；
- 后端无任何查询按 `mode` 过滤或分组（唯一命中是 `GROUP BY model`，另一列），加取值零副作用。

### 3. 启动清理历史噪音

`purge_successful_probe_logs()`，在 `run_probe_loop` 进入循环前调用一次：

```sql
DELETE FROM request_logs
 WHERE is_probe = 1 AND status_code >= 200 AND status_code < 300
```

真实审计记录（`is_probe = 0`）与探测失败行（502，含已标记恢复的）一律不动 —— 有测试专门
钉住这点。放在 `run_probe_loop` 开头而非 `lib.rs`/`web_server.rs` 两处，桌面端与 headless
端一次覆盖；且不受 `probe.enabled` 影响（噪音是既成的，关掉探测也该清）。条数走
`tracing::info!`。

### 4. 顺带修复：`mark_probe_ok` 两处调用都漏了 `.await`（独立提交，可单独 drop）

它是 `async fn`，不 await 的 future 被直接丢弃，**函数体一次都不执行**，编译器一直在报：

```
warning: unused implementer of `futures_util::Future` that must be used
   --> src\endpoint_executor\driver.rs:221:13
   --> src\core\proxy.rs:395:17
```

`driver.rs` 与 `core/proxy.rs` 是两条独立转发轨，两处都漏 = C-04「真实请求成功后立即恢复
探测健康标记」这条机制完全不存在，渠道只能等下一轮主动探测（默认 300 秒）才从沉底回来。
各补一个 `.await`；返回 `()`、调用点已在 `async fn` 内，无签名变更。与本 PR 主体相关：
边沿判定的输入正是 `last_probe_ok`，本修复让它能被被动路径正常复位。

## 测试（health_probe 10/10）

- `probe_state_transitions_are_recorded`：按 `seq` 断言 `(mode, status, upstream_model)`
  完整序列 —— 故障新增行；持续故障不增；**恢复行数不变、状态仍 502、标记写在
  upstream_model**；持续正常不写不改；再故障新增一行且不误改旧标记行
- `probe_recovery_without_failure_row_writes_nothing`：无待标记行时零写入，
  但调度用的 `last_probe_ok` 仍正常复位
- `repeated_probe_failure_records_only_first_edge`：连续 3 轮失败只 1 行
- `purge_removes_only_successful_probe_rows`：五种行（真实 / 0.3.1 成功 / 失败 /
  中间版本恢复 200 / 已标记失败 502）各一条时**只删两条 2xx 探测行**，并断言
  「已标记恢复的 502 行」必须存活
- 既有 `usage_stats_exclude_probe_rows`、候选排序类测试不受影响

## 验证对照（与未改动的 0.3.1 基线 `8e25adb`，另开 worktree 实测）

| 项 | 基线 0.3.1 | 本分支 |
|:---|:---|:---|
| `cargo test --lib` | 881 passed / 2 failed（共 883） | **885 passed / 2 failed**（共 887，+4 为本次新增测试） |
| `cargo test --no-fail-fast`（全 target） | — | 931 passed / 2 failed |
| `cargo fmt --check` | 16 处 | **16 处**，逐文件一致，净增 0 |
| `cargo clippy --all-targets` | lib 224 告警 | lib **222**（净减 2，即那两条真实告警） |

失败的那 2 条在基线上**已单独复现为失败**，与本 PR 无关：
`codex_login::export_is_nested_private_backed_up_and_preserves_old_file_if_rename_fails`
（`codex_login.rs:1833` unwrap on `ProviderError`）、
`router::responses_replay_replays_frames_and_synthesizes_incomplete_tail`（`router.rs:424`，
410 vs 200）。

另：跑全量时偶见第三条失败
`responses_codec::tests::responses_stream_terminal_usage_once_and_any_split`，**是测试自身的
时间 flaky**（它遍历每个切分点并断言所有解码结果完全相等，而编码输出嵌了 `created` 秒级
时间戳，循环跨秒必失败）：单跑 5/5 通过、同一段代码重跑即恢复。本 PR 不碰 codec 代码。
建议另开 issue 把 `created` 从比较中剔除或注入固定时钟。

## 端到端

用带本改动的构建在真实库副本（2.9 GB）上正常启动：迁移前后真实审计行数与 `request_body`
字节总量完全一致、`PRAGMA integrity_check` = ok、所有 2xx 探测行清零、探测失败行保留。

## 已知取舍

- `upstream_model` 承载「已恢复」是**显示层复用**：换来零新增列 + 零前端改动 + 列表直接可见。
  若维护者偏好数据层用英文值（如 `recovered`）+ 前端映射，只需改 `mark_probe_recovered`
  里那一个常量。
- 存量噪音靠启动清理一次性解决，不新增迁移（它是一次性数据清理而非 schema 变更，且放在
  探测循环入口能同时覆盖桌面与 headless 两条启动路径）。
- 「恢复」不再记为独立事件行，因此无法统计「恢复耗时/次数」；如需要，建议加渠道级指标而非
  日志行。
- 若某渠道的故障行是在本次改动之前发生的（老版本只写成功行），恢复时无行可标记，会静默
  跳过 —— 该渠道下一次故障起即完全正确。

## 版本号 / CHANGELOG

未改，按仓库惯例留给维护者发版时统一处理。