### PR TITLE
fix(rag): 重建失败时保留旧切片并原子替换结果

### DIFF
--- a/src-tauri/src/services/knowledge/processor.rs
+++ b/src-tauri/src/services/knowledge/processor.rs
@@ -80,8 +80,7 @@ pub async fn process_document(
     .await
 }
 
-/// 同 `process_document`，但复用映射由调用方提供——`reindex_document`
-/// 先删旧 chunk 再重处理，必须在删除**前**捕获映射（删除后哈希就没了）。
+/// 同 `process_document`，但复用映射由调用方提供；准备成功前保留旧切片。
 #[allow(clippy::too_many_arguments)]
 pub async fn process_document_with_reuse(
     pool: &SqlitePool,
@@ -97,10 +96,18 @@ pub async fn process_document_with_reuse(
 ) -> Result<(), String> {
     let repo = KbRepository::new(pool.clone());
 
-    // Update status to processing
-    repo.update_document_status(doc_id, "processing", None)
+    let was_ready = repo
+        .get_document(doc_id)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| e.to_string())?
+        .status
+        == "ready";
+    // 已就绪文档重建期间继续提供旧内容，首次摄入才进入 processing。
+    if !was_ready {
+        repo.update_document_status(doc_id, "processing", None)
+            .await
+            .map_err(|e| e.to_string())?;
+    }
 
     emit_progress(events, doc_id, kb_id, filename, "processing", 0, "开始处理");
 
@@ -121,7 +128,11 @@ pub async fn process_document_with_reuse(
     if let Err(ref e) = result {
         let err_msg = format!("文档「{}」处理失败: {}", filename, e);
         let _ = repo
-            .update_document_status(doc_id, "failed", Some(&err_msg))
+            .update_document_status(
+                doc_id,
+                if was_ready { "ready" } else { "failed" },
+                Some(&err_msg),
+            )
             .await;
         events.emit(
             "kb-document-error",
@@ -310,24 +321,8 @@ async fn process_document_inner(
     };
 
     if chunks.is_empty() {
-        // 分块后为空状态改为失败,且失败信息给客户端提示
-        events.emit(
-            "kb-document-error",
-            serde_json::json!({
-                "doc_id": doc_id,
-                "kb_id": kb_id,
-                "filename": filename,
-                "error": "分块后为空，无法继续处理".to_string(),
-            }),
-        );
-        repo.update_document_status(doc_id, "failed", None)
-            .await
-            .map_err(|e| e.to_string())?;
-        return Ok(());
+        return Err("分块后为空，无法继续处理".to_string());
     }
-
-    let total_chunks = chunks.len() as i64;
-    let total_tokens: i64 = chunks.iter().map(|c| c.token_count as i64).sum();
 
     // 3. Embed chunks in batches（内容未变的块复用既有向量，C-06/R1）
     let emb_model = embedding_model.unwrap_or(DEFAULT_EMBEDDING_MODEL);
@@ -416,19 +411,9 @@ async fn process_document_inner(
         );
     }
 
-    // Auto-detect and update KB embedding dimension if not set
-    if expected_dim.is_none() && !all_embeddings.is_empty() {
-        let detected_dim = all_embeddings[0].len() as i64;
-        tracing::info!(
-            "Auto-detected embedding dim {} for KB {}",
-            detected_dim,
-            kb_id
-        );
-        repo.update_kb_embedding_dim(kb_id, detected_dim).await.ok();
-    }
-
     // 4. Store chunks with embeddings
     let chunks_total = chunks.len();
+    let mut prepared_chunks = Vec::with_capacity(chunks_total);
     for (i, chunk) in chunks.iter().enumerate() {
         // Storing progress: 80% ~ 95%
         if i % 10 == 0 || i == chunks_total - 1 {
@@ -457,9 +442,7 @@ async fn process_document_inner(
             content_hash: Some(chunk_hashes[i].clone()),
             created_at: now_iso(),
         };
-        repo.create_chunk(&chunk_insert)
-            .await
-            .map_err(|e| e.to_string())?;
+        prepared_chunks.push(chunk_insert);
     }
 
     // 5. Update document and KB counts
@@ -472,21 +455,14 @@ async fn process_document_inner(
         98,
         "更新统计",
     );
-    repo.update_document_counts(doc_id, total_chunks, total_tokens)
-        .await
-        .map_err(|e| e.to_string())?;
-    // OCR 文档回填识别信息（引擎/页数/失败页码）
-    if let Some(outcome) = &ocr_outcome {
-        let failed_json =
-            serde_json::to_string(&outcome.failed_pages).unwrap_or_else(|_| "[]".to_string());
-        repo.update_document_ocr_info(doc_id, "vlm", outcome.page_count as i64, &failed_json)
-            .await
-            .map_err(|e| e.to_string())?;
-    }
-    repo.update_document_status(doc_id, "ready", None)
-        .await
-        .map_err(|e| e.to_string())?;
-    repo.update_kb_counts(kb_id)
+    let failed_pages = ocr_outcome.as_ref().map(|outcome| {
+        serde_json::to_string(&outcome.failed_pages).unwrap_or_else(|_| "[]".to_string())
+    });
+    let ocr_info = ocr_outcome
+        .as_ref()
+        .zip(failed_pages.as_deref())
+        .map(|(outcome, failed)| (outcome.page_count as i64, failed));
+    repo.replace_document_chunks(doc_id, kb_id, &prepared_chunks, ocr_info)
         .await
         .map_err(|e| e.to_string())?;
 
@@ -543,7 +519,7 @@ async fn process_document_inner(
     Ok(())
 }
 
-/// Reindex a document (delete old chunks, reprocess)
+/// 重建文档：先读取/准备新内容，成功后原子替换旧切片。
 pub async fn reindex_document(
     pool: &SqlitePool,
     events: &EventSink,
@@ -553,20 +529,6 @@ pub async fn reindex_document(
 ) -> Result<(), String> {
     let repo = KbRepository::new(pool.clone());
     let doc = repo.get_document(doc_id).await.map_err(|e| e.to_string())?;
-
-    // 哈希复用映射必须在删除前捕获——删除后旧 chunk 的哈希就没了
-    let reuse = match repo.get_chunk_hashes_by_doc(doc_id).await {
-        Ok(m) => m,
-        Err(e) => {
-            tracing::warn!("Failed to load chunk hashes before reindex: {}", e);
-            std::collections::HashMap::new()
-        }
-    };
-
-    // Delete existing chunks
-    repo.delete_chunks_by_doc(doc_id)
-        .await
-        .map_err(|e| e.to_string())?;
 
     // Read file content from path
     let content = if let Some(path) = &doc.file_path {
@@ -578,7 +540,7 @@ pub async fn reindex_document(
     // Get KB for embedding model
     let kb = repo.get_kb(&doc.kb_id).await.map_err(|e| e.to_string())?;
 
-    process_document_with_reuse(
+    process_document(
         pool,
         events,
         &doc.kb_id,
@@ -588,7 +550,6 @@ pub async fn reindex_document(
         kb.embedding_model.as_deref(),
         settings,
         data_dir,
-        reuse,
     )
     .await
 }
@@ -643,5 +604,146 @@ mod tests {
 
         assert!(to_embed.is_empty());
         assert_eq!(reused.len(), 2);
+    }
+    async fn reindex_fixture() -> (
+        SqlitePool,
+        EventSink,
+        SettingsStore,
+        std::path::PathBuf,
+        String,
+        String,
+    ) {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        let dir = std::env::temp_dir().join(format!("kb-reindex-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("source.txt");
+        let content = "alpha old document content";
+        std::fs::write(&file, content).unwrap();
+        let repo = KbRepository::new(pool.clone());
+        let kb = repo
+            .create_kb(
+                &serde_json::from_value(
+                    serde_json::json!({"name":"reindex", "embedding_model":"embed-test"}),
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        let hash = hex::encode(sha2::Sha256::digest(content.as_bytes()));
+        let doc = repo
+            .create_document(
+                &kb.id,
+                "source.txt",
+                file.to_str(),
+                "txt",
+                content.len() as i64,
+                &hash,
+            )
+            .await
+            .unwrap();
+        repo.create_chunk(&ChunkInsert {
+            id: "old-chunk".into(),
+            doc_id: doc.id.clone(),
+            kb_id: kb.id.clone(),
+            chunk_index: 0,
+            content: content.into(),
+            token_count: 6,
+            embedding: retriever::encode_embedding(&[1.0, 0.0]),
+            embedding_dim: 2,
+            metadata: "{}".into(),
+            content_hash: Some(hash),
+            created_at: now_iso(),
+        })
+        .await
+        .unwrap();
+        repo.update_document_counts(&doc.id, 1, 6).await.unwrap();
+        repo.update_document_status(&doc.id, "ready", None)
+            .await
+            .unwrap();
+        repo.update_kb_counts(&kb.id).await.unwrap();
+        let (tx, _) = tokio::sync::broadcast::channel(64);
+        let events = EventSink::headless(tx);
+        let settings = SettingsStore::file(dir.join("settings.json"));
+        (pool, events, settings, dir, kb.id, doc.id)
+    }
+
+    #[tokio::test]
+    async fn reindex_read_and_embedding_failures_preserve_ready_document() {
+        let (pool, events, settings, dir, kb_id, doc_id) = reindex_fixture().await;
+        let source = dir.join("source.txt");
+        std::fs::remove_file(&source).unwrap();
+        assert!(reindex_document(&pool, &events, &doc_id, &settings, &dir)
+            .await
+            .is_err());
+        // 内容变化使旧哈希不能复用；无渠道模拟向量化失败。
+        std::fs::write(&source, "new content requires an embedding request").unwrap();
+        assert!(reindex_document(&pool, &events, &doc_id, &settings, &dir)
+            .await
+            .is_err());
+        let repo = KbRepository::new(pool.clone());
+        let chunks = repo.get_chunks_by_kb(&kb_id).await.unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].0, "old-chunk");
+        assert_eq!(chunks[0].1, "alpha old document content");
+        let doc = repo.get_document(&doc_id).await.unwrap();
+        assert_eq!(doc.status, "ready");
+        assert_eq!((doc.chunk_count, doc.token_count), (1, 6));
+        assert_eq!(repo.get_kb(&kb_id).await.unwrap().chunk_count, 1);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn reindex_success_atomically_replaces_old_chunks() {
+        let (pool, events, settings, dir, kb_id, doc_id) = reindex_fixture().await;
+        reindex_document(&pool, &events, &doc_id, &settings, &dir)
+            .await
+            .unwrap();
+        let repo = KbRepository::new(pool.clone());
+        let chunks = repo.get_chunks_by_kb(&kb_id).await.unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_ne!(chunks[0].0, "old-chunk");
+        assert_eq!(chunks[0].1, "alpha old document content");
+        assert_eq!(retriever::decode_embedding(&chunks[0].3), vec![1.0, 0.0]);
+        assert_eq!(repo.get_document(&doc_id).await.unwrap().status, "ready");
+        assert_eq!(repo.get_kb(&kb_id).await.unwrap().chunk_count, 1);
+        // 等待后台小索引任务结束，避免测试退出抢先关闭 runtime。
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        retriever::drop_index(&pool, &kb_id).await.unwrap();
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn replacement_insert_error_rolls_back_chunks_and_counts() {
+        let (pool, _, _, dir, kb_id, doc_id) = reindex_fixture().await;
+        let repo = KbRepository::new(pool.clone());
+        let chunk = || ChunkInsert {
+            id: "duplicate-new-id".into(),
+            doc_id: doc_id.clone(),
+            kb_id: kb_id.clone(),
+            chunk_index: 0,
+            content: "new".into(),
+            token_count: 1,
+            embedding: retriever::encode_embedding(&[0.0, 1.0]),
+            embedding_dim: 2,
+            metadata: "{}".into(),
+            content_hash: None,
+            created_at: now_iso(),
+        };
+        assert!(repo
+            .replace_document_chunks(&doc_id, &kb_id, &[chunk(), chunk()], None)
+            .await
+            .is_err());
+        let chunks = repo.get_chunks_by_kb(&kb_id).await.unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].0, "old-chunk");
+        let doc = repo.get_document(&doc_id).await.unwrap();
+        assert_eq!((doc.chunk_count, doc.token_count), (1, 6));
+        assert_eq!(repo.get_kb(&kb_id).await.unwrap().chunk_count, 1);
+        std::fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/src-tauri/src/services/knowledge/repository.rs
+++ b/src-tauri/src/services/knowledge/repository.rs
@@ -343,6 +343,14 @@ impl KbRepository {
     // ==================== Chunk ====================
 
     pub async fn create_chunk(&self, chunk: &ChunkInsert) -> Result<(), sqlx::Error> {
+        let mut connection = self.pool.acquire().await?;
+        Self::insert_chunk(&mut connection, chunk).await
+    }
+
+    async fn insert_chunk(
+        connection: &mut sqlx::SqliteConnection,
+        chunk: &ChunkInsert,
+    ) -> Result<(), sqlx::Error> {
         // 从 metadata JSON 中提取 symbol_name / symbol_kind
         let meta: serde_json::Value = serde_json::from_str(&chunk.metadata).unwrap_or_default();
         let symbol_name = meta.get("symbol_name").and_then(|v| v.as_str());
@@ -365,9 +373,41 @@ impl KbRepository {
         .bind(symbol_kind)
         .bind(&chunk.content_hash)
         .bind(&chunk.created_at)
-        .execute(&self.pool)
+        .execute(connection)
         .await?;
         Ok(())
+    }
+
+    /// 新切片全部准备好后一次替换；失败时事务回滚，旧文档仍可检索。
+    pub async fn replace_document_chunks(
+        &self,
+        doc_id: &str,
+        kb_id: &str,
+        chunks: &[ChunkInsert],
+        ocr_info: Option<(i64, &str)>,
+    ) -> Result<(), sqlx::Error> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("DELETE FROM kb_chunks WHERE doc_id = ?")
+            .bind(doc_id)
+            .execute(&mut *tx)
+            .await?;
+        for chunk in chunks {
+            Self::insert_chunk(&mut tx, chunk).await?;
+        }
+        let now = now_iso();
+        let total_tokens: i64 = chunks.iter().map(|chunk| chunk.token_count).sum();
+        sqlx::query("UPDATE kb_documents SET chunk_count = ?, token_count = ?, status = 'ready', error_message = NULL, updated_at = ? WHERE id = ? AND kb_id = ?")
+            .bind(chunks.len() as i64).bind(total_tokens).bind(&now).bind(doc_id).bind(kb_id)
+            .execute(&mut *tx).await?;
+        if let Some((pages, failed_pages)) = ocr_info {
+            sqlx::query("UPDATE kb_documents SET ocr_engine = 'vlm', page_count = ?, ocr_failed_pages = ? WHERE id = ?")
+                .bind(pages).bind(failed_pages).bind(doc_id).execute(&mut *tx).await?;
+        }
+        let dim = chunks.first().map(|chunk| chunk.embedding_dim).unwrap_or(0);
+        sqlx::query("UPDATE kb_knowledge_bases SET doc_count = (SELECT COUNT(*) FROM kb_documents WHERE kb_id = ?), chunk_count = (SELECT COUNT(*) FROM kb_chunks WHERE kb_id = ?), total_tokens = (SELECT COALESCE(SUM(token_count), 0) FROM kb_chunks WHERE kb_id = ?), embedding_dim = CASE WHEN embedding_dim = 0 THEN ? ELSE embedding_dim END, updated_at = ? WHERE id = ?")
+            .bind(kb_id).bind(kb_id).bind(kb_id).bind(dim).bind(&now).bind(kb_id)
+            .execute(&mut *tx).await?;
+        tx.commit().await
     }
 
     /// 该文档现存 chunk 的 (content_hash → embedding) 映射，供重处理时


### PR DESCRIPTION
> 本 PR 已汇总到 [#115](https://github.com/fuzhengwei/WaLiAPI/pull/115)，后续请在汇总 PR 审阅。关闭本 PR 仅为避免重复申请，代码修复已保留在汇总 PR 中。

文档重新索引原先先删除旧切片，再读取源文件和调用 Embedding；任一步失败都会丢失原有检索内容。现在准备期间保留已就绪文档，全部新切片完成后，用同一个事务替换切片、文档状态/计数、OCR 信息及知识库统计；读取、向量化或插入失败时保留旧结果。

验证：`cargo test --lib --no-default-features services::knowledge -- --test-threads=1`，65 个测试通过；新增读取失败、向量化失败、写入回滚和成功替换回归。`git diff --check` 通过。

本 PR 仅处理 RAG 检查中的第 2 项。Git/URL 导入没有可读快照时仍明确拒绝重新索引，但不会因此清空现有切片。

与 #106 一起合并时：抽出的 `insert_chunk` 需要保留 `search_text` 列和 `search_projection` 绑定，并使用传入的事务连接执行；同时保留 `backfill_search_text` 与 `replace_document_chunks` 两个方法。与 #113 一起合并时，维度更新留在替换事务内，并保留嵌入配置版本条件。

按上述衔接方式在临时工作区整合现有 #106 / #109 与本批 5 个独立修复后，91 项相关测试通过（知识库 76、授权与计费 9、集成 6）。Clippy 与仅包含现有 PR 的基线逐项比较，均为 212 条既有告警，无新增告警或编译错误。