### PR TITLE
fix(rag): 切换嵌入模型后重新生成向量

### DIFF
--- a/src-tauri/migrations/039_kb_embedding_revision.sql
+++ b/src-tauri/migrations/039_kb_embedding_revision.sql
@@ -1,0 +1,3 @@
+-- 模型配置变更后，旧版本向量不能继续作为缓存或参与向量检索。
+-- 既有切片 metadata 未记录版本，按初始版本 0 兼容。
+ALTER TABLE kb_knowledge_bases ADD COLUMN embedding_revision INTEGER NOT NULL DEFAULT 0;

--- a/src-tauri/src/services/knowledge/models.rs
+++ b/src-tauri/src/services/knowledge/models.rs
@@ -18,6 +18,7 @@ pub struct KbKnowledgeBase {
     pub excluded_files: String,
     pub included_files: String,
     pub embedding_dim: i64,
+    pub embedding_revision: i64,
     pub index_status: String,
     pub embedding_batch_size: i64,
     /// 知识库级 OCR 视觉模型（如 qwen-vl-max）；None/空 = 不启用。

--- a/src-tauri/src/services/knowledge/processor.rs
+++ b/src-tauri/src/services/knowledge/processor.rs
@@ -330,7 +330,13 @@ async fn process_document_inner(
     let total_tokens: i64 = chunks.iter().map(|c| c.token_count as i64).sum();
 
     // 3. Embed chunks in batches（内容未变的块复用既有向量，C-06/R1）
-    let emb_model = embedding_model.unwrap_or(DEFAULT_EMBEDDING_MODEL);
+    let emb_model = kb
+        .embedding_model
+        .as_deref()
+        .unwrap_or(DEFAULT_EMBEDDING_MODEL);
+    if embedding_model.unwrap_or(DEFAULT_EMBEDDING_MODEL) != emb_model {
+        return Err("处理期间嵌入模型配置已变更，请重新处理文档".to_string());
+    }
     let main_repo = Repository::new(pool.clone());
 
     // Detect expected embedding dimension from KB config
@@ -353,7 +359,11 @@ async fn process_document_inner(
         .iter()
         .map(|c| hex::encode(sha2::Sha256::digest(c.content.as_bytes())))
         .collect();
-    let (mut to_embed, reused) = split_chunks_for_embedding(&chunk_hashes, reuse_embeddings);
+    let cache_keys: Vec<String> = chunk_hashes
+        .iter()
+        .map(|hash| format!("{}:{hash}", kb.embedding_revision))
+        .collect();
+    let (mut to_embed, reused) = split_chunks_for_embedding(&cache_keys, reuse_embeddings);
 
     let mut all_embeddings: Vec<Vec<f32>> = vec![Vec::new(); chunks.len()];
     let mut reused_count = 0usize;
@@ -424,7 +434,9 @@ async fn process_document_inner(
             detected_dim,
             kb_id
         );
-        repo.update_kb_embedding_dim(kb_id, detected_dim).await.ok();
+        repo.update_kb_embedding_dim(kb_id, detected_dim, kb.embedding_revision)
+            .await
+            .map_err(|e| e.to_string())?;
     }
 
     // 4. Store chunks with embeddings
@@ -444,6 +456,8 @@ async fn process_document_inner(
             );
         }
         let embedding_bytes = retriever::encode_embedding(&all_embeddings[i]);
+        let mut metadata = serde_json::to_value(&chunk.metadata).map_err(|e| e.to_string())?;
+        metadata["embedding_revision"] = serde_json::json!(kb.embedding_revision);
         let chunk_insert = ChunkInsert {
             id: uuid::Uuid::new_v4().to_string(),
             doc_id: doc_id.to_string(),
@@ -453,7 +467,7 @@ async fn process_document_inner(
             token_count: chunk.token_count as i64,
             embedding: embedding_bytes,
             embedding_dim: all_embeddings[i].len() as i64,
-            metadata: serde_json::to_string(&chunk.metadata).unwrap_or_else(|_| "{}".to_string()),
+            metadata: metadata.to_string(),
             content_hash: Some(chunk_hashes[i].clone()),
             created_at: now_iso(),
         };

--- a/src-tauri/src/services/knowledge/repository.rs
+++ b/src-tauri/src/services/knowledge/repository.rs
@@ -65,6 +65,16 @@ impl KbRepository {
             q.push(", description = ").push_bind(desc);
         }
         if let Some(model) = &input.embedding_model {
+            // 同一 UPDATE 中的表达式均读取旧值；重复保存相同模型不使缓存失效。
+            for (column, changed) in [
+                ("embedding_revision", "embedding_revision + 1"),
+                ("embedding_dim", "0"),
+                ("index_status", "'stale'"),
+            ] {
+                q.push(format!(", {column} = CASE WHEN COALESCE(embedding_model, 'text-embedding-3-small') != "))
+                    .push_bind(model)
+                    .push(format!(" THEN {changed} ELSE {column} END"));
+            }
             q.push(", embedding_model = ").push_bind(model);
         }
         if let Some(ch) = &input.embedding_channel_id {
@@ -163,12 +173,18 @@ impl KbRepository {
         Ok(())
     }
 
-    pub async fn update_kb_embedding_dim(&self, kb_id: &str, dim: i64) -> Result<(), sqlx::Error> {
+    pub async fn update_kb_embedding_dim(
+        &self,
+        kb_id: &str,
+        dim: i64,
+        embedding_revision: i64,
+    ) -> Result<(), sqlx::Error> {
         let now = now_iso();
-        sqlx::query("UPDATE kb_knowledge_bases SET embedding_dim = ?, updated_at = ? WHERE id = ?")
+        sqlx::query("UPDATE kb_knowledge_bases SET embedding_dim = ?, updated_at = ? WHERE id = ? AND embedding_revision = ?")
             .bind(dim)
             .bind(&now)
             .bind(kb_id)
+            .bind(embedding_revision)
             .execute(&self.pool)
             .await?;
         Ok(())
@@ -370,22 +386,24 @@ impl KbRepository {
         Ok(())
     }
 
-    /// 该文档现存 chunk 的 (content_hash → embedding) 映射，供重处理时
-    /// 复用未变内容块的向量（仅含 content_hash 与 embedding 均非空的行）。
+    /// 缓存键同时包含配置版本和内容哈希，防止同维度模型切换时复用旧向量。
+    /// 将版本保留在键中，也能拒绝读取缓存之后才发生的配置变更。
     pub async fn get_chunk_hashes_by_doc(
         &self,
         doc_id: &str,
     ) -> Result<std::collections::HashMap<String, Vec<u8>>, sqlx::Error> {
-        let rows: Vec<(Option<String>, Vec<u8>)> = sqlx::query_as(
-            "SELECT content_hash, embedding FROM kb_chunks \
-             WHERE doc_id = ? AND content_hash IS NOT NULL AND embedding IS NOT NULL",
+        let rows: Vec<(String, Vec<u8>, i64)> = sqlx::query_as(
+            "SELECT c.content_hash, c.embedding, COALESCE(json_extract(c.metadata, '$.embedding_revision'), 0)
+             FROM kb_chunks c JOIN kb_knowledge_bases kb ON c.kb_id = kb.id
+             WHERE c.doc_id = ? AND c.content_hash IS NOT NULL AND c.embedding IS NOT NULL
+               AND COALESCE(json_extract(c.metadata, '$.embedding_revision'), 0) = kb.embedding_revision",
         )
         .bind(doc_id)
         .fetch_all(&self.pool)
         .await?;
         Ok(rows
             .into_iter()
-            .filter_map(|(h, e)| h.map(|h| (h, e)))
+            .map(|(hash, embedding, revision)| (format!("{revision}:{hash}"), embedding))
             .collect())
     }
 
@@ -398,7 +416,9 @@ impl KbRepository {
         sqlx::query_as(
             "SELECT c.id, c.embedding FROM kb_chunks c \
              JOIN kb_documents d ON c.doc_id = d.id \
-             WHERE c.doc_id = ? AND c.embedding IS NOT NULL AND d.status = 'ready'",
+             JOIN kb_knowledge_bases kb ON c.kb_id = kb.id \
+             WHERE c.doc_id = ? AND c.embedding IS NOT NULL AND d.status = 'ready' \
+               AND COALESCE(json_extract(c.metadata, '$.embedding_revision'), 0) = kb.embedding_revision",
         )
         .bind(doc_id)
         .fetch_all(&self.pool)
@@ -421,7 +441,9 @@ impl KbRepository {
             "SELECT c.id, c.content, c.metadata, c.embedding, d.filename, c.doc_id
              FROM kb_chunks c
              JOIN kb_documents d ON c.doc_id = d.id
+             JOIN kb_knowledge_bases kb ON c.kb_id = kb.id
              WHERE c.kb_id = ? AND c.embedding IS NOT NULL AND d.status = 'ready'
+               AND COALESCE(json_extract(c.metadata, '$.embedding_revision'), 0) = kb.embedding_revision
              ORDER BY c.id",
         )
         .bind(kb_id)
@@ -437,7 +459,9 @@ impl KbRepository {
             "SELECT c.id, c.content, c.metadata, c.embedding, c.embedding_dim, d.filename, c.doc_id
              FROM kb_chunks c
              JOIN kb_documents d ON c.doc_id = d.id
-             WHERE c.kb_id = ? AND c.embedding IS NOT NULL AND d.status = 'ready'",
+             JOIN kb_knowledge_bases kb ON c.kb_id = kb.id
+             WHERE c.kb_id = ? AND c.embedding IS NOT NULL AND d.status = 'ready'
+               AND COALESCE(json_extract(c.metadata, '$.embedding_revision'), 0) = kb.embedding_revision",
         )
         .bind(kb_id)
         .fetch_all(&self.pool)

--- a/src-tauri/src/services/knowledge/retriever.rs
+++ b/src-tauri/src/services/knowledge/retriever.rs
@@ -276,7 +276,10 @@ pub async fn index_delta(
     let repo = KbRepository::new(pool.clone());
     let path = index_path(kb_id);
 
-    let loaded = if path.exists() {
+    let kb = repo.get_kb(kb_id).await.map_err(|e| e.to_string())?;
+    let loaded = if kb.index_status == "stale" {
+        Err("embedding model changed".to_string())
+    } else if path.exists() {
         HnswIndex::load(&path)
     } else {
         Err("index file missing".to_string())

--- a/src-tauri/tests/rag_embedding_revision.rs
+++ b/src-tauri/tests/rag_embedding_revision.rs
@@ -1,0 +1,268 @@
+//! 嵌入模型变更后的缓存、向量空间与索引维度回归。
+use axum::{routing::post, Json, Router};
+use serde_json::{json, Value};
+use sqlx::SqlitePool;
+use std::sync::{Arc, Mutex};
+use waliapi_lib::db::repository::Repository;
+use waliapi_lib::server::event_bridge::EventSink;
+use waliapi_lib::services::knowledge::{
+    models::{CreateKbInput, UpdateKbInput},
+    processor,
+    repository::{ChunkInsert, KbRepository},
+    retriever,
+};
+use waliapi_lib::settings_store::SettingsStore;
+
+async fn pool() -> SqlitePool {
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+    sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+    pool
+}
+
+async fn wait_for_index(
+    events: &mut tokio::sync::broadcast::Receiver<waliapi_lib::server::event_bridge::AdminEvent>,
+) {
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            let event = events.recv().await.unwrap();
+            if event.event == "kb-index-progress" && event.payload["status"] == "ready" {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("索引任务应完成");
+}
+
+#[tokio::test]
+async fn model_switch_reembeds_unchanged_text_and_rebuilds_vector_space() {
+    let pool = pool().await;
+    let repo = KbRepository::new(pool.clone());
+    let calls = Arc::new(Mutex::new(Vec::<String>::new()));
+    let captured = calls.clone();
+    let mock = Router::new().route(
+        "/v1/embeddings",
+        post(move |Json(body): Json<Value>| {
+            let captured = captured.clone();
+            async move {
+                let model = body["model"].as_str().unwrap();
+                captured.lock().unwrap().push(model.to_string());
+                let vector = match model {
+                    "embed-b" => json!([0.0, 1.0, 0.0]),
+                    "embed-c" => json!([0.0, 0.0, 0.0, 1.0, 0.0]),
+                    _ => json!([1.0, 0.0, 0.0]),
+                };
+                let data: Vec<_> = body["input"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .enumerate()
+                    .map(|(index, _)| json!({"index": index, "embedding": vector}))
+                    .collect();
+                Json(json!({"data": data}))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}/v1", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move { axum::serve(listener, mock).await.unwrap() });
+    Repository::new(pool.clone())
+        .create_channel(
+            &serde_json::from_value(json!({
+                "name": "local-embedding-test", "type": "openai", "base_url": base_url,
+                "api_key": "test-only", "models": ["embed-a", "embed-b", "embed-c"]
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    let kb = repo
+        .create_kb(
+            &serde_json::from_value::<CreateKbInput>(json!({
+                "name": "model-switch", "embedding_model": "embed-a"
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    let directory = std::env::temp_dir().join(format!("rag-model-{}", kb.id));
+    std::fs::create_dir_all(&directory).unwrap();
+    let settings = SettingsStore::file(directory.join("settings.json"));
+    let (tx, _) = tokio::sync::broadcast::channel(100);
+    let events = EventSink::headless(tx);
+    let mut receiver = events.subscribe();
+    let mut docs = Vec::new();
+    for name in ["first", "second"] {
+        let filename = format!("{name}.txt");
+        let file = directory.join(&filename);
+        let content = format!("alpha {name} document remains unchanged across model switches");
+        std::fs::write(&file, &content).unwrap();
+        let doc = repo
+            .create_document(
+                &kb.id,
+                &filename,
+                file.to_str(),
+                "text",
+                content.len() as i64,
+                name,
+            )
+            .await
+            .unwrap();
+        processor::process_document(
+            &pool,
+            &events,
+            &kb.id,
+            &doc.id,
+            &filename,
+            content.as_bytes(),
+            Some("embed-a"),
+            &settings,
+            &directory,
+        )
+        .await
+        .unwrap();
+        wait_for_index(&mut receiver).await;
+        docs.push(doc);
+    }
+    let doc = &docs[0];
+    // 同一模型的普通重建仍复用缓存，不增加模型调用。
+    let same = repo
+        .update_kb(
+            &kb.id,
+            &serde_json::from_value::<UpdateKbInput>(json!({"embedding_model": "embed-a"}))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(same.embedding_revision, 0);
+    processor::reindex_document(&pool, &events, &doc.id, &settings, &directory)
+        .await
+        .unwrap();
+    wait_for_index(&mut receiver).await;
+    assert_eq!(calls.lock().unwrap().len(), 2);
+
+    for (revision, model, vector) in [
+        (1, "embed-b", vec![0.0, 1.0, 0.0]),
+        (2, "embed-c", vec![0.0, 0.0, 0.0, 1.0, 0.0]),
+    ] {
+        let changed = repo
+            .update_kb(
+                &kb.id,
+                &serde_json::from_value::<UpdateKbInput>(json!({"embedding_model": model}))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(changed.embedding_revision, revision);
+        assert_eq!(changed.embedding_dim, 0);
+        assert_eq!(changed.index_status, "stale");
+        assert!(repo
+            .get_chunk_hashes_by_doc(&doc.id)
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(repo
+            .get_chunks_by_kb_with_dim(&kb.id)
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(retriever::search(&pool, &kb.id, &vector, 5)
+            .await
+            .unwrap()
+            .is_empty());
+        processor::reindex_document(&pool, &events, &doc.id, &settings, &directory)
+            .await
+            .unwrap();
+        wait_for_index(&mut receiver).await;
+        let chunks = repo.get_chunk_vectors_by_doc(&doc.id).await.unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(retriever::decode_embedding(&chunks[0].1), vector);
+        assert!(repo
+            .get_chunk_vectors_by_doc(&docs[1].id)
+            .await
+            .unwrap()
+            .is_empty());
+        let found = retriever::search(&pool, &kb.id, &vector, 5).await.unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].doc_id, doc.id);
+        let meta = repo.get_index_meta(&kb.id).await.unwrap().unwrap();
+        assert_eq!(meta.embedding_dim, vector.len() as i64);
+        assert_eq!(meta.chunk_count, 1);
+        assert_eq!(
+            repo.get_kb(&kb.id).await.unwrap().embedding_dim,
+            vector.len() as i64
+        );
+    }
+    assert_eq!(
+        *calls.lock().unwrap(),
+        ["embed-a", "embed-a", "embed-b", "embed-c"]
+    );
+    retriever::drop_index(&pool, &kb.id).await.unwrap();
+    server.abort();
+    std::fs::remove_dir_all(directory).unwrap();
+}
+
+#[tokio::test]
+async fn legacy_cache_is_compatible_until_the_effective_model_changes() {
+    let pool = pool().await;
+    let repo = KbRepository::new(pool.clone());
+    let kb = repo
+        .create_kb(&serde_json::from_value(json!({"name": "legacy-cache"})).unwrap())
+        .await
+        .unwrap();
+    let doc = repo
+        .create_document(&kb.id, "legacy.txt", None, "text", 5, "doc-hash")
+        .await
+        .unwrap();
+    repo.create_chunk(&ChunkInsert {
+        id: "legacy-chunk".into(),
+        doc_id: doc.id.clone(),
+        kb_id: kb.id.clone(),
+        chunk_index: 0,
+        content: "alpha".into(),
+        token_count: 2,
+        embedding: retriever::encode_embedding(&[1.0, 0.0]),
+        embedding_dim: 2,
+        metadata: "{}".into(),
+        content_hash: Some("content-hash".into()),
+        created_at: "2026-09-11T00:00:00Z".into(),
+    })
+    .await
+    .unwrap();
+    repo.update_document_status(&doc.id, "ready", None)
+        .await
+        .unwrap();
+    let unchanged = repo
+        .update_kb(
+            &kb.id,
+            &serde_json::from_value(json!({
+                "name": "renamed", "embedding_model": "text-embedding-3-small"
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(unchanged.embedding_revision, 0);
+    let old_cache = repo.get_chunk_hashes_by_doc(&doc.id).await.unwrap();
+    assert!(old_cache.contains_key("0:content-hash"));
+    assert_eq!(repo.get_chunks_by_kb(&kb.id).await.unwrap().len(), 1);
+    repo.update_kb(
+        &kb.id,
+        &serde_json::from_value(json!({"embedding_model": "embed-next"})).unwrap(),
+    )
+    .await
+    .unwrap();
+    assert!(repo
+        .get_chunk_hashes_by_doc(&doc.id)
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(!old_cache.contains_key("1:content-hash"));
+    // 变更前仍在执行的任务，不能回写新模型的期望维度。
+    repo.update_kb_embedding_dim(&kb.id, 2, 0).await.unwrap();
+    assert_eq!(repo.get_kb(&kb.id).await.unwrap().embedding_dim, 0);
+}


### PR DESCRIPTION
> 本 PR 已汇总到 [#115](https://github.com/fuzhengwei/WaLiAPI/pull/115)，后续请在汇总 PR 审阅。关闭本 PR 仅为避免重复申请，代码修复已保留在汇总 PR 中。

修改知识库嵌入模型后，对未修改的文档执行重建仍会按内容哈希复用旧模型向量；同维度模型不会触发现有维度检查，跨维度模型还会留下旧索引。

新增嵌入配置版本：实际模型发生变化时递增版本、清空期望维度并标记索引过期。缓存键和切片元数据记录版本，向量检索只读取当前版本，增量更新遇到过期索引时重建。相同模型的正常重建继续复用缓存，旧切片缺失版本时按初始版本 0 兼容。旧任务不能回写新版本的期望维度。

验证：本地模拟向量服务验证同模型缓存复用、同维度切换重新生成、跨维度切换与索引重建、未重建文档退出向量检索，以及旧数据兼容；`cargo test --no-default-features --test rag_embedding_revision` 2 项通过。知识库模块 62 项测试通过，`git diff --check` 通过。

新增迁移使用 039，避开现有 #106 / #109 的 037 / 038。模型切换后需要重建文档以恢复向量检索；关键词正文仍保留。本 PR 不重复已有检索和授权修复。

与 #111 一起合并时：保留其事务替换流程，维度更新也放在 `replace_document_chunks` 内。从首个新切片 metadata 读取 `embedding_revision`（缺失按 0），仅在 `embedding_dim = 0 AND embedding_revision = 新切片版本` 时写入探测维度；不要恢复事务前的维度更新。保留版本化缓存读取以及每个新切片的版本标记。与 #106 一起合并时保留中文检索投影回填方法。

按上述衔接方式在临时工作区整合现有 #106 / #109 与本批 5 个独立修复后，91 项相关测试通过（知识库 76、授权与计费 9、集成 6）。Clippy 与仅包含现有 PR 的基线逐项比较，均为 212 条既有告警，无新增告警或编译错误。