### PR TITLE
fix(rag): 仅返回实际提供给模型的来源

### DIFF
--- a/src-tauri/src/services/knowledge/rag.rs
+++ b/src-tauri/src/services/knowledge/rag.rs
@@ -223,7 +223,7 @@ pub async fn ask_with_config(
     let model_limit = retriever::get_model_context_limit(chat_model);
     let context_limit = (model_limit as f64 * 0.7) as usize; // Reserve 30% for response
 
-    let (final_prompt, context_used) = if estimated_tokens > context_limit {
+    let (final_prompt, context_results) = if estimated_tokens > context_limit {
         // Stage 1: Trim context (remove lowest-scoring chunks)
         let trimmed = trim_context(&results, &query, history, context_limit);
         if retriever::estimate_tokens(&trimmed.0) > context_limit {
@@ -239,22 +239,22 @@ pub async fn ask_with_config(
                     "注意：由于 token 限制，无法附上 RAG 上下文。\n\n问题: {}",
                     query
                 );
-                (bare, false)
+                (bare, vec![])
             } else {
-                (no_history, true)
+                (no_history, results.clone())
             }
         } else {
             trimmed
         }
     } else {
-        (prompt, true)
+        (prompt, results.clone())
     };
 
     tracing::info!(
         "RAG prompt: estimated {} tokens, limit {}, context_used: {}",
-        estimated_tokens,
+        retriever::estimate_tokens(&final_prompt),
         context_limit,
-        context_used
+        !context_results.is_empty()
     );
 
     // 6. Call LLM via proxy（系统提示词走模板表：激活版本优先，回退编译期默认）
@@ -299,7 +299,8 @@ pub async fn ask_with_config(
                 total_tokens: u.total_tokens,
             });
 
-            let sources: Vec<SourceInfo> = results
+            // 来源只来自最终发送给模型的切片，裁掉的检索命中仅保留在检索详情。
+            let sources: Vec<SourceInfo> = context_results
                 .iter()
                 .map(|r| SourceInfo {
                     filename: r.filename.clone(),
@@ -451,39 +452,92 @@ fn trim_context(
     query: &str,
     history: &[ConversationMessage],
     target_tokens: usize,
-) -> (String, bool) {
-    // Sort by score ascending (remove lowest first)
-    let mut indexed: Vec<(usize, &super::models::SearchResult)> =
-        results.iter().enumerate().collect();
+) -> (String, Vec<super::models::SearchResult>) {
+    // 按低分顺序移除，但保留剩余切片原来的展示顺序。
+    let mut indexed: Vec<_> = results.iter().enumerate().collect();
     indexed.sort_by(|a, b| {
         a.1.score
             .partial_cmp(&b.1.score)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
-
     let mut removed = std::collections::HashSet::new();
-    let mut current_estimate =
-        retriever::estimate_tokens(&build_rag_prompt(&build_context(results), query, history));
-
-    for (idx, r) in &indexed {
-        if current_estimate <= target_tokens {
+    let mut remaining = results.to_vec();
+    let mut prompt = build_rag_prompt(&build_context(&remaining), query, history);
+    for (idx, _) in indexed {
+        if retriever::estimate_tokens(&prompt) <= target_tokens {
             break;
         }
-        removed.insert(*idx);
-        current_estimate = current_estimate.saturating_sub(retriever::estimate_tokens(&r.content));
+        removed.insert(idx);
+        remaining = results
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| !removed.contains(i))
+            .map(|(_, r)| r.clone())
+            .collect();
+        // 连同文档标题和符号信息重新计算，不能只减正文估算值而多删来源。
+        prompt = build_rag_prompt(&build_context(&remaining), query, history);
+    }
+    (prompt, remaining)
+}
+
+#[cfg(test)]
+mod context_tests {
+    use super::*;
+
+    fn result(id: &str, score: f32, content: &str) -> super::super::models::SearchResult {
+        super::super::models::SearchResult {
+            chunk_id: id.into(),
+            doc_id: id.into(),
+            filename: format!("{id}.txt"),
+            score,
+            content: content.into(),
+            metadata: serde_json::json!({}),
+        }
     }
 
-    // Rebuild context without removed chunks
-    let remaining: Vec<_> = results
-        .iter()
-        .enumerate()
-        .filter(|(i, _)| !removed.contains(i))
-        .map(|(_, r)| r.clone())
-        .collect();
+    #[test]
+    fn trimming_returns_exactly_the_chunks_kept_in_the_prompt() {
+        let results = vec![
+            result("best", 0.9, "high relevance"),
+            result("low", 0.1, &"x".repeat(1000)),
+        ];
+        let budget = retriever::estimate_tokens(&build_rag_prompt(
+            &build_context(&results[..1]),
+            "query",
+            &[],
+        ));
+        let (prompt, used) = trim_context(&results, "query", &[], budget);
+        assert_eq!(used.len(), 1);
+        assert_eq!(used[0].chunk_id, "best");
+        assert!(prompt.contains("best.txt"));
+        assert!(!prompt.contains("low.txt"));
+        assert!(retriever::estimate_tokens(&prompt) <= budget);
+        let (_, all) = trim_context(&results, "query", &[], usize::MAX);
+        assert_eq!(all.len(), 2);
+        let (empty_prompt, none) = trim_context(&results, "query", &[], 1);
+        assert!(none.is_empty());
+        assert!(!empty_prompt.contains("best.txt"));
+        assert!(!empty_prompt.contains("low.txt"));
+    }
 
-    let new_context = build_context(&remaining);
-    let new_prompt = build_rag_prompt(&new_context, query, history);
-    (new_prompt, !removed.is_empty())
+    #[test]
+    fn trimming_counts_document_headers_and_preserves_display_order() {
+        let mut results = vec![
+            result("first", 0.8, "first"),
+            result("low", 0.1, "low"),
+            result("best", 0.9, "best"),
+        ];
+        results[1].metadata = serde_json::json!({"symbol_name": "s".repeat(2000)});
+        let keep = vec![results[0].clone(), results[2].clone()];
+        let budget =
+            retriever::estimate_tokens(&build_rag_prompt(&build_context(&keep), "query", &[]));
+        let (prompt, used) = trim_context(&results, "query", &[], budget);
+        assert_eq!(
+            used.iter().map(|r| r.chunk_id.as_str()).collect::<Vec<_>>(),
+            ["first", "best"]
+        );
+        assert!(retriever::estimate_tokens(&prompt) <= budget);
+    }
 }
 
 /// Deep Research: multi-round iterative retrieval and analysis

--- a/src-tauri/tests/rag_sources.rs
+++ b/src-tauri/tests/rag_sources.rs
@@ -1,0 +1,122 @@
+//! 实际模型请求、响应来源与持久化会话来源必须一致。
+use axum::{routing::post, Json, Router};
+use serde_json::{json, Value};
+use std::sync::{Arc, Mutex};
+use waliapi_lib::db::repository::Repository;
+use waliapi_lib::services::knowledge::{
+    models::ConversationMessage,
+    rag,
+    repository::{ChunkInsert, KbRepository},
+    retriever,
+};
+use waliapi_lib::settings_store::SettingsStore;
+
+#[tokio::test]
+async fn ask_reports_only_sources_that_were_sent_to_the_model() {
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+    sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+    let calls = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let captured = calls.clone();
+    let mock = Router::new().route("/v1/chat/completions", post(move |Json(body): Json<Value>| {
+        let captured = captured.clone();
+        async move {
+            captured.lock().unwrap().push(body.clone());
+            Json(json!({"id":"source-test", "object":"chat.completion", "model":body["model"],
+                "choices":[{"index":0,"message":{"role":"assistant","content":"test answer"},"finish_reason":"stop"}],
+                "usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}}))
+        }
+    }));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}/v1", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move { axum::serve(listener, mock).await.unwrap() });
+    Repository::new(pool.clone()).create_channel(&serde_json::from_value(json!({
+        "name":"local-chat-test", "type":"openai", "base_url":base_url, "api_key":"test-only",
+        "models":["chat-test"], "protocol":"openai", "provider":"custom", "native_base_url":base_url,
+        "native_endpoints":["chat_completions"]
+    })).unwrap()).await.unwrap();
+    let repo = KbRepository::new(pool.clone());
+    let kb = repo
+        .create_kb(&serde_json::from_value(json!({"name":"sources"})).unwrap())
+        .await
+        .unwrap();
+    let doc = repo
+        .create_document(&kb.id, "source.txt", None, "text", 40, "doc-hash")
+        .await
+        .unwrap();
+    let text = "alpha answer must be grounded in this exact source";
+    repo.create_chunk(&ChunkInsert {
+        id: "source-chunk".into(),
+        doc_id: doc.id.clone(),
+        kb_id: kb.id.clone(),
+        chunk_index: 0,
+        content: text.into(),
+        token_count: 12,
+        embedding: retriever::encode_embedding(&[1.0, 0.0]),
+        embedding_dim: 2,
+        metadata: "{}".into(),
+        content_hash: None,
+        created_at: "2026-09-11T00:00:00Z".into(),
+    })
+    .await
+    .unwrap();
+    repo.update_document_status(&doc.id, "ready", None)
+        .await
+        .unwrap();
+    let directory = std::env::temp_dir().join(format!("rag-sources-{}", kb.id));
+    std::fs::create_dir_all(&directory).unwrap();
+    let settings = SettingsStore::file(directory.join("settings.json"));
+    // 正常、上下文裁空、连历史也超预算三种实际调用。
+    for (history_chars, expect_source) in [(0, true), (22600, false), (30000, false)] {
+        let history = if history_chars == 0 {
+            vec![]
+        } else {
+            vec![ConversationMessage {
+                role: "user".into(),
+                content: "x".repeat(history_chars),
+            }]
+        };
+        let answer = rag::ask_with_config(
+            &pool,
+            &kb.id,
+            "alpha",
+            "unused",
+            "chat-test",
+            5,
+            false,
+            &history,
+            &settings,
+            0.7,
+            0.3,
+            "keyword",
+        )
+        .await
+        .unwrap();
+        assert_eq!(answer.answer, "test answer");
+        let prompt = calls.lock().unwrap().last().unwrap()["messages"][1]["content"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(
+            prompt.contains(text),
+            expect_source,
+            "history_chars={history_chars}"
+        );
+        assert_eq!(!answer.sources.is_empty(), expect_source);
+        assert_eq!(answer.retrieval_details.as_ref().unwrap().len(), 1);
+        if expect_source {
+            assert_eq!(answer.sources[0].filename, "source.txt");
+        }
+        let stored: Option<String> = sqlx::query_scalar(
+            "SELECT sources FROM kb_conversations WHERE kb_id = ? AND role = 'assistant' ORDER BY rowid DESC LIMIT 1"
+        ).bind(&kb.id).fetch_one(&pool).await.unwrap();
+        let stored: Vec<Value> = serde_json::from_str(stored.as_deref().unwrap()).unwrap();
+        assert_eq!(stored.len(), answer.sources.len());
+    }
+    assert_eq!(calls.lock().unwrap().len(), 3);
+    server.abort();
+    std::fs::remove_dir_all(directory).unwrap();
+}


### PR DESCRIPTION
> 本 PR 已汇总到 [#115](https://github.com/fuzhengwei/WaLiAPI/pull/115)，后续请在汇总 PR 审阅。关闭本 PR 仅为避免重复申请，代码修复已保留在汇总 PR 中。

RAG 提示词因 token 限制裁掉部分或全部文档后，响应仍从原始检索结果生成来源列表，会把模型没有看到的内容标为回答来源，并写入会话记录。

裁剪函数同时返回最终提示词与保留切片，响应和会话来源仅使用保留切片；完全移除上下文时来源为空。裁剪重新计算含文档标题、符号信息的完整提示词，避免过度移除。检索详情继续显示原始命中，日志记录最终提示词的估算值及是否实际包含上下文。

验证：本地模拟聊天服务核对实际出站请求、响应来源及会话记录，覆盖正常上下文、裁空和历史超限回退。另有切片部分保留、全部移除、文档标题计入预算和顺序保留测试。`cargo test --no-default-features --test rag_sources` 1 项通过；`cargo test --lib --no-default-features services::knowledge -- --test-threads=1` 64 项通过，`git diff --check` 通过。