### PR TITLE
fix(rag): 修复文档数据保护、索引并发、模型缓存和来源标注

### DIFF
--- a/src-tauri/migrations/039_kb_embedding_revision.sql
+++ b/src-tauri/migrations/039_kb_embedding_revision.sql
@@ -1,0 +1,3 @@
+-- 模型配置变更后，旧版本向量不能继续作为缓存或参与向量检索。
+-- 既有切片 metadata 未记录版本，按初始版本 0 兼容。
+ALTER TABLE kb_knowledge_bases ADD COLUMN embedding_revision INTEGER NOT NULL DEFAULT 0;

--- a/src-tauri/src/commands/knowledge_base.rs
+++ b/src-tauri/src/commands/knowledge_base.rs
@@ -58,9 +58,12 @@ pub async fn delete_kb_document(
 ) -> Result<(), String> {
     let repo = KbRepository::new(state.db.pool.clone());
     if let Ok(doc) = repo.get_document(&doc_id).await {
-        if let Some(path) = &doc.file_path {
-            std::fs::remove_file(path).ok();
-        }
+        crate::services::knowledge::upload::remove_managed_file(
+            &state.data_dir,
+            &doc.kb_id,
+            &doc.source_type,
+            doc.file_path.as_deref(),
+        )?;
         // 级联删除 OCR 页级缓存（以内容哈希为键）
         crate::services::knowledge::ocr::cache::remove_cache(&state.data_dir, &doc.content_hash);
     }

--- a/src-tauri/src/services/knowledge/handlers.rs
+++ b/src-tauri/src/services/knowledge/handlers.rs
@@ -244,8 +244,13 @@ pub async fn delete_document(
     let repo = KbRepository::new(shared.state.db.pool.clone());
 
     if let Ok(doc) = repo.get_document(&doc_id).await {
-        if let Some(path) = &doc.file_path {
-            std::fs::remove_file(path).ok();
+        if let Err(e) = super::upload::remove_managed_file(
+            &shared.state.data_dir,
+            &doc.kb_id,
+            &doc.source_type,
+            doc.file_path.as_deref(),
+        ) {
+            return (StatusCode::INTERNAL_SERVER_ERROR, e).into_response();
         }
         // 级联删除 OCR 页级缓存（以内容哈希为键）
         super::ocr::cache::remove_cache(&shared.state.data_dir, &doc.content_hash);

--- a/src-tauri/src/services/knowledge/index.rs
+++ b/src-tauri/src/services/knowledge/index.rs
@@ -419,8 +419,25 @@ impl HnswIndex {
 
     /// Save to file.
     pub fn save(&self, path: &Path) -> Result<(), String> {
-        let data = self.to_bytes();
-        std::fs::write(path, &data).map_err(|e| format!("Failed to write index file: {}", e))
+        use std::io::Write;
+        let data = serialize(self).map_err(|e| format!("Failed to serialize index: {e}"))?;
+        let temporary = path.with_extension(format!("{}.tmp", uuid::Uuid::new_v4()));
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)
+            .map_err(|e| format!("Failed to create index file: {e}"))?;
+        let result = (|| -> std::io::Result<()> {
+            file.write_all(&data)?;
+            file.sync_all()?;
+            drop(file);
+            // 同目录原子替换：检索只能读到完整的旧文件或新文件。
+            std::fs::rename(&temporary, path)
+        })();
+        if result.is_err() {
+            let _ = std::fs::remove_file(&temporary);
+        }
+        result.map_err(|e| format!("Failed to save index file: {e}"))
     }
 
     /// Load from file.

--- a/src-tauri/src/services/knowledge/models.rs
+++ b/src-tauri/src/services/knowledge/models.rs
@@ -18,6 +18,7 @@ pub struct KbKnowledgeBase {
     pub excluded_files: String,
     pub included_files: String,
     pub embedding_dim: i64,
+    pub embedding_revision: i64,
     pub index_status: String,
     pub embedding_batch_size: i64,
     /// 知识库级 OCR 视觉模型（如 qwen-vl-max）；None/空 = 不启用。

--- a/src-tauri/src/services/knowledge/processor.rs
+++ b/src-tauri/src/services/knowledge/processor.rs
@@ -80,8 +80,7 @@ pub async fn process_document(
     .await
 }
 
-/// 同 `process_document`，但复用映射由调用方提供——`reindex_document`
-/// 先删旧 chunk 再重处理，必须在删除**前**捕获映射（删除后哈希就没了）。
+/// 同 `process_document`，但复用映射由调用方提供；准备成功前保留旧切片。
 #[allow(clippy::too_many_arguments)]
 pub async fn process_document_with_reuse(
     pool: &SqlitePool,
@@ -97,10 +96,18 @@ pub async fn process_document_with_reuse(
 ) -> Result<(), String> {
     let repo = KbRepository::new(pool.clone());
 
-    // Update status to processing
-    repo.update_document_status(doc_id, "processing", None)
+    let was_ready = repo
+        .get_document(doc_id)
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| e.to_string())?
+        .status
+        == "ready";
+    // 已就绪文档重建期间继续提供旧内容，首次摄入才进入 processing。
+    if !was_ready {
+        repo.update_document_status(doc_id, "processing", None)
+            .await
+            .map_err(|e| e.to_string())?;
+    }
 
     emit_progress(events, doc_id, kb_id, filename, "processing", 0, "开始处理");
 
@@ -121,7 +128,11 @@ pub async fn process_document_with_reuse(
     if let Err(ref e) = result {
         let err_msg = format!("文档「{}」处理失败: {}", filename, e);
         let _ = repo
-            .update_document_status(doc_id, "failed", Some(&err_msg))
+            .update_document_status(
+                doc_id,
+                if was_ready { "ready" } else { "failed" },
+                Some(&err_msg),
+            )
             .await;
         events.emit(
             "kb-document-error",
@@ -310,24 +321,8 @@ async fn process_document_inner(
     };
 
     if chunks.is_empty() {
-        // 分块后为空状态改为失败,且失败信息给客户端提示
-        events.emit(
-            "kb-document-error",
-            serde_json::json!({
-                "doc_id": doc_id,
-                "kb_id": kb_id,
-                "filename": filename,
-                "error": "分块后为空，无法继续处理".to_string(),
-            }),
-        );
-        repo.update_document_status(doc_id, "failed", None)
-            .await
-            .map_err(|e| e.to_string())?;
-        return Ok(());
+        return Err("分块后为空，无法继续处理".to_string());
     }
-
-    let total_chunks = chunks.len() as i64;
-    let total_tokens: i64 = chunks.iter().map(|c| c.token_count as i64).sum();
 
     // 3. Embed chunks in batches（内容未变的块复用既有向量，C-06/R1）
     let emb_model = embedding_model.unwrap_or(DEFAULT_EMBEDDING_MODEL);
@@ -416,19 +411,9 @@ async fn process_document_inner(
         );
     }
 
-    // Auto-detect and update KB embedding dimension if not set
-    if expected_dim.is_none() && !all_embeddings.is_empty() {
-        let detected_dim = all_embeddings[0].len() as i64;
-        tracing::info!(
-            "Auto-detected embedding dim {} for KB {}",
-            detected_dim,
-            kb_id
-        );
-        repo.update_kb_embedding_dim(kb_id, detected_dim).await.ok();
-    }
-
     // 4. Store chunks with embeddings
     let chunks_total = chunks.len();
+    let mut prepared_chunks = Vec::with_capacity(chunks_total);
     for (i, chunk) in chunks.iter().enumerate() {
         // Storing progress: 80% ~ 95%
         if i % 10 == 0 || i == chunks_total - 1 {
@@ -457,9 +442,7 @@ async fn process_document_inner(
             content_hash: Some(chunk_hashes[i].clone()),
             created_at: now_iso(),
         };
-        repo.create_chunk(&chunk_insert)
-            .await
-            .map_err(|e| e.to_string())?;
+        prepared_chunks.push(chunk_insert);
     }
 
     // 5. Update document and KB counts
@@ -472,21 +455,14 @@ async fn process_document_inner(
         98,
         "更新统计",
     );
-    repo.update_document_counts(doc_id, total_chunks, total_tokens)
-        .await
-        .map_err(|e| e.to_string())?;
-    // OCR 文档回填识别信息（引擎/页数/失败页码）
-    if let Some(outcome) = &ocr_outcome {
-        let failed_json =
-            serde_json::to_string(&outcome.failed_pages).unwrap_or_else(|_| "[]".to_string());
-        repo.update_document_ocr_info(doc_id, "vlm", outcome.page_count as i64, &failed_json)
-            .await
-            .map_err(|e| e.to_string())?;
-    }
-    repo.update_document_status(doc_id, "ready", None)
-        .await
-        .map_err(|e| e.to_string())?;
-    repo.update_kb_counts(kb_id)
+    let failed_pages = ocr_outcome.as_ref().map(|outcome| {
+        serde_json::to_string(&outcome.failed_pages).unwrap_or_else(|_| "[]".to_string())
+    });
+    let ocr_info = ocr_outcome
+        .as_ref()
+        .zip(failed_pages.as_deref())
+        .map(|(outcome, failed)| (outcome.page_count as i64, failed));
+    repo.replace_document_chunks(doc_id, kb_id, &prepared_chunks, ocr_info)
         .await
         .map_err(|e| e.to_string())?;
 
@@ -543,7 +519,7 @@ async fn process_document_inner(
     Ok(())
 }
 
-/// Reindex a document (delete old chunks, reprocess)
+/// 重建文档：先读取/准备新内容，成功后原子替换旧切片。
 pub async fn reindex_document(
     pool: &SqlitePool,
     events: &EventSink,
@@ -553,20 +529,6 @@ pub async fn reindex_document(
 ) -> Result<(), String> {
     let repo = KbRepository::new(pool.clone());
     let doc = repo.get_document(doc_id).await.map_err(|e| e.to_string())?;
-
-    // 哈希复用映射必须在删除前捕获——删除后旧 chunk 的哈希就没了
-    let reuse = match repo.get_chunk_hashes_by_doc(doc_id).await {
-        Ok(m) => m,
-        Err(e) => {
-            tracing::warn!("Failed to load chunk hashes before reindex: {}", e);
-            std::collections::HashMap::new()
-        }
-    };
-
-    // Delete existing chunks
-    repo.delete_chunks_by_doc(doc_id)
-        .await
-        .map_err(|e| e.to_string())?;
 
     // Read file content from path
     let content = if let Some(path) = &doc.file_path {
@@ -578,7 +540,7 @@ pub async fn reindex_document(
     // Get KB for embedding model
     let kb = repo.get_kb(&doc.kb_id).await.map_err(|e| e.to_string())?;
 
-    process_document_with_reuse(
+    process_document(
         pool,
         events,
         &doc.kb_id,
@@ -588,7 +550,6 @@ pub async fn reindex_document(
         kb.embedding_model.as_deref(),
         settings,
         data_dir,
-        reuse,
     )
     .await
 }
@@ -643,5 +604,146 @@ mod tests {
 
         assert!(to_embed.is_empty());
         assert_eq!(reused.len(), 2);
+    }
+    async fn reindex_fixture() -> (
+        SqlitePool,
+        EventSink,
+        SettingsStore,
+        std::path::PathBuf,
+        String,
+        String,
+    ) {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        let dir = std::env::temp_dir().join(format!("kb-reindex-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("source.txt");
+        let content = "alpha old document content";
+        std::fs::write(&file, content).unwrap();
+        let repo = KbRepository::new(pool.clone());
+        let kb = repo
+            .create_kb(
+                &serde_json::from_value(
+                    serde_json::json!({"name":"reindex", "embedding_model":"embed-test"}),
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        let hash = hex::encode(sha2::Sha256::digest(content.as_bytes()));
+        let doc = repo
+            .create_document(
+                &kb.id,
+                "source.txt",
+                file.to_str(),
+                "txt",
+                content.len() as i64,
+                &hash,
+            )
+            .await
+            .unwrap();
+        repo.create_chunk(&ChunkInsert {
+            id: "old-chunk".into(),
+            doc_id: doc.id.clone(),
+            kb_id: kb.id.clone(),
+            chunk_index: 0,
+            content: content.into(),
+            token_count: 6,
+            embedding: retriever::encode_embedding(&[1.0, 0.0]),
+            embedding_dim: 2,
+            metadata: "{}".into(),
+            content_hash: Some(hash),
+            created_at: now_iso(),
+        })
+        .await
+        .unwrap();
+        repo.update_document_counts(&doc.id, 1, 6).await.unwrap();
+        repo.update_document_status(&doc.id, "ready", None)
+            .await
+            .unwrap();
+        repo.update_kb_counts(&kb.id).await.unwrap();
+        let (tx, _) = tokio::sync::broadcast::channel(64);
+        let events = EventSink::headless(tx);
+        let settings = SettingsStore::file(dir.join("settings.json"));
+        (pool, events, settings, dir, kb.id, doc.id)
+    }
+
+    #[tokio::test]
+    async fn reindex_read_and_embedding_failures_preserve_ready_document() {
+        let (pool, events, settings, dir, kb_id, doc_id) = reindex_fixture().await;
+        let source = dir.join("source.txt");
+        std::fs::remove_file(&source).unwrap();
+        assert!(reindex_document(&pool, &events, &doc_id, &settings, &dir)
+            .await
+            .is_err());
+        // 内容变化使旧哈希不能复用；无渠道模拟向量化失败。
+        std::fs::write(&source, "new content requires an embedding request").unwrap();
+        assert!(reindex_document(&pool, &events, &doc_id, &settings, &dir)
+            .await
+            .is_err());
+        let repo = KbRepository::new(pool.clone());
+        let chunks = repo.get_chunks_by_kb(&kb_id).await.unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].0, "old-chunk");
+        assert_eq!(chunks[0].1, "alpha old document content");
+        let doc = repo.get_document(&doc_id).await.unwrap();
+        assert_eq!(doc.status, "ready");
+        assert_eq!((doc.chunk_count, doc.token_count), (1, 6));
+        assert_eq!(repo.get_kb(&kb_id).await.unwrap().chunk_count, 1);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn reindex_success_atomically_replaces_old_chunks() {
+        let (pool, events, settings, dir, kb_id, doc_id) = reindex_fixture().await;
+        reindex_document(&pool, &events, &doc_id, &settings, &dir)
+            .await
+            .unwrap();
+        let repo = KbRepository::new(pool.clone());
+        let chunks = repo.get_chunks_by_kb(&kb_id).await.unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_ne!(chunks[0].0, "old-chunk");
+        assert_eq!(chunks[0].1, "alpha old document content");
+        assert_eq!(retriever::decode_embedding(&chunks[0].3), vec![1.0, 0.0]);
+        assert_eq!(repo.get_document(&doc_id).await.unwrap().status, "ready");
+        assert_eq!(repo.get_kb(&kb_id).await.unwrap().chunk_count, 1);
+        // 等待后台小索引任务结束，避免测试退出抢先关闭 runtime。
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        retriever::drop_index(&pool, &kb_id).await.unwrap();
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn replacement_insert_error_rolls_back_chunks_and_counts() {
+        let (pool, _, _, dir, kb_id, doc_id) = reindex_fixture().await;
+        let repo = KbRepository::new(pool.clone());
+        let chunk = || ChunkInsert {
+            id: "duplicate-new-id".into(),
+            doc_id: doc_id.clone(),
+            kb_id: kb_id.clone(),
+            chunk_index: 0,
+            content: "new".into(),
+            token_count: 1,
+            embedding: retriever::encode_embedding(&[0.0, 1.0]),
+            embedding_dim: 2,
+            metadata: "{}".into(),
+            content_hash: None,
+            created_at: now_iso(),
+        };
+        assert!(repo
+            .replace_document_chunks(&doc_id, &kb_id, &[chunk(), chunk()], None)
+            .await
+            .is_err());
+        let chunks = repo.get_chunks_by_kb(&kb_id).await.unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].0, "old-chunk");
+        let doc = repo.get_document(&doc_id).await.unwrap();
+        assert_eq!((doc.chunk_count, doc.token_count), (1, 6));
+        assert_eq!(repo.get_kb(&kb_id).await.unwrap().chunk_count, 1);
+        std::fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/src-tauri/src/services/knowledge/processor.rs
+++ b/src-tauri/src/services/knowledge/processor.rs
@@ -325,7 +325,13 @@ async fn process_document_inner(
     }
 
     // 3. Embed chunks in batches（内容未变的块复用既有向量，C-06/R1）
-    let emb_model = embedding_model.unwrap_or(DEFAULT_EMBEDDING_MODEL);
+    let emb_model = kb
+        .embedding_model
+        .as_deref()
+        .unwrap_or(DEFAULT_EMBEDDING_MODEL);
+    if embedding_model.unwrap_or(DEFAULT_EMBEDDING_MODEL) != emb_model {
+        return Err("处理期间嵌入模型配置已变更，请重新处理文档".to_string());
+    }
     let main_repo = Repository::new(pool.clone());
 
     // Detect expected embedding dimension from KB config
@@ -348,7 +354,11 @@ async fn process_document_inner(
         .iter()
         .map(|c| hex::encode(sha2::Sha256::digest(c.content.as_bytes())))
         .collect();
-    let (mut to_embed, reused) = split_chunks_for_embedding(&chunk_hashes, reuse_embeddings);
+    let cache_keys: Vec<String> = chunk_hashes
+        .iter()
+        .map(|hash| format!("{}:{hash}", kb.embedding_revision))
+        .collect();
+    let (mut to_embed, reused) = split_chunks_for_embedding(&cache_keys, reuse_embeddings);
 
     let mut all_embeddings: Vec<Vec<f32>> = vec![Vec::new(); chunks.len()];
     let mut reused_count = 0usize;
@@ -429,6 +439,8 @@ async fn process_document_inner(
             );
         }
         let embedding_bytes = retriever::encode_embedding(&all_embeddings[i]);
+        let mut metadata = serde_json::to_value(&chunk.metadata).map_err(|e| e.to_string())?;
+        metadata["embedding_revision"] = serde_json::json!(kb.embedding_revision);
         let chunk_insert = ChunkInsert {
             id: uuid::Uuid::new_v4().to_string(),
             doc_id: doc_id.to_string(),
@@ -438,7 +450,7 @@ async fn process_document_inner(
             token_count: chunk.token_count as i64,
             embedding: embedding_bytes,
             embedding_dim: all_embeddings[i].len() as i64,
-            metadata: serde_json::to_string(&chunk.metadata).unwrap_or_else(|_| "{}".to_string()),
+            metadata: metadata.to_string(),
             content_hash: Some(chunk_hashes[i].clone()),
             created_at: now_iso(),
         };

--- a/src-tauri/src/services/knowledge/rag.rs
+++ b/src-tauri/src/services/knowledge/rag.rs
@@ -223,7 +223,7 @@ pub async fn ask_with_config(
     let model_limit = retriever::get_model_context_limit(chat_model);
     let context_limit = (model_limit as f64 * 0.7) as usize; // Reserve 30% for response
 
-    let (final_prompt, context_used) = if estimated_tokens > context_limit {
+    let (final_prompt, context_results) = if estimated_tokens > context_limit {
         // Stage 1: Trim context (remove lowest-scoring chunks)
         let trimmed = trim_context(&results, &query, history, context_limit);
         if retriever::estimate_tokens(&trimmed.0) > context_limit {
@@ -239,22 +239,22 @@ pub async fn ask_with_config(
                     "注意：由于 token 限制，无法附上 RAG 上下文。\n\n问题: {}",
                     query
                 );
-                (bare, false)
+                (bare, vec![])
             } else {
-                (no_history, true)
+                (no_history, results.clone())
             }
         } else {
             trimmed
         }
     } else {
-        (prompt, true)
+        (prompt, results.clone())
     };
 
     tracing::info!(
         "RAG prompt: estimated {} tokens, limit {}, context_used: {}",
-        estimated_tokens,
+        retriever::estimate_tokens(&final_prompt),
         context_limit,
-        context_used
+        !context_results.is_empty()
     );
 
     // 6. Call LLM via proxy（系统提示词走模板表：激活版本优先，回退编译期默认）
@@ -299,7 +299,8 @@ pub async fn ask_with_config(
                 total_tokens: u.total_tokens,
             });
 
-            let sources: Vec<SourceInfo> = results
+            // 来源只来自最终发送给模型的切片，裁掉的检索命中仅保留在检索详情。
+            let sources: Vec<SourceInfo> = context_results
                 .iter()
                 .map(|r| SourceInfo {
                     filename: r.filename.clone(),
@@ -451,39 +452,92 @@ fn trim_context(
     query: &str,
     history: &[ConversationMessage],
     target_tokens: usize,
-) -> (String, bool) {
-    // Sort by score ascending (remove lowest first)
-    let mut indexed: Vec<(usize, &super::models::SearchResult)> =
-        results.iter().enumerate().collect();
+) -> (String, Vec<super::models::SearchResult>) {
+    // 按低分顺序移除，但保留剩余切片原来的展示顺序。
+    let mut indexed: Vec<_> = results.iter().enumerate().collect();
     indexed.sort_by(|a, b| {
         a.1.score
             .partial_cmp(&b.1.score)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
-
     let mut removed = std::collections::HashSet::new();
-    let mut current_estimate =
-        retriever::estimate_tokens(&build_rag_prompt(&build_context(results), query, history));
-
-    for (idx, r) in &indexed {
-        if current_estimate <= target_tokens {
+    let mut remaining = results.to_vec();
+    let mut prompt = build_rag_prompt(&build_context(&remaining), query, history);
+    for (idx, _) in indexed {
+        if retriever::estimate_tokens(&prompt) <= target_tokens {
             break;
         }
-        removed.insert(*idx);
-        current_estimate = current_estimate.saturating_sub(retriever::estimate_tokens(&r.content));
+        removed.insert(idx);
+        remaining = results
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| !removed.contains(i))
+            .map(|(_, r)| r.clone())
+            .collect();
+        // 连同文档标题和符号信息重新计算，不能只减正文估算值而多删来源。
+        prompt = build_rag_prompt(&build_context(&remaining), query, history);
+    }
+    (prompt, remaining)
+}
+
+#[cfg(test)]
+mod context_tests {
+    use super::*;
+
+    fn result(id: &str, score: f32, content: &str) -> super::super::models::SearchResult {
+        super::super::models::SearchResult {
+            chunk_id: id.into(),
+            doc_id: id.into(),
+            filename: format!("{id}.txt"),
+            score,
+            content: content.into(),
+            metadata: serde_json::json!({}),
+        }
     }
 
-    // Rebuild context without removed chunks
-    let remaining: Vec<_> = results
-        .iter()
-        .enumerate()
-        .filter(|(i, _)| !removed.contains(i))
-        .map(|(_, r)| r.clone())
-        .collect();
+    #[test]
+    fn trimming_returns_exactly_the_chunks_kept_in_the_prompt() {
+        let results = vec![
+            result("best", 0.9, "high relevance"),
+            result("low", 0.1, &"x".repeat(1000)),
+        ];
+        let budget = retriever::estimate_tokens(&build_rag_prompt(
+            &build_context(&results[..1]),
+            "query",
+            &[],
+        ));
+        let (prompt, used) = trim_context(&results, "query", &[], budget);
+        assert_eq!(used.len(), 1);
+        assert_eq!(used[0].chunk_id, "best");
+        assert!(prompt.contains("best.txt"));
+        assert!(!prompt.contains("low.txt"));
+        assert!(retriever::estimate_tokens(&prompt) <= budget);
+        let (_, all) = trim_context(&results, "query", &[], usize::MAX);
+        assert_eq!(all.len(), 2);
+        let (empty_prompt, none) = trim_context(&results, "query", &[], 1);
+        assert!(none.is_empty());
+        assert!(!empty_prompt.contains("best.txt"));
+        assert!(!empty_prompt.contains("low.txt"));
+    }
 
-    let new_context = build_context(&remaining);
-    let new_prompt = build_rag_prompt(&new_context, query, history);
-    (new_prompt, !removed.is_empty())
+    #[test]
+    fn trimming_counts_document_headers_and_preserves_display_order() {
+        let mut results = vec![
+            result("first", 0.8, "first"),
+            result("low", 0.1, "low"),
+            result("best", 0.9, "best"),
+        ];
+        results[1].metadata = serde_json::json!({"symbol_name": "s".repeat(2000)});
+        let keep = vec![results[0].clone(), results[2].clone()];
+        let budget =
+            retriever::estimate_tokens(&build_rag_prompt(&build_context(&keep), "query", &[]));
+        let (prompt, used) = trim_context(&results, "query", &[], budget);
+        assert_eq!(
+            used.iter().map(|r| r.chunk_id.as_str()).collect::<Vec<_>>(),
+            ["first", "best"]
+        );
+        assert!(retriever::estimate_tokens(&prompt) <= budget);
+    }
 }
 
 /// Deep Research: multi-round iterative retrieval and analysis

--- a/src-tauri/src/services/knowledge/repository.rs
+++ b/src-tauri/src/services/knowledge/repository.rs
@@ -343,6 +343,14 @@ impl KbRepository {
     // ==================== Chunk ====================
 
     pub async fn create_chunk(&self, chunk: &ChunkInsert) -> Result<(), sqlx::Error> {
+        let mut connection = self.pool.acquire().await?;
+        Self::insert_chunk(&mut connection, chunk).await
+    }
+
+    async fn insert_chunk(
+        connection: &mut sqlx::SqliteConnection,
+        chunk: &ChunkInsert,
+    ) -> Result<(), sqlx::Error> {
         // 从 metadata JSON 中提取 symbol_name / symbol_kind
         let meta: serde_json::Value = serde_json::from_str(&chunk.metadata).unwrap_or_default();
         let symbol_name = meta.get("symbol_name").and_then(|v| v.as_str());
@@ -365,9 +373,41 @@ impl KbRepository {
         .bind(symbol_kind)
         .bind(&chunk.content_hash)
         .bind(&chunk.created_at)
-        .execute(&self.pool)
+        .execute(connection)
         .await?;
         Ok(())
+    }
+
+    /// 新切片全部准备好后一次替换；失败时事务回滚，旧文档仍可检索。
+    pub async fn replace_document_chunks(
+        &self,
+        doc_id: &str,
+        kb_id: &str,
+        chunks: &[ChunkInsert],
+        ocr_info: Option<(i64, &str)>,
+    ) -> Result<(), sqlx::Error> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("DELETE FROM kb_chunks WHERE doc_id = ?")
+            .bind(doc_id)
+            .execute(&mut *tx)
+            .await?;
+        for chunk in chunks {
+            Self::insert_chunk(&mut tx, chunk).await?;
+        }
+        let now = now_iso();
+        let total_tokens: i64 = chunks.iter().map(|chunk| chunk.token_count).sum();
+        sqlx::query("UPDATE kb_documents SET chunk_count = ?, token_count = ?, status = 'ready', error_message = NULL, updated_at = ? WHERE id = ? AND kb_id = ?")
+            .bind(chunks.len() as i64).bind(total_tokens).bind(&now).bind(doc_id).bind(kb_id)
+            .execute(&mut *tx).await?;
+        if let Some((pages, failed_pages)) = ocr_info {
+            sqlx::query("UPDATE kb_documents SET ocr_engine = 'vlm', page_count = ?, ocr_failed_pages = ? WHERE id = ?")
+                .bind(pages).bind(failed_pages).bind(doc_id).execute(&mut *tx).await?;
+        }
+        let dim = chunks.first().map(|chunk| chunk.embedding_dim).unwrap_or(0);
+        sqlx::query("UPDATE kb_knowledge_bases SET doc_count = (SELECT COUNT(*) FROM kb_documents WHERE kb_id = ?), chunk_count = (SELECT COUNT(*) FROM kb_chunks WHERE kb_id = ?), total_tokens = (SELECT COALESCE(SUM(token_count), 0) FROM kb_chunks WHERE kb_id = ?), embedding_dim = CASE WHEN embedding_dim = 0 THEN ? ELSE embedding_dim END, updated_at = ? WHERE id = ?")
+            .bind(kb_id).bind(kb_id).bind(kb_id).bind(dim).bind(&now).bind(kb_id)
+            .execute(&mut *tx).await?;
+        tx.commit().await
     }
 
     /// 该文档现存 chunk 的 (content_hash → embedding) 映射，供重处理时

--- a/src-tauri/src/services/knowledge/repository.rs
+++ b/src-tauri/src/services/knowledge/repository.rs
@@ -65,6 +65,16 @@ impl KbRepository {
             q.push(", description = ").push_bind(desc);
         }
         if let Some(model) = &input.embedding_model {
+            // 同一 UPDATE 中的表达式均读取旧值；重复保存相同模型不使缓存失效。
+            for (column, changed) in [
+                ("embedding_revision", "embedding_revision + 1"),
+                ("embedding_dim", "0"),
+                ("index_status", "'stale'"),
+            ] {
+                q.push(format!(", {column} = CASE WHEN COALESCE(embedding_model, 'text-embedding-3-small') != "))
+                    .push_bind(model)
+                    .push(format!(" THEN {changed} ELSE {column} END"));
+            }
             q.push(", embedding_model = ").push_bind(model);
         }
         if let Some(ch) = &input.embedding_channel_id {
@@ -156,17 +166,6 @@ impl KbRepository {
         let now = now_iso();
         sqlx::query("UPDATE kb_knowledge_bases SET index_status = ?, updated_at = ? WHERE id = ?")
             .bind(status)
-            .bind(&now)
-            .bind(kb_id)
-            .execute(&self.pool)
-            .await?;
-        Ok(())
-    }
-
-    pub async fn update_kb_embedding_dim(&self, kb_id: &str, dim: i64) -> Result<(), sqlx::Error> {
-        let now = now_iso();
-        sqlx::query("UPDATE kb_knowledge_bases SET embedding_dim = ?, updated_at = ? WHERE id = ?")
-            .bind(dim)
             .bind(&now)
             .bind(kb_id)
             .execute(&self.pool)
@@ -404,28 +403,34 @@ impl KbRepository {
                 .bind(pages).bind(failed_pages).bind(doc_id).execute(&mut *tx).await?;
         }
         let dim = chunks.first().map(|chunk| chunk.embedding_dim).unwrap_or(0);
-        sqlx::query("UPDATE kb_knowledge_bases SET doc_count = (SELECT COUNT(*) FROM kb_documents WHERE kb_id = ?), chunk_count = (SELECT COUNT(*) FROM kb_chunks WHERE kb_id = ?), total_tokens = (SELECT COALESCE(SUM(token_count), 0) FROM kb_chunks WHERE kb_id = ?), embedding_dim = CASE WHEN embedding_dim = 0 THEN ? ELSE embedding_dim END, updated_at = ? WHERE id = ?")
-            .bind(kb_id).bind(kb_id).bind(kb_id).bind(dim).bind(&now).bind(kb_id)
+        let revision = chunks.first()
+            .and_then(|chunk| serde_json::from_str::<serde_json::Value>(&chunk.metadata).ok())
+            .and_then(|metadata| metadata.get("embedding_revision").and_then(serde_json::Value::as_i64))
+            .unwrap_or(0);
+        sqlx::query("UPDATE kb_knowledge_bases SET doc_count = (SELECT COUNT(*) FROM kb_documents WHERE kb_id = ?), chunk_count = (SELECT COUNT(*) FROM kb_chunks WHERE kb_id = ?), total_tokens = (SELECT COALESCE(SUM(token_count), 0) FROM kb_chunks WHERE kb_id = ?), embedding_dim = CASE WHEN embedding_dim = 0 AND embedding_revision = ? THEN ? ELSE embedding_dim END, updated_at = ? WHERE id = ?")
+            .bind(kb_id).bind(kb_id).bind(kb_id).bind(revision).bind(dim).bind(&now).bind(kb_id)
             .execute(&mut *tx).await?;
         tx.commit().await
     }
 
-    /// 该文档现存 chunk 的 (content_hash → embedding) 映射，供重处理时
-    /// 复用未变内容块的向量（仅含 content_hash 与 embedding 均非空的行）。
+    /// 缓存键同时包含配置版本和内容哈希，防止同维度模型切换时复用旧向量。
+    /// 将版本保留在键中，也能拒绝读取缓存之后才发生的配置变更。
     pub async fn get_chunk_hashes_by_doc(
         &self,
         doc_id: &str,
     ) -> Result<std::collections::HashMap<String, Vec<u8>>, sqlx::Error> {
-        let rows: Vec<(Option<String>, Vec<u8>)> = sqlx::query_as(
-            "SELECT content_hash, embedding FROM kb_chunks \
-             WHERE doc_id = ? AND content_hash IS NOT NULL AND embedding IS NOT NULL",
+        let rows: Vec<(String, Vec<u8>, i64)> = sqlx::query_as(
+            "SELECT c.content_hash, c.embedding, COALESCE(json_extract(c.metadata, '$.embedding_revision'), 0)
+             FROM kb_chunks c JOIN kb_knowledge_bases kb ON c.kb_id = kb.id
+             WHERE c.doc_id = ? AND c.content_hash IS NOT NULL AND c.embedding IS NOT NULL
+               AND COALESCE(json_extract(c.metadata, '$.embedding_revision'), 0) = kb.embedding_revision",
         )
         .bind(doc_id)
         .fetch_all(&self.pool)
         .await?;
         Ok(rows
             .into_iter()
-            .filter_map(|(h, e)| h.map(|h| (h, e)))
+            .map(|(hash, embedding, revision)| (format!("{revision}:{hash}"), embedding))
             .collect())
     }
 
@@ -438,7 +443,9 @@ impl KbRepository {
         sqlx::query_as(
             "SELECT c.id, c.embedding FROM kb_chunks c \
              JOIN kb_documents d ON c.doc_id = d.id \
-             WHERE c.doc_id = ? AND c.embedding IS NOT NULL AND d.status = 'ready'",
+             JOIN kb_knowledge_bases kb ON c.kb_id = kb.id \
+             WHERE c.doc_id = ? AND c.embedding IS NOT NULL AND d.status = 'ready' \
+               AND COALESCE(json_extract(c.metadata, '$.embedding_revision'), 0) = kb.embedding_revision",
         )
         .bind(doc_id)
         .fetch_all(&self.pool)
@@ -461,7 +468,9 @@ impl KbRepository {
             "SELECT c.id, c.content, c.metadata, c.embedding, d.filename, c.doc_id
              FROM kb_chunks c
              JOIN kb_documents d ON c.doc_id = d.id
+             JOIN kb_knowledge_bases kb ON c.kb_id = kb.id
              WHERE c.kb_id = ? AND c.embedding IS NOT NULL AND d.status = 'ready'
+               AND COALESCE(json_extract(c.metadata, '$.embedding_revision'), 0) = kb.embedding_revision
              ORDER BY c.id",
         )
         .bind(kb_id)
@@ -477,7 +486,9 @@ impl KbRepository {
             "SELECT c.id, c.content, c.metadata, c.embedding, c.embedding_dim, d.filename, c.doc_id
              FROM kb_chunks c
              JOIN kb_documents d ON c.doc_id = d.id
-             WHERE c.kb_id = ? AND c.embedding IS NOT NULL AND d.status = 'ready'",
+             JOIN kb_knowledge_bases kb ON c.kb_id = kb.id
+             WHERE c.kb_id = ? AND c.embedding IS NOT NULL AND d.status = 'ready'
+               AND COALESCE(json_extract(c.metadata, '$.embedding_revision'), 0) = kb.embedding_revision",
         )
         .bind(kb_id)
         .fetch_all(&self.pool)

--- a/src-tauri/src/services/knowledge/retriever.rs
+++ b/src-tauri/src/services/knowledge/retriever.rs
@@ -4,6 +4,24 @@ use super::repository::KbRepository;
 use crate::server::event_bridge::EventSink;
 use sqlx::SqlitePool;
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+
+/// 同一知识库的完整读改写串行；弱引用避免删除过的知识库永久占用锁表。
+fn index_write_lock(kb_id: &str) -> Arc<tokio::sync::Mutex<()>> {
+    type LockMap = std::collections::HashMap<String, Weak<tokio::sync::Mutex<()>>>;
+    static LOCKS: OnceLock<Mutex<LockMap>> = OnceLock::new();
+    let mut locks = LOCKS
+        .get_or_init(|| Mutex::new(std::collections::HashMap::new()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    locks.retain(|_, lock| lock.strong_count() > 0);
+    if let Some(lock) = locks.get(kb_id).and_then(Weak::upgrade) {
+        return lock;
+    }
+    let lock = Arc::new(tokio::sync::Mutex::new(()));
+    locks.insert(kb_id.to_string(), Arc::downgrade(&lock));
+    lock
+}
 
 /// Default HNSW parameters
 const DEFAULT_M: usize = 16;
@@ -273,6 +291,7 @@ pub async fn index_delta(
     doc_id: &str,
     events: &EventSink,
 ) -> Result<(), String> {
+    let _guard = index_write_lock(kb_id).lock_owned().await;
     let repo = KbRepository::new(pool.clone());
     let path = index_path(kb_id);
 
@@ -291,7 +310,7 @@ pub async fn index_delta(
                 kb_id,
                 doc_id
             );
-            return build_index(pool, kb_id, events).await;
+            return build_index_locked(pool, kb_id, events).await;
         }
     };
 
@@ -356,6 +375,16 @@ pub async fn index_delta(
 /// Build HNSW index for a KB from all its chunks.
 /// Emits `kb-index-progress` Tauri events with percentage.
 pub async fn build_index(pool: &SqlitePool, kb_id: &str, events: &EventSink) -> Result<(), String> {
+    let _guard = index_write_lock(kb_id).lock_owned().await;
+    build_index_locked(pool, kb_id, events).await
+}
+
+/// 调用方已持有该库写锁；delta 的全量回退不能重复加锁。
+async fn build_index_locked(
+    pool: &SqlitePool,
+    kb_id: &str,
+    events: &EventSink,
+) -> Result<(), String> {
     let repo = KbRepository::new(pool.clone());
 
     let chunks = repo
@@ -471,6 +500,7 @@ pub async fn build_index(pool: &SqlitePool, kb_id: &str, events: &EventSink) -> 
 
 /// Drop the HNSW index for a KB.
 pub async fn drop_index(pool: &SqlitePool, kb_id: &str) -> Result<(), String> {
+    let _guard = index_write_lock(kb_id).lock_owned().await;
     let repo = KbRepository::new(pool.clone());
 
     // Delete index file
@@ -1147,6 +1177,69 @@ mod index_delta_tests {
         assert_eq!(rebuilt.doc_node_ids("doc-a").len(), 2);
 
         std::fs::remove_file(index_path(&kb_id)).ok();
+    }
+    #[tokio::test]
+    async fn concurrent_deltas_preserve_every_ready_document() {
+        let pool = delta_pool().await;
+        let events = sink();
+        let kb_id = format!("kb-concurrent-{}", uuid::Uuid::new_v4());
+        seed_kb(&pool, &kb_id).await;
+        seed_doc(&pool, &kb_id, "baseline").await;
+        add_chunk(&pool, &kb_id, "baseline", "baseline-chunk", 0.1).await;
+        build_index(&pool, &kb_id, &events).await.unwrap();
+        let docs: Vec<String> = (0..24).map(|i| format!("doc-{i}")).collect();
+        for (i, doc_id) in docs.iter().enumerate() {
+            seed_doc(&pool, &kb_id, doc_id).await;
+            add_chunk(&pool, &kb_id, doc_id, &format!("chunk-{i}"), i as f32 + 1.0).await;
+        }
+        let updates = docs
+            .iter()
+            .map(|doc_id| index_delta(&pool, &kb_id, doc_id, &events));
+        for result in futures_util::future::join_all(updates).await {
+            result.unwrap();
+        }
+        let index = HnswIndex::load(&index_path(&kb_id)).unwrap();
+        assert_eq!(index.len(), 25);
+        for i in 0..24 {
+            assert!(index.contains_live(&format!("chunk-{i}")));
+        }
+        let meta = KbRepository::new(pool.clone())
+            .get_index_meta(&kb_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(meta.chunk_count, 25);
+        assert_eq!(meta.status, "ready");
+        drop_index(&pool, &kb_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn drop_waits_for_the_same_write_lock_as_build_and_delta() {
+        let pool = delta_pool().await;
+        let events = sink();
+        let kb_id = format!("kb-drop-lock-{}", uuid::Uuid::new_v4());
+        seed_kb(&pool, &kb_id).await;
+        seed_doc(&pool, &kb_id, "baseline").await;
+        add_chunk(&pool, &kb_id, "baseline", "baseline-chunk", 0.1).await;
+        // 索引不存在的 delta 回退全量构建，不能重复加锁导致死锁。
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            index_delta(&pool, &kb_id, "baseline", &events),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let guard = index_write_lock(&kb_id).lock_owned().await;
+        let mut dropping = Box::pin(drop_index(&pool, &kb_id));
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), &mut dropping)
+                .await
+                .is_err()
+        );
+        assert!(index_path(&kb_id).exists());
+        drop(guard);
+        dropping.await.unwrap();
+        assert!(!index_path(&kb_id).exists());
     }
 }
 

--- a/src-tauri/src/services/knowledge/retriever.rs
+++ b/src-tauri/src/services/knowledge/retriever.rs
@@ -295,7 +295,10 @@ pub async fn index_delta(
     let repo = KbRepository::new(pool.clone());
     let path = index_path(kb_id);
 
-    let loaded = if path.exists() {
+    let kb = repo.get_kb(kb_id).await.map_err(|e| e.to_string())?;
+    let loaded = if kb.index_status == "stale" {
+        Err("embedding model changed".to_string())
+    } else if path.exists() {
         HnswIndex::load(&path)
     } else {
         Err("index file missing".to_string())

--- a/src-tauri/src/services/knowledge/upload.rs
+++ b/src-tauri/src/services/knowledge/upload.rs
@@ -79,6 +79,39 @@ pub fn storage_path(
     Ok(path)
 }
 
+/// 只清理应用拥有的上传副本；目录/Git/URL 来源路径不属于应用。
+pub fn remove_managed_file(
+    data_dir: &Path,
+    kb_id: &str,
+    source_type: &str,
+    file_path: Option<&str>,
+) -> Result<(), String> {
+    if source_type != "upload" {
+        return Ok(());
+    }
+    let Some(file_path) = file_path else {
+        return Ok(());
+    };
+    validate_kb_id(kb_id)?;
+    let path = Path::new(file_path);
+    let canonical = match path.canonicalize() {
+        Ok(path) => path,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(format!("无法确认上传文件路径: {e}")),
+    };
+    let root = data_dir.canonicalize().map_err(|e| e.to_string())?;
+    let managed = root.join("kb_files").join(kb_id);
+    // 旧数据可能指向源文件，符号链接也不能使清理越过受管目录。
+    if canonical.parent() != Some(managed.as_path()) {
+        return Ok(());
+    }
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(format!("删除上传副本失败: {e}")),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -165,5 +198,37 @@ mod tests {
         assert!(storage_path(data_dir, "..", DOC_ID, "a.pdf").is_err());
         assert!(storage_path(data_dir, "a/b", DOC_ID, "a.pdf").is_err());
         assert!(storage_path(data_dir, "", DOC_ID, "a.pdf").is_err());
+    }
+    #[test]
+    fn removal_preserves_sources_and_only_cleans_owned_uploads() {
+        let dir = std::env::temp_dir().join(format!("kb-delete-{}", uuid::Uuid::new_v4()));
+        let managed = dir.join("kb_files/kb-test");
+        std::fs::create_dir_all(&managed).unwrap();
+        let original = dir.join("original.txt");
+        std::fs::write(&original, "user source").unwrap();
+        for source_type in ["local_dir", "git", "url", "upload"] {
+            remove_managed_file(&dir, "kb-test", source_type, original.to_str()).unwrap();
+            assert!(
+                original.exists(),
+                "must preserve original for {source_type}"
+            );
+        }
+        let uploaded = managed.join("upload.txt");
+        std::fs::write(&uploaded, "owned copy").unwrap();
+        remove_managed_file(&dir, "kb-test", "local_dir", uploaded.to_str()).unwrap();
+        assert!(
+            uploaded.exists(),
+            "source ownership matters even inside the data directory"
+        );
+        remove_managed_file(&dir, "kb-test", "upload", uploaded.to_str()).unwrap();
+        assert!(!uploaded.exists());
+        remove_managed_file(&dir, "kb-test", "upload", uploaded.to_str()).unwrap();
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&original, &uploaded).unwrap();
+            remove_managed_file(&dir, "kb-test", "upload", uploaded.to_str()).unwrap();
+            assert!(original.exists());
+        }
+        std::fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/src-tauri/src/services/mcp/handlers.rs
+++ b/src-tauri/src/services/mcp/handlers.rs
@@ -1334,9 +1334,12 @@ async fn handle_tool_call(
                 .map_err(|e| e.to_string())?;
 
             // Delete file from disk
-            if let Some(path) = &doc.file_path {
-                std::fs::remove_file(path).ok();
-            }
+            crate::services::knowledge::upload::remove_managed_file(
+                &shared.state.data_dir,
+                &doc.kb_id,
+                &doc.source_type,
+                doc.file_path.as_deref(),
+            )?;
             // 级联删除 OCR 页级缓存（以内容哈希为键）
             crate::services::knowledge::ocr::cache::remove_cache(
                 &shared.state.data_dir,

--- a/src-tauri/tests/rag_embedding_revision.rs
+++ b/src-tauri/tests/rag_embedding_revision.rs
@@ -1,0 +1,269 @@
+//! 嵌入模型变更后的缓存、向量空间与索引维度回归。
+use axum::{routing::post, Json, Router};
+use serde_json::{json, Value};
+use sqlx::SqlitePool;
+use std::sync::{Arc, Mutex};
+use waliapi_lib::db::repository::Repository;
+use waliapi_lib::server::event_bridge::EventSink;
+use waliapi_lib::services::knowledge::{
+    models::{CreateKbInput, UpdateKbInput},
+    processor,
+    repository::{ChunkInsert, KbRepository},
+    retriever,
+};
+use waliapi_lib::settings_store::SettingsStore;
+
+async fn pool() -> SqlitePool {
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+    sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+    pool
+}
+
+async fn wait_for_index(
+    events: &mut tokio::sync::broadcast::Receiver<waliapi_lib::server::event_bridge::AdminEvent>,
+) {
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            let event = events.recv().await.unwrap();
+            if event.event == "kb-index-progress" && event.payload["status"] == "ready" {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("索引任务应完成");
+}
+
+#[tokio::test]
+async fn model_switch_reembeds_unchanged_text_and_rebuilds_vector_space() {
+    let pool = pool().await;
+    let repo = KbRepository::new(pool.clone());
+    let calls = Arc::new(Mutex::new(Vec::<String>::new()));
+    let captured = calls.clone();
+    let mock = Router::new().route(
+        "/v1/embeddings",
+        post(move |Json(body): Json<Value>| {
+            let captured = captured.clone();
+            async move {
+                let model = body["model"].as_str().unwrap();
+                captured.lock().unwrap().push(model.to_string());
+                let vector = match model {
+                    "embed-b" => json!([0.0, 1.0, 0.0]),
+                    "embed-c" => json!([0.0, 0.0, 0.0, 1.0, 0.0]),
+                    _ => json!([1.0, 0.0, 0.0]),
+                };
+                let data: Vec<_> = body["input"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .enumerate()
+                    .map(|(index, _)| json!({"index": index, "embedding": vector}))
+                    .collect();
+                Json(json!({"data": data}))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}/v1", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move { axum::serve(listener, mock).await.unwrap() });
+    Repository::new(pool.clone())
+        .create_channel(
+            &serde_json::from_value(json!({
+                "name": "local-embedding-test", "type": "openai", "base_url": base_url,
+                "api_key": "test-only", "models": ["embed-a", "embed-b", "embed-c"]
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    let kb = repo
+        .create_kb(
+            &serde_json::from_value::<CreateKbInput>(json!({
+                "name": "model-switch", "embedding_model": "embed-a"
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    let directory = std::env::temp_dir().join(format!("rag-model-{}", kb.id));
+    std::fs::create_dir_all(&directory).unwrap();
+    let settings = SettingsStore::file(directory.join("settings.json"));
+    let (tx, _) = tokio::sync::broadcast::channel(100);
+    let events = EventSink::headless(tx);
+    let mut receiver = events.subscribe();
+    let mut docs = Vec::new();
+    for name in ["first", "second"] {
+        let filename = format!("{name}.txt");
+        let file = directory.join(&filename);
+        let content = format!("alpha {name} document remains unchanged across model switches");
+        std::fs::write(&file, &content).unwrap();
+        let doc = repo
+            .create_document(
+                &kb.id,
+                &filename,
+                file.to_str(),
+                "text",
+                content.len() as i64,
+                name,
+            )
+            .await
+            .unwrap();
+        processor::process_document(
+            &pool,
+            &events,
+            &kb.id,
+            &doc.id,
+            &filename,
+            content.as_bytes(),
+            Some("embed-a"),
+            &settings,
+            &directory,
+        )
+        .await
+        .unwrap();
+        wait_for_index(&mut receiver).await;
+        docs.push(doc);
+    }
+    let doc = &docs[0];
+    // 同一模型的普通重建仍复用缓存，不增加模型调用。
+    let same = repo
+        .update_kb(
+            &kb.id,
+            &serde_json::from_value::<UpdateKbInput>(json!({"embedding_model": "embed-a"}))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(same.embedding_revision, 0);
+    processor::reindex_document(&pool, &events, &doc.id, &settings, &directory)
+        .await
+        .unwrap();
+    wait_for_index(&mut receiver).await;
+    assert_eq!(calls.lock().unwrap().len(), 2);
+
+    for (revision, model, vector) in [
+        (1, "embed-b", vec![0.0, 1.0, 0.0]),
+        (2, "embed-c", vec![0.0, 0.0, 0.0, 1.0, 0.0]),
+    ] {
+        let changed = repo
+            .update_kb(
+                &kb.id,
+                &serde_json::from_value::<UpdateKbInput>(json!({"embedding_model": model}))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(changed.embedding_revision, revision);
+        assert_eq!(changed.embedding_dim, 0);
+        assert_eq!(changed.index_status, "stale");
+        assert!(repo
+            .get_chunk_hashes_by_doc(&doc.id)
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(repo
+            .get_chunks_by_kb_with_dim(&kb.id)
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(retriever::search(&pool, &kb.id, &vector, 5)
+            .await
+            .unwrap()
+            .is_empty());
+        processor::reindex_document(&pool, &events, &doc.id, &settings, &directory)
+            .await
+            .unwrap();
+        wait_for_index(&mut receiver).await;
+        let chunks = repo.get_chunk_vectors_by_doc(&doc.id).await.unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(retriever::decode_embedding(&chunks[0].1), vector);
+        assert!(repo
+            .get_chunk_vectors_by_doc(&docs[1].id)
+            .await
+            .unwrap()
+            .is_empty());
+        let found = retriever::search(&pool, &kb.id, &vector, 5).await.unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].doc_id, doc.id);
+        let meta = repo.get_index_meta(&kb.id).await.unwrap().unwrap();
+        assert_eq!(meta.embedding_dim, vector.len() as i64);
+        assert_eq!(meta.chunk_count, 1);
+        assert_eq!(
+            repo.get_kb(&kb.id).await.unwrap().embedding_dim,
+            vector.len() as i64
+        );
+    }
+    assert_eq!(
+        *calls.lock().unwrap(),
+        ["embed-a", "embed-a", "embed-b", "embed-c"]
+    );
+    retriever::drop_index(&pool, &kb.id).await.unwrap();
+    server.abort();
+    std::fs::remove_dir_all(directory).unwrap();
+}
+
+#[tokio::test]
+async fn legacy_cache_is_compatible_until_the_effective_model_changes() {
+    let pool = pool().await;
+    let repo = KbRepository::new(pool.clone());
+    let kb = repo
+        .create_kb(&serde_json::from_value(json!({"name": "legacy-cache"})).unwrap())
+        .await
+        .unwrap();
+    let doc = repo
+        .create_document(&kb.id, "legacy.txt", None, "text", 5, "doc-hash")
+        .await
+        .unwrap();
+    let original = ChunkInsert {
+        id: "legacy-chunk".into(),
+        doc_id: doc.id.clone(),
+        kb_id: kb.id.clone(),
+        chunk_index: 0,
+        content: "alpha".into(),
+        token_count: 2,
+        embedding: retriever::encode_embedding(&[1.0, 0.0]),
+        embedding_dim: 2,
+        metadata: "{}".into(),
+        content_hash: Some("content-hash".into()),
+        created_at: "2026-09-11T00:00:00Z".into(),
+    };
+    repo.create_chunk(&original).await.unwrap();
+    repo.update_document_status(&doc.id, "ready", None)
+        .await
+        .unwrap();
+    let unchanged = repo
+        .update_kb(
+            &kb.id,
+            &serde_json::from_value(json!({
+                "name": "renamed", "embedding_model": "text-embedding-3-small"
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(unchanged.embedding_revision, 0);
+    let old_cache = repo.get_chunk_hashes_by_doc(&doc.id).await.unwrap();
+    assert!(old_cache.contains_key("0:content-hash"));
+    assert_eq!(repo.get_chunks_by_kb(&kb.id).await.unwrap().len(), 1);
+    repo.update_kb(
+        &kb.id,
+        &serde_json::from_value(json!({"embedding_model": "embed-next"})).unwrap(),
+    )
+    .await
+    .unwrap();
+    assert!(repo
+        .get_chunk_hashes_by_doc(&doc.id)
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(!old_cache.contains_key("1:content-hash"));
+    // 变更前仍在执行的任务，不能回写新模型的期望维度。
+    repo.replace_document_chunks(&doc.id, &kb.id, &[original], None)
+        .await
+        .unwrap();
+    assert_eq!(repo.get_kb(&kb.id).await.unwrap().embedding_dim, 0);
+}

--- a/src-tauri/tests/rag_sources.rs
+++ b/src-tauri/tests/rag_sources.rs
@@ -1,0 +1,122 @@
+//! 实际模型请求、响应来源与持久化会话来源必须一致。
+use axum::{routing::post, Json, Router};
+use serde_json::{json, Value};
+use std::sync::{Arc, Mutex};
+use waliapi_lib::db::repository::Repository;
+use waliapi_lib::services::knowledge::{
+    models::ConversationMessage,
+    rag,
+    repository::{ChunkInsert, KbRepository},
+    retriever,
+};
+use waliapi_lib::settings_store::SettingsStore;
+
+#[tokio::test]
+async fn ask_reports_only_sources_that_were_sent_to_the_model() {
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+    sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+    let calls = Arc::new(Mutex::new(Vec::<Value>::new()));
+    let captured = calls.clone();
+    let mock = Router::new().route("/v1/chat/completions", post(move |Json(body): Json<Value>| {
+        let captured = captured.clone();
+        async move {
+            captured.lock().unwrap().push(body.clone());
+            Json(json!({"id":"source-test", "object":"chat.completion", "model":body["model"],
+                "choices":[{"index":0,"message":{"role":"assistant","content":"test answer"},"finish_reason":"stop"}],
+                "usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}}))
+        }
+    }));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}/v1", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move { axum::serve(listener, mock).await.unwrap() });
+    Repository::new(pool.clone()).create_channel(&serde_json::from_value(json!({
+        "name":"local-chat-test", "type":"openai", "base_url":base_url, "api_key":"test-only",
+        "models":["chat-test"], "protocol":"openai", "provider":"custom", "native_base_url":base_url,
+        "native_endpoints":["chat_completions"]
+    })).unwrap()).await.unwrap();
+    let repo = KbRepository::new(pool.clone());
+    let kb = repo
+        .create_kb(&serde_json::from_value(json!({"name":"sources"})).unwrap())
+        .await
+        .unwrap();
+    let doc = repo
+        .create_document(&kb.id, "source.txt", None, "text", 40, "doc-hash")
+        .await
+        .unwrap();
+    let text = "alpha answer must be grounded in this exact source";
+    repo.create_chunk(&ChunkInsert {
+        id: "source-chunk".into(),
+        doc_id: doc.id.clone(),
+        kb_id: kb.id.clone(),
+        chunk_index: 0,
+        content: text.into(),
+        token_count: 12,
+        embedding: retriever::encode_embedding(&[1.0, 0.0]),
+        embedding_dim: 2,
+        metadata: "{}".into(),
+        content_hash: None,
+        created_at: "2026-09-11T00:00:00Z".into(),
+    })
+    .await
+    .unwrap();
+    repo.update_document_status(&doc.id, "ready", None)
+        .await
+        .unwrap();
+    let directory = std::env::temp_dir().join(format!("rag-sources-{}", kb.id));
+    std::fs::create_dir_all(&directory).unwrap();
+    let settings = SettingsStore::file(directory.join("settings.json"));
+    // 正常、上下文裁空、连历史也超预算三种实际调用。
+    for (history_chars, expect_source) in [(0, true), (22600, false), (30000, false)] {
+        let history = if history_chars == 0 {
+            vec![]
+        } else {
+            vec![ConversationMessage {
+                role: "user".into(),
+                content: "x".repeat(history_chars),
+            }]
+        };
+        let answer = rag::ask_with_config(
+            &pool,
+            &kb.id,
+            "alpha",
+            "unused",
+            "chat-test",
+            5,
+            false,
+            &history,
+            &settings,
+            0.7,
+            0.3,
+            "keyword",
+        )
+        .await
+        .unwrap();
+        assert_eq!(answer.answer, "test answer");
+        let prompt = calls.lock().unwrap().last().unwrap()["messages"][1]["content"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(
+            prompt.contains(text),
+            expect_source,
+            "history_chars={history_chars}"
+        );
+        assert_eq!(!answer.sources.is_empty(), expect_source);
+        assert_eq!(answer.retrieval_details.as_ref().unwrap().len(), 1);
+        if expect_source {
+            assert_eq!(answer.sources[0].filename, "source.txt");
+        }
+        let stored: Option<String> = sqlx::query_scalar(
+            "SELECT sources FROM kb_conversations WHERE kb_id = ? AND role = 'assistant' ORDER BY rowid DESC LIMIT 1"
+        ).bind(&kb.id).fetch_one(&pool).await.unwrap();
+        let stored: Vec<Value> = serde_json::from_str(stored.as_deref().unwrap()).unwrap();
+        assert_eq!(stored.len(), answer.sources.len());
+    }
+    assert_eq!(calls.lock().unwrap().len(), 3);
+    server.abort();
+    std::fs::remove_dir_all(directory).unwrap();
+}


### PR DESCRIPTION
RAG 文档删除、重建和索引更新存在数据丢失风险；切换嵌入模型后仍可能复用旧向量，提示词被裁剪后也可能返回模型没有看到的来源。本 PR 修复以下 5 项问题：

- 删除文档只清理知识库拥有的上传副本，保留本地目录导入的原文件；桌面、REST、MCP 入口行为一致。
- 文档重新解析、向量化全部成功后，在事务中替换切片及统计；读取、向量化、写入失败时保留旧内容。
- 按知识库串行执行增量更新、全量构建和删除，索引通过临时文件原子替换，避免并发覆盖和读取半文件。
- 模型变更时使旧缓存和索引失效，按嵌入配置版本隔离向量；维度更新也在切片替换事务中进行，旧任务不能写入新模型的期望维度。
- 响应及会话来源仅包含最终发送给模型的切片，全部上下文被裁掉时来源为空；预算计算包括文档标题和符号信息。

新增迁移 040，现有切片缺失版本时按 0 兼容；切换模型后需重建文档恢复向量检索，关键词正文仍保留。

已同步最新 `v0.3.2`（`ff1dc9c`）：切片写入同时保留中文 `search_text` 投影和事务连接，保留索引回填与原子替换逻辑；知识库迁移顺延为 `040`，避开上游日志索引迁移 `039`。


